### PR TITLE
fix for new custom types

### DIFF
--- a/Cheat Engine/MainUnit.pas
+++ b/Cheat Engine/MainUnit.pas
@@ -3900,6 +3900,7 @@ begin
       Add('alloc(TypeName,256)');
       Add('alloc(ByteSize,4)');
       Add('alloc(UsesFloat,1)');
+      Add('alloc(CallMethod,1)');
       Add('');
       Add('TypeName:');
       Add('db ''' + n + ''',0');


### PR DESCRIPTION
Missing alloc in DefineNewCustomType procedure.

Related with fix 59f3d2a1eea26a9d38058e479a1cf24da0775a2c


CE didn't detect any errors due to getPotentialLabels from autoassembler unit.