### PR TITLE
onMemRecPreExecute and onMemRecPostExecute

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -1005,7 +1005,7 @@ begin
               system.vtString: lua_pushstring(L, pchar(parameters[i].VString));
               system.vtPointer: lua_pushlightuserdata(L, parameters[i].VPointer);
               system.vtPChar: lua_pushstring(L, parameters[i].VPChar);
-              system.vtObject: lua_pushlightuserdata(L, pointer(parameters[i].VObject));
+              system.vtObject: luaclass_newClass(L, parameters[i].VObject); //lua_pushlightuserdata(L, pointer(parameters[i].VObject));
               system.vtClass: lua_pushlightuserdata(L, pointer(parameters[i].VClass));
               system.vtWideChar, vtPWideChar, vtVariant, vtInterface,
                 vtWideString: lua_pushstring(L, rsCheatengineIsBeingAFag);

--- a/Cheat Engine/bin/main.lua
+++ b/Cheat Engine/bin/main.lua
@@ -1592,6 +1592,20 @@ methods
   getHotkey(index): Returns the hotkey from the hotkey array
   getHotkeyByID(integer): Returns the hotkey with the given id
 
+global events
+  function onMemRecPreExecute(memoryrecord, newstate BOOLEAN):
+    If above function is defined it will be called before action* has been performed.
+    Active property is about to change to newState.
+  
+  function onMemRecPostExecute(memoryrecord, newState BOOLEAN, succeeded BOOLEAN):
+    If above function is defined it will be called after action*.
+    Active property was supposed to change to newState.
+    If 'succeeded' is true it means that Active state has changed and is newState.
+    
+    newState and succeeded are read only.
+  
+    *action can be: running auto assembler script (ENABLE or DISABLE section), freezing and unfreezing.
+  
 
 Addresslist Class: (Inheritance: Panel->WinControl->Control->Component->Object)
 properties


### PR DESCRIPTION
Add onMemRecPreExecute and onMemRecPostExecute global events.

Small changes in code flow.

Also deprecate _memrec_'+description+'_activating callback family. I haven't seen anyone using it. Tried forum search.



TMemoryRecord.setActive diff looks messy, here whole procedure:
https://github.com/mgrinzPlayer/cheat-engine/blob/e8fb4099ac1198bb0c484d97548a70b1a6e41155/Cheat%20Engine/MemoryRecordUnit.pas#L1425





One of many uses:
```Lua
function onMemRecPostExecute(m,newstate,succeeded)
  if m.Type==vtAutoAssembler then
    if succeeded then
      if m.Active then playSound(ActivateScriptSound) -- activated
                  else playSound(DeactivateScriptSound) -- deactivated
      end
    else beep() end -- error (old aob signature or something)
  else
    if succeeded then playSound(freezeunfreezeSound) end -- frozen/unfrozen
  end
end

```
