### PR TITLE
Typo: debug variable list

### DIFF
--- a/Cheat Engine/bin/main.lua
+++ b/Cheat Engine/bin/main.lua
@@ -391,8 +391,8 @@ alignmentparam is a string which either holds the value the addresses must be di
 
 debug variables
 EFLAGS
-32-bit: EAX, EBX, ECX, EDX, EDI, ESP, EBP, ESP, EIP
-64-bit: RAX, EBX, RBX, RDX, RDI, RSP, RBP, RSP, RIP, R8, R9, R10, R11, R12, R13, R14, R15 : The value of the register
+32-/64-bit: EAX, EBX, ECX, EDX, EDI, ESI, EBP, ESP, EIP
+64-bit only: RAX, RBX, RCX, RDX, RDI, RSI, RBP, RSP, RIP, R8, R9, R10, R11, R12, R13, R14, R15 : The value of the register
 
 Debug related routines:
 function debugger_onBreakpoint():


### PR DESCRIPTION
Based on https://github.com/cheat-engine/cheat-engine/blob/21393be5766a4787ea6d58a9240820212dd4e944/Cheat%20Engine/LuaHandler.pas#L590

Also, can someone check the order? It's different from the above.