### PR TITLE
Added additional TMemoryRecord LUA bindings 

### DIFF
--- a/Cheat Engine/LuaMemoryRecord.pas
+++ b/Cheat Engine/LuaMemoryRecord.pas
@@ -371,6 +371,7 @@ begin
   result:=1;
 end;
 
+{$ifndef unix}
 function memoryrecord_getCollapsed(L: PLua_State): integer; cdecl;
 var
   memoryrecord: TMemoryRecord;
@@ -432,6 +433,7 @@ begin
     memoryrecord.treenode.Expand(recurse);
   end;
 end;
+{$endif}
 
 function memoryrecord_freeze(L: PLua_State): integer; cdecl;
 var
@@ -809,17 +811,19 @@ begin
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'setScript', memoryrecord_setScript);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getActive', memoryrecord_getActive);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'setActive', memoryrecord_setActive);
-  luaclass_addClassFunctionToTable(L, metatable, userdata, 'getCollapsed', memoryrecord_getCollapsed);
-  luaclass_addClassFunctionToTable(L, metatable, userdata, 'setCollapsed', memoryrecord_setCollapsed);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getChild', memoryrecord_getChild);
 
+  {$ifndef unix}
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'expand', memoryrecord_expand);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'collapse', memoryrecord_collapse);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'getCollapsed', memoryrecord_getCollapsed); // redundant
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'setCollapsed', memoryrecord_setCollapsed);
+  {$endif}
+
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'isSelected', memoryrecord_isSelected);
-  luaclass_addClassFunctionToTable(L, metatable, userdata, 'isGroupHeader', memoryrecord_isGroupHeader);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'isReadable', memoryrecord_isReadableAddress);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'appendToEntry', memoryrecord_appendToEntry);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'delete', memoryrecord_delete);
-  luaclass_addClassFunctionToTable(L, metatable, userdata, 'expand', memoryrecord_expand);
-  luaclass_addClassFunctionToTable(L, metatable, userdata, 'collapse', memoryrecord_collapse);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkeyCount', memoryrecord_getHotkeyCount);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkey', memoryrecord_getHotkey);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkeyByID', memoryrecord_getHotkeyByID);
@@ -834,6 +838,8 @@ begin
   luaclass_addPropertyToTable(L, metatable, userdata, 'Active', memoryrecord_getActive, memoryrecord_setActive);
   luaclass_addPropertyToTable(L, metatable, userdata, 'Collapsed', memoryrecord_getCollapsed, memoryrecord_setCollapsed);
   luaclass_addPropertyToTable(L, metatable, userdata, 'Selected', memoryrecord_isSelected, nil);
+  luaclass_addPropertyToTable(L, metatable, userdata, 'Readable', memoryrecord_isReadableAddress, nil);
+  luaclass_addPropertyToTable(L, metatable, userdata, 'IsGroupHeader', memoryrecord_isGroupHeader, nil);
   luaclass_addPropertyToTable(L, metatable, userdata, 'HotkeyCount', memoryrecord_getHotkeyCount, nil);
   luaclass_addArrayPropertyToTable(L, metatable, userdata, 'Hotkey', memoryrecord_getHotkey, nil);
 

--- a/Cheat Engine/LuaMemoryRecord.pas
+++ b/Cheat Engine/LuaMemoryRecord.pas
@@ -353,6 +353,66 @@ begin
   result:=1;
 end;
 
+function memoryrecord_getCollapsed(L: PLua_State): integer; cdecl;
+var
+  memoryrecord: TMemoryRecord;
+begin
+  memoryrecord:=luaclass_getClassObject(L);
+  lua_pushboolean(L, (memoryrecord.Count > 0) and (not memoryrecord.treenode.Expanded));
+  result:=1;
+end;
+
+function memoryrecord_setCollapsed(L: PLua_State): integer; cdecl;
+var
+  memoryrecord: TMemoryRecord;
+  collapsed: boolean;
+begin
+  result:=0;
+  memoryrecord:=luaclass_getClassObject(L);
+  if (memoryrecord.Count > 0) and (lua_gettop(L) >= 1) then
+  begin
+    collapsed:=lua_toboolean(L, 1);
+    if collapsed and memoryrecord.treenode.Expanded then
+       memoryrecord.treenode.Collapse(False)
+    else if not collapsed and not memoryrecord.treenode.Expanded then
+       memoryrecord.treenode.Expand(False);
+     lua_pushboolean(L, (memoryrecord.Count > 0) and (not memoryrecord.treenode.Expanded));
+  end;
+  lua_pop(L, lua_gettop(L));
+end;
+
+function memoryrecord_collapse(L: PLua_State): integer; cdecl;
+var
+  memoryrecord: TMemoryRecord;
+  recurse: boolean = False;
+begin
+  result:=0;
+  memoryrecord:=luaclass_getClassObject(L);
+  if memoryrecord.Count > 0 then
+  begin
+    if lua_gettop(L) = 1 then
+       recurse:=lua_toboolean(L, 1);
+    memoryrecord.treenode.Collapse(recurse);
+  end;
+  lua_pop(L, lua_gettop(L));
+end;
+
+function memoryrecord_expand(L: PLua_State): integer; cdecl;
+var
+  memoryrecord: TMemoryRecord;
+  recurse: boolean = False;
+begin
+  result:=0;
+  memoryrecord:=luaclass_getClassObject(L);
+  if memoryrecord.Count > 0 then
+  begin
+    if lua_gettop(L) = 1 then
+       recurse:=lua_toboolean(L, 1);
+    memoryrecord.treenode.Expand(recurse);
+  end;
+  lua_pop(L, lua_gettop(L));
+end;
+
 function memoryrecord_freeze(L: PLua_State): integer; cdecl;
 var
   memrec: pointer;
@@ -729,11 +789,15 @@ begin
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'setScript', memoryrecord_setScript);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getActive', memoryrecord_getActive);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'setActive', memoryrecord_setActive);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'getCollapsed', memoryrecord_getCollapsed);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'setCollapsed', memoryrecord_setCollapsed);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getChild', memoryrecord_getChild);
 
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'isSelected', memoryrecord_isSelected);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'appendToEntry', memoryrecord_appendToEntry);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'delete', memoryrecord_delete);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'expand', memoryrecord_expand);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'collapse', memoryrecord_collapse);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkeyCount', memoryrecord_getHotkeyCount);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkey', memoryrecord_getHotkey);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getHotkeyByID', memoryrecord_getHotkeyByID);
@@ -746,6 +810,7 @@ begin
   luaclass_addPropertyToTable(L, metatable, userdata, 'Value', memoryrecord_getValue, memoryrecord_setValue);
   luaclass_addPropertyToTable(L, metatable, userdata, 'Script', memoryrecord_getScript, memoryrecord_setScript);
   luaclass_addPropertyToTable(L, metatable, userdata, 'Active', memoryrecord_getActive, memoryrecord_setActive);
+  luaclass_addPropertyToTable(L, metatable, userdata, 'Collapsed', memoryrecord_getCollapsed, memoryrecord_setCollapsed);
   luaclass_addPropertyToTable(L, metatable, userdata, 'Selected', memoryrecord_isSelected, nil);
   luaclass_addPropertyToTable(L, metatable, userdata, 'HotkeyCount', memoryrecord_getHotkeyCount, nil);
   luaclass_addArrayPropertyToTable(L, metatable, userdata, 'Hotkey', memoryrecord_getHotkey, nil);
@@ -815,6 +880,10 @@ begin
   lua_register(LuaVM, 'memoryrecord_setScript', memoryrecord_setScript);
   lua_register(LuaVM, 'memoryrecord_isActive', memoryrecord_getActive);
   lua_register(LuaVM, 'memoryrecord_isSelected', memoryrecord_isSelected);
+  lua_register(LuaVM, 'memoryrecord_getCollapsed', memoryrecord_getCollapsed);
+  lua_register(LuaVM, 'memoryrecord_setCollapsed', memoryrecord_setCollapsed);
+  lua_register(LuaVM, 'memoryrecord_expand', memoryrecord_expand);
+  lua_register(LuaVM, 'memoryrecord_collapse', memoryrecord_collapse);
   lua_register(LuaVM, 'memoryrecord_freeze', memoryrecord_freeze);
   lua_register(LuaVM, 'memoryrecord_unfreeze', memoryrecord_unfreeze);
   lua_register(LuaVM, 'memoryrecord_setColor', memoryrecord_setColor);

--- a/Cheat Engine/LuaMemoryRecord.pas
+++ b/Cheat Engine/LuaMemoryRecord.pas
@@ -333,6 +333,24 @@ begin
   result:=1;
 end;
 
+function memoryrecord_isGroupHeader(L: PLua_State): integer; cdecl;
+var
+  memrecord: TMemoryRecord;
+begin
+  memrecord:=luaclass_getClassObject(L);
+  lua_pushboolean(L, memrecord.IsGroupHeader);
+  result:=1;
+end;
+
+function memoryrecord_isReadableAddress(L: PLua_State): integer; cdecl;
+var
+  memrecord: TMemoryRecord;
+begin
+  memrecord:=luaclass_getClassObject(L);
+  lua_pushboolean(L, memrecord.IsReadableAddress);
+  result:=1;
+end;
+
 function memoryrecord_setActive(L: PLua_State): integer; cdecl;
 var
   memrec: TMemoryRecord;
@@ -794,6 +812,8 @@ begin
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getChild', memoryrecord_getChild);
 
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'isSelected', memoryrecord_isSelected);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'isGroupHeader', memoryrecord_isGroupHeader);
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'isReadable', memoryrecord_isReadableAddress);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'appendToEntry', memoryrecord_appendToEntry);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'delete', memoryrecord_delete);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'expand', memoryrecord_expand);
@@ -880,6 +900,8 @@ begin
   lua_register(LuaVM, 'memoryrecord_setScript', memoryrecord_setScript);
   lua_register(LuaVM, 'memoryrecord_isActive', memoryrecord_getActive);
   lua_register(LuaVM, 'memoryrecord_isSelected', memoryrecord_isSelected);
+  lua_register(LuaVM, 'memoryrecord_isGroupHeader', memoryrecord_isGroupHeader);
+  lua_register(LuaVM, 'memoryrecord_isReadable', memoryrecord_isReadableAddress);
   lua_register(LuaVM, 'memoryrecord_getCollapsed', memoryrecord_getCollapsed);
   lua_register(LuaVM, 'memoryrecord_setCollapsed', memoryrecord_setCollapsed);
   lua_register(LuaVM, 'memoryrecord_expand', memoryrecord_expand);

--- a/Cheat Engine/LuaMemoryRecord.pas
+++ b/Cheat Engine/LuaMemoryRecord.pas
@@ -359,7 +359,7 @@ begin
   memrec:=luaclass_getClassObject(L);
 
   if lua_gettop(L)>=1 then
-    memrec.active:=lua_toboolean(L, 1);
+    memrec.active:=lua_toboolean(L, -1);
 end;
 
 function memoryrecord_getActive(L: PLua_State): integer; cdecl;
@@ -384,51 +384,53 @@ function memoryrecord_setCollapsed(L: PLua_State): integer; cdecl;
 var
   memoryrecord: TMemoryRecord;
   collapsed: boolean;
+  parameters: integer;
 begin
   result:=0;
   memoryrecord:=luaclass_getClassObject(L);
-  if (memoryrecord.Count > 0) and (lua_gettop(L) >= 1) then
+  parameters:=lua_gettop(L);
+  if (memoryrecord.Count > 0) and (parameters >= 1) and lua_isboolean(L, parameters) then
   begin
-    collapsed:=lua_toboolean(L, 1);
+    collapsed := lua_toboolean(L, parameters);
     if collapsed and memoryrecord.treenode.Expanded then
        memoryrecord.treenode.Collapse(False)
     else if not collapsed and not memoryrecord.treenode.Expanded then
        memoryrecord.treenode.Expand(False);
-     lua_pushboolean(L, (memoryrecord.Count > 0) and (not memoryrecord.treenode.Expanded));
   end;
-  lua_pop(L, lua_gettop(L));
 end;
 
 function memoryrecord_collapse(L: PLua_State): integer; cdecl;
 var
   memoryrecord: TMemoryRecord;
   recurse: boolean = False;
+  parameters: integer;
 begin
   result:=0;
   memoryrecord:=luaclass_getClassObject(L);
+  parameters:=lua_gettop(L);
   if memoryrecord.Count > 0 then
   begin
-    if lua_gettop(L) = 1 then
-       recurse:=lua_toboolean(L, 1);
+    if (parameters >= 1) and lua_isboolean(L, parameters) then
+       recurse:=lua_toboolean(L, parameters);
     memoryrecord.treenode.Collapse(recurse);
   end;
-  lua_pop(L, lua_gettop(L));
 end;
 
 function memoryrecord_expand(L: PLua_State): integer; cdecl;
 var
   memoryrecord: TMemoryRecord;
   recurse: boolean = False;
+  parameters: integer;
 begin
   result:=0;
   memoryrecord:=luaclass_getClassObject(L);
+  parameters:=lua_gettop(L);
   if memoryrecord.Count > 0 then
   begin
-    if lua_gettop(L) = 1 then
-       recurse:=lua_toboolean(L, 1);
+    if (parameters >= 1) and lua_isboolean(L, parameters) then
+       recurse:=lua_toboolean(L, parameters);
     memoryrecord.treenode.Expand(recurse);
   end;
-  lua_pop(L, lua_gettop(L));
 end;
 
 function memoryrecord_freeze(L: PLua_State): integer; cdecl;

--- a/Cheat Engine/bin/main.lua
+++ b/Cheat Engine/bin/main.lua
@@ -1510,9 +1510,9 @@ properties
 
 methods
   setVolume(int)
-  playXM(filename, OPTIONAL noloop)
-  playXM(tablefile, OPTIONAL noloop)
-  playXM(Stream, OPTIONAL noloop)
+  playXM(filename, noloop OPTIONAL)
+  playXM(tablefile, noloop OPTIONAL)
+  playXM(Stream, noloop OPTIONAL)
   pause()
   resume()
   stop()
@@ -1595,6 +1595,9 @@ properties
   ShowAsSigned: boolean - Self explanatory
   AllowIncrease: boolean - Allow value increasing, unfreeze will reset it to false
   AllowDecrease: boolean - Allow value decreasing, unfreeze will reset it to false
+  Collapsed: boolean - Set to true to collapse this record or false to expand it. Use expand/collapse methods for recursive operations. (Windows only)
+  IsGroupHeader: boolean - Set to true if the record was created as a Group Header with no address or value info. (ReadOnly)
+  Readable: boolean - Set to false if record contains an unreadable address. NOTE: This property will not be set until the value property is accessed at least once. (ReadOnly)
 
   Count: Number of children
   Child[index] : Array to access the child records
@@ -1609,10 +1612,13 @@ properties
   DontSave: boolean - Don't save this memoryrecord and it's children
 
 methods
+  isSelected()
+  isReadable()
   getDescription()
   setDescription()
   getAddress() : Returns the interpretable addressstring of this record. If it is a pointer, it returns a second result as a table filled with the offsets
   setAddress(string) : Sets the interpretable address string, and if offsets are provided make it a pointer
+  getCurrentAddress(): Returns the current address as an integer (the final result of the interpretable address and pointer offsets)
 
   getOffsetCount(): Returns the number of offsets for this memoryrecord
   setOffsetCount(integer): Lets you set the number of offsets
@@ -1620,10 +1626,13 @@ methods
   getOffset(index) : Gets the offset at the given index
   setOffset(index, value) : Sets the offset at the given index
 
-  getCurrentAddress(): Returns the current address as an integer (the final result of the interpretable address and pointer offsets)
-
+  getCollapsed()
+  setCollapsed(boolean)
+  expand(recurse OPTIONAL): Expand the record's tree node. Setting recurse to true will recursively expand the record and all of its child nodes.
+  collapse(recurse OPTIONAL): Collapse the record's tree node. Setting recurse to true will recursively expand the record and all of its child nodes. (Windows only)
   appendToEntry(memrec): Appends the current memory record to the given memory record
 
+  getHotkeyCount()
   getHotkey(index): Returns the hotkey from the hotkey array
   getHotkeyByID(integer): Returns the hotkey with the given id
 


### PR DESCRIPTION
Pretty straight-forward. Added the following:

- **Properties**
  - `MemoryRecord.Collapsed`
  - `MemoryRecord.IsGroupHeader`
  - `MemoryRecord.Readable` (Pass-through to `TMemoryRecord.IsReadableAddress`)
- **Methods**
  - `MemoryRecord:expand(recurse OPTIONAL)`
  - `MemoryRecord:collapse(recurse OPTIONAL)`
  - Getter/Setter methods for `MemoryRecord.Collapsed` property.
  - Getter method for `MemoryRecord.Readable` property.

The collapse/expand bits would be helpful when writing UI-oriented automation scripts. The other two properties were just added because I noticed them along the way, and they seemed convenient.

In hindsight, the `Collapsed` property was sort of redundant and unnecessary. 