### PR TITLE
Fix  for executeCodeLocal calls with a parameter

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -6375,9 +6375,9 @@ begin
     if lua_gettop(L)>=2 then
     begin
       if lua_isstring(L,2) then
-        address:=selfsymhandler.getAddressFromName(Lua_ToString(L,2))
+        parameter:=selfsymhandler.getAddressFromName(Lua_ToString(L,2))
       else
-        address:=lua_tointeger(L, 2)
+        parameter:=lua_tointeger(L, 2)
 
     end
     else


### PR DESCRIPTION
Looks like you forgot to change `address` to `parameter` after copying and pasting the if branch, so the function address was getting overwritten with the parameter value.