### PR TITLE
Fix parameter handling in executeCode

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -6251,9 +6251,9 @@ begin
     if lua_gettop(L)>=2 then
     begin
       if lua_isnumber(L,2) then
-        address:=lua_tointeger(L, 2)
+        parameter:=lua_tointeger(L, 2)
       else
-        address:=selfsymhandler.getAddressFromName(Lua_ToString(L,2));
+        parameter:=selfsymhandler.getAddressFromName(Lua_ToString(L,2));
     end
     else
       parameter:=0;


### PR DESCRIPTION
I should've noticed this when I did my last pull request, but it's the same deal as `executeCodeLocal`: function address is being overwritten with the parameter value.