### PR TITLE
Additional LUA bindings for TableFiles

### DIFF
--- a/Cheat Engine/LuaTableFile.pas
+++ b/Cheat Engine/LuaTableFile.pas
@@ -59,6 +59,17 @@ begin
 end;
 
 
+function tablefile_delete(L: Plua_State): integer; cdecl;
+var
+  lf: TLuaFile;
+begin
+  result:=0;
+  lf:=luaclass_getClassObject(L);
+  mainform.LuaFiles.Remove(lf);
+  mainform.UpdateMenu;
+  lf.Free;
+end;
+
 function tablefile_saveToFile(L: Plua_State): integer; cdecl;
 var parameters: integer;
   lf: TLuaFile;
@@ -86,6 +97,7 @@ procedure tablefile_addMetaData(L: PLua_state; metatable: integer; userdata: int
 begin
   object_addMetaData(L, metatable, userdata);
 
+  luaclass_addClassFunctionToTable(L, metatable, userdata, 'delete', tablefile_delete);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'saveToFile', tablefile_saveToFile);
   luaclass_addClassFunctionToTable(L, metatable, userdata, 'getData', tablefile_getData);
 end;
@@ -93,6 +105,7 @@ end;
 procedure initializeLuaTableFile;
 begin
   Lua_register(LuaVM, 'findTableFile', findTableFile);
+  Lua_register(LuaVM, 'tablefile_delete', tablefile_delete);
   Lua_register(LuaVM, 'tablefile_saveToFile', tablefile_saveToFile);
   Lua_register(LuaVM, 'tablefile_getData', tablefile_getData);
 end;

--- a/Cheat Engine/LuaTableFile.pas
+++ b/Cheat Engine/LuaTableFile.pas
@@ -23,7 +23,7 @@ var parameters: integer;
 begin
   result:=0;
   parameters:=lua_gettop(L);
-  if parameters=1 then
+  if parameters>=1 then
   begin
     f:=Lua_ToString(L, -1);
     lua_pop(L, lua_gettop(L));
@@ -35,6 +35,7 @@ begin
         s.position:=0;
         luaclass_newClass(L, mainform.Luafiles[i]); //return the tableFile, not the stream. To get the stream, use  tablefile_getData
         result:=1;
+        break; // abort iteration on first result
       end;
 
     if result=0 then //not overriden
@@ -47,6 +48,7 @@ begin
           s.position:=0;
           luaclass_newClass(L, mainform.InternalLuaFiles[i]);
           result:=1;
+          break;
         end;
       end;
     end;
@@ -61,9 +63,9 @@ function tablefile_saveToFile(L: Plua_State): integer; cdecl;
 var parameters: integer;
   lf: TLuaFile;
   f: string;
-  i: integer;
 begin
   lf:=luaclass_getClassObject(L);
+  f:=lf.name;
   if parameters>=1 then
     f:=Lua_ToString(L, -1);
 
@@ -75,7 +77,7 @@ function tablefile_getData(L: Plua_State): integer; cdecl;
 var parameters: integer;
   lf: TLuaFile;
 begin
-  result:=0;
+  result:=1;
   lf:=luaclass_getClassObject(L);
   luaclass_newClass(L, lf.stream);
 end;

--- a/Cheat Engine/LuaTableFile.pas
+++ b/Cheat Engine/LuaTableFile.pas
@@ -121,32 +121,15 @@ begin
   begin
     f:=Lua_ToString(L, -1);
     lua_pop(L, lua_gettop(L));
-    for i:=0 to mainform.LuaFiles.count-1 do
-      if mainform.Luafiles[i].name=f then
-      begin
-        s:=mainform.Luafiles[i].stream;
-
-        s.position:=0;
-        luaclass_newClass(L, mainform.Luafiles[i]); //return the tableFile, not the stream. To get the stream, use  tablefile_getData
-        result:=1;
-        break; // abort iteration on first result
-      end;
-
-    if result=0 then //not overriden
+    i:=indexOfLuaFileByName(f);
+    if i<>-1 then
+      result:=pushLuaTableFile(L, i) //return the tableFile, not the stream. To get the stream, use  tablefile_getData
+    else
     begin
-      for i:=0 to mainform.InternalLuaFiles.count-1 do
-      begin
-        if mainform.InternalLuaFiles[i].name=f then
-        begin
-          s:=mainform.InternalLuaFiles[i].stream;
-          s.position:=0;
-          luaclass_newClass(L, mainform.InternalLuaFiles[i]);
-          result:=1;
-          break;
-        end;
-      end;
+      i:=indexOfLuaFileByName(f, true); //internal file
+      if i<>-1 then
+        result:=pushLuaTableFile(L, i, true);
     end;
-
   end
   else
     lua_pop(L, lua_gettop(L));
@@ -162,6 +145,7 @@ begin
   mainform.LuaFiles.Remove(lf);
   mainform.UpdateMenu;
   lf.Free;
+  mainform.editedsincelastsave:=true;
 end;
 
 function tablefile_saveToFile(L: Plua_State): integer; cdecl;

--- a/Cheat Engine/bin/main.lua
+++ b/Cheat Engine/bin/main.lua
@@ -1492,12 +1492,14 @@ DataString: The internal string
 
 TableFile class (Inheritance: Object)
 findTableFile(filename): Returns the TableFile class object for the saved file
+createTableFile(filename, filepath OPTIONAL): TableFile - Add a new file to your table. If no filepath is specified, it will create a blank file. Otherwise, it will read the contents from disk.
 
 properties
   Name: string
   Stream: MemoryStream
 
 methods
+  delete() : Deletes this file from your table.
   saveToFile(filename)
   getData() : Gets a MemoryStream object
 


### PR DESCRIPTION
I was looking at adding a new XML section for persisting table-specific user data, but then I remembered this functionality and thought it'd do the job. I added the following:

- `TableFile.delete` method
- `createTableFile` function for adding an existing or new (blank) file to the table
- Few fixes and tweaks:
   - `TableFile.getData` wasn't returning anything
   - `TableFile.saveToFile` was treating the `filename` parameter like an optional argument, but didn't have a default value to use when it wasn't specified. (I used the `name` property)
   - Updated the `findTableFile` parameter handling behavior to be a bit more consistent with the rest of the bindings.

I originally wrote `createTableFile` as two separate functions, (`addTableFile` & `createTableFile`) but I think this is a bit cleaner.