### PR TITLE
fix registerAssembler AssemblerEvent

### DIFF
--- a/Cheat Engine/Assemblerunit.pas
+++ b/Cheat Engine/Assemblerunit.pas
@@ -1575,7 +1575,7 @@ type
 type ttokens=array of string;
 type TAssemblerBytes=array of byte;
 
-type TAssemblerEvent=procedure(address:integer; instruction: string; var bytes: TAssemblerBytes) of object;
+type TAssemblerEvent=procedure(address:qword; instruction: string; var bytes: TAssemblerBytes) of object;
 
 type TassemblerPreference=(apNone, apShort, apLong);
 

--- a/Cheat Engine/LuaCaller.pas
+++ b/Cheat Engine/LuaCaller.pas
@@ -64,7 +64,7 @@ type
       function AddressLookupCallback(address: ptruint): string;
       function SymbolLookupCallback(s: string): ptruint;
       function StructureNameLookup(var address: ptruint; var name: string): boolean;
-      procedure AssemblerEvent(address:integer; instruction: string; var bytes: TAssemblerBytes);
+      procedure AssemblerEvent(address:qword; instruction: string; var bytes: TAssemblerBytes);
       procedure AutoAssemblerPrologueEvent(code: TStrings; syntaxcheckonly: boolean);
       procedure ScreenFormEvent(Sender: TObject; Form: TCustomForm);
 
@@ -1076,7 +1076,7 @@ begin
   end;
 end;
 
-procedure TLuaCaller.AssemblerEvent(address:integer; instruction: string; var bytes: TAssemblerBytes);
+procedure TLuaCaller.AssemblerEvent(address:qword; instruction: string; var bytes: TAssemblerBytes);
 var
   oldstack: integer;
   tableindex: integer;


### PR DESCRIPTION
It fixes 64bit addresses being truncated to 32bit signed in functions
registered with registerAssembler.