### PR TITLE
Resolve #92 & #29 : Default table name when not first open process

### DIFF
--- a/Cheat Engine/MainUnit.pas
+++ b/Cheat Engine/MainUnit.pas
@@ -2423,11 +2423,6 @@ var
   fname: string;
   expectedfilename: string;
 begin
-  if savedialog1.Filename <> '' then
-    exit;
-  if opendialog1.Filename <> '' then
-    exit;
-
   Fname := copy(processlabel.Caption, pos('-', processlabel.Caption) + 1,
     length(processLabel.Caption));
 


### PR DESCRIPTION
Resolve issue #92 from rzndsa and #29 from Symbai.

Default table name when not first open process was wrong (save and open).
SetExpectedTableName was checking savedialog1.Filename and opendialog1.Filename to be empty.