### PR TITLE
Resolve #92 & #29 : Default table name when not first open process

### DIFF
--- a/Cheat Engine/MainUnit.pas
+++ b/Cheat Engine/MainUnit.pas
@@ -2588,7 +2588,8 @@ begin
     begin
       if (messagedlg(strKeepList, mtConfirmation, [mbYes, mbNo], 0) = mrNo) then
       begin
-
+        savedialog1.FileName := '';
+        Opendialog1.FileName := '';
         ClearList;
       end
       else
@@ -2632,6 +2633,11 @@ begin
         end;
       end;
 
+    end
+    else
+    begin
+      savedialog1.FileName := '';
+      Opendialog1.FileName := '';
     end;
 
   end;


### PR DESCRIPTION
savedialog1.Filename and opendialog1.Filename are set to empty if we have no address in the list or if we don't keep the current address list so the SetExpectedTableName procedure will set expectedFilename.

Resolve #92 & #29 like #93 but without the problem of deleting the name of the current table if one was loaded before opening the target process.