### PR TITLE
RLE compression for structures

### DIFF
--- a/Cheat Engine/StructuresFrm2.lfm
+++ b/Cheat Engine/StructuresFrm2.lfm
@@ -242,6 +242,10 @@ object frmStructures2: TfrmStructures2
         Caption = 'New integer types default to hexadecimal'
         OnClick = miDefaultHexadecimalClick
       end
+      object miRLECompression: TMenuItem
+        Caption = 'Enable RLE Compression'
+        OnClick = miRLECompressionClick
+      end
     end
   end
   object pmStructureView: TPopupMenu


### PR DESCRIPTION
I made few autoguessed structures (size: 4096). Resulting CT file is about 65% smaller.

cons: compression is not that great
pros: CSX file is still human readable