### PR TITLE
 fix expandsign position calculation

### DIFF
--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -1204,7 +1204,7 @@ begin
     while n<>nil do
     begin
       if moManualExpandCollapse in  TMemoryRecord(n.data).Options then
-        inc(textrect.left,treeview.indent div 2);
+        inc(textrect.left,expandsignsize+1);
       n:=n.parent;
     end;
 
@@ -1277,7 +1277,7 @@ begin
     begin
       if moManualExpandCollapse in  TMemoryRecord(n.data).Options then
       begin
-        inc(textrect.left,treeview.indent div 2);
+        inc(textrect.left,expandsignsize+1);
       end;
 
       n:=n.parent;
@@ -1296,7 +1296,7 @@ begin
 
         treeview.OnCollapsing:=TreeviewOnCollapse;
       end;
-      inc(textrect.left,treeview.indent div 2);
+      inc(textrect.left,expandsignsize+1);
     end;
 
     checkboxstart:=textrect.left+1;


### PR DESCRIPTION
Expandsign size is adjusted inside AdvancedCustomDrawItem.

Tested my patch on below table. Tier6 expandsign, checkbox and allow increase/decrease arrow position are now properly calculated.
```xml
<?xml version="1.0" encoding="utf-8"?>
<CheatTable>
  <CheatEntries>
    <CheatEntry>
      <ID>0</ID>
      <Description>"0"</Description>
      <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
      <VariableType>4 Bytes</VariableType>
      <Address>400500</Address>
      <CheatEntries>
        <CheatEntry>
          <ID>1</ID>
          <Description>"1"</Description>
          <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
          <VariableType>4 Bytes</VariableType>
          <Address>400500</Address>
          <CheatEntries>
            <CheatEntry>
              <ID>2</ID>
              <Description>"2"</Description>
              <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
              <VariableType>4 Bytes</VariableType>
              <Address>400500</Address>
              <CheatEntries>
                <CheatEntry>
                  <ID>3</ID>
                  <Description>"3"</Description>
                  <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
                  <VariableType>4 Bytes</VariableType>
                  <Address>400500</Address>
                  <CheatEntries>
                    <CheatEntry>
                      <ID>4</ID>
                      <Description>"4"</Description>
                      <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
                      <VariableType>4 Bytes</VariableType>
                      <Address>400500</Address>
                      <CheatEntries>
                        <CheatEntry>
                          <ID>5</ID>
                          <Description>"5"</Description>
                          <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
                          <VariableType>4 Bytes</VariableType>
                          <Address>400500</Address>
                          <CheatEntries>
                            <CheatEntry>
                              <ID>6</ID>
                              <Description>"6"</Description>
                              <Options moManualExpandCollapse="1" moAllowManualCollapseAndExpand="1"/>
                              <VariableType>4 Bytes</VariableType>
                              <Address>400500</Address>
                              <CheatEntries>
                                <CheatEntry>
                                  <ID>7</ID>
                                  <Description>"7"</Description>
                                  <VariableType>4 Bytes</VariableType>
                                  <Address>400500</Address>
                                </CheatEntry>
                              </CheatEntries>
                            </CheatEntry>
                          </CheatEntries>
                        </CheatEntry>
                      </CheatEntries>
                    </CheatEntry>
                  </CheatEntries>
                </CheatEntry>
              </CheatEntries>
            </CheatEntry>
          </CheatEntries>
        </CheatEntry>
      </CheatEntries>
    </CheatEntry>
  </CheatEntries>
</CheatTable>
```