### PR TITLE
fix right-clicking R8-R9 register in MemoryBrowser

### DIFF
--- a/Cheat Engine/MemoryBrowserFormUnit.pas
+++ b/Cheat Engine/MemoryBrowserFormUnit.pas
@@ -880,7 +880,7 @@ begin
   begin
     if (sender is TLabel) then
     begin
-      s:=tlabel(sender).Caption;
+      s:=trim(tlabel(sender).Caption);
       i:=pos(' ',s);
       if i>0 then //should always be true
       begin


### PR DESCRIPTION
fix this issue (viewtopic.php?p=5733213#5733213):

>Right-clicking a register should copy its value, but it does not work for all registers. However, R8 and R9 includes name of reg:
>R8 0000000000000000
>R9 0000000000000000
