### PR TITLE
fix selected checkbox color for high contrast theme

### DIFF
--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -2276,7 +2276,7 @@ begin
   symhandler.AddFinishedLoadingSymbolsNotification(SymbolsLoaded);
 
 
-  checkboxActiveSelectedColor:=clBlack;
+  checkboxActiveSelectedColor:=clRed;
   CheckboxActiveColor:=clRed;
   CheckboxSelectedColor:=clWindowtext;
   CheckboxColor:=clWindowtext;


### PR DESCRIPTION
This is a fix for:
the check box in the address list is not visible or has low contrast when the row is selected under high contrast color schemes #255

Im curious as to why the checkbox was black on selected rows to begin with? Did they have something else in mind at the time? Does the developer use a different theme or does newer windows use different color for highlighted rows?
