### PR TITLE
PR to fix certain types of warnings

### DIFF
--- a/Cheat Engine/ExtraTrainerComponents.pas
+++ b/Cheat Engine/ExtraTrainerComponents.pas
@@ -119,7 +119,7 @@ type TCheatList = class (twincontrol)
     fshowhotkeys: boolean;
     fBeepOnActivate: boolean;
     Function GetItem(i:integer):tcheat;
-    procedure SetAutosize(x:boolean);
+    procedure SetAutosize(x:boolean); override;
     procedure sethotkeyleft(i:integer);
     procedure setDescriptionleft(i: integer);
     procedure setEditLeft(i: integer);

--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -7475,6 +7475,7 @@ end;
 
 function lua_unloadLoadedFont(L: PLua_state): integer; cdecl;
 begin
+  result:=0;
   if lua_isnumber(L, 1) then
     RemoveFontMemResourceEx(lua_tointeger(L,1));
 end;
@@ -7488,7 +7489,7 @@ var
 
   h: THandle;
 begin
-
+  result:=0;
   if lua_isuserdata(L, 1) then
   begin
     s:=lua_toceuserdata(L, 1);
@@ -7499,12 +7500,7 @@ begin
       lua_pushinteger(L, h);
       result:=1;
     end;
-
   end;
-
-
-
-
 end;
 
 function lua_speakex(engLang: boolean; L: Plua_State): integer; cdecl;
@@ -7552,12 +7548,12 @@ end;
 
 function lua_speak(L: Plua_State): integer; cdecl;
 begin
-  lua_speakEx(false,L);
+  result:=lua_speakEx(false,L);
 end;
 
 function lua_speakEnglish(L: Plua_State): integer; cdecl;
 begin
-  lua_speakEx(true,L);
+  result:=lua_speakEx(true,L);
 end;
 
 
@@ -7790,6 +7786,7 @@ end;
 function lua_unregisterEXETrainerFeature(L: Plua_State): integer; cdecl;
 var i: integer;
 begin
+  result:=0;
   if (lua_gettop(L)=1) and lua_isnumber(L, 1) then
   begin
     i:=lua_tointeger(L,1);
@@ -8133,6 +8130,7 @@ end;
 
 function lua_saveOpenedFile(L: Plua_State): integer; cdecl;
 begin
+  result:=0;
   if lua_gettop(L)>=1 then
     filehandler.commitchanges(Lua_ToString(L,1))
   else
@@ -8390,6 +8388,7 @@ begin
   if r=STATUS_INFO_LENGTH_MISMATCH then exit(0);
   if r<>0 then exit(0);
 
+  peprocess:=0;
   if lua_gettop(L)>=1 then
   begin
     filter:=lua_tointeger(L,1);

--- a/Cheat Engine/LuaObject.pas
+++ b/Cheat Engine/LuaObject.pas
@@ -34,6 +34,7 @@ var c: TObject;
 
 
 begin
+  result:=0;
   i:=ifthen(lua_type(L, lua_upvalueindex(1))=LUA_TUSERDATA, lua_upvalueindex(1), 1);
   c:=lua_toceuserdata(L, i);
   lua_getmetatable(L, i);

--- a/Cheat Engine/LuaSQL.pas
+++ b/Cheat Engine/LuaSQL.pas
@@ -164,6 +164,7 @@ end;
 
 function sqlite3connection_createDB(L: Plua_State): integer; cdecl;
 begin
+  result:=0;
   try
     TSQLite3Connection(luaclass_getClassObject(L)).CreateDB;
   except
@@ -177,6 +178,7 @@ end;
 
 function sqlite3connection_dropDB(L: Plua_State): integer; cdecl;
 begin
+  result:=0;
   try
     TSQLite3Connection(luaclass_getClassObject(L)).DropDB;
   except

--- a/Cheat Engine/MemoryBrowserFormUnit.pas
+++ b/Cheat Engine/MemoryBrowserFormUnit.pas
@@ -1226,7 +1226,7 @@ begin
   else
     hexview.UseRelativeBase:=false;
 
-  hexview.update;
+  hexview.UpdateView;
 end;
 
 procedure TMemoryBrowser.miSVCopyClick(Sender: TObject);
@@ -1609,7 +1609,7 @@ begin
     begin
       hexview.GetSelectionRange(a,a2);
       DebuggerThread.SetOnAccessBreakpoint(a, 1+(a2-a));
-      hexview.Update;
+      hexview.UpdateView;
     end;
   except
     on e: exception do
@@ -1627,7 +1627,7 @@ begin
     begin
       hexview.GetSelectionRange(a,a2);
       DebuggerThread.SetOnWriteBreakpoint(a, 1+(a2-a));
-      hexview.Update;
+      hexview.UpdateView;
     end;
   except
     on e: exception do
@@ -1734,7 +1734,7 @@ begin
     finally
       debuggerthread.unlockbplist;
     end;
-    hexview.update;
+    hexview.UpdateView;
   end;
 end;
 
@@ -1770,7 +1770,7 @@ begin
     hexview.GetSelectionRange(a,a2);
 
     DebuggerThread.FindWhatAccesses(a,1+(a2-a));
-    hexview.Update;
+    hexview.UpdateView;
   end;
 end;
 
@@ -1783,7 +1783,7 @@ begin
     hexview.GetSelectionRange(a,a2);
 
     DebuggerThread.FindWhatWrites(a,1+(a2-a));
-    hexview.Update;
+    hexview.UpdateView;
   end;
 
 end;
@@ -2195,7 +2195,7 @@ var
 begin
   if Visible then
   begin
-    if hexview<>nil then hexview.update;
+    if hexview<>nil then hexview.UpdateView;
     if disassemblerview<>nil then disassemblerview.Update;
 
     //refresh the modulelist
@@ -2261,7 +2261,7 @@ begin
     original:=0;
 
     RewriteCode(processhandle,disassemblerview.SelectedAddress,@nops[0],codelength);
-    hexview.update;
+    hexview.UpdateView;
     disassemblerview.Update;;
   end;
 end;
@@ -2712,7 +2712,7 @@ begin
 
         bytelength:=length(bytes);
         RewriteCode(processhandle,disassemblerview.SelectedAddress,@bytes[0],bytelength);
-        hexview.update;
+        hexview.UpdateView;
         disassemblerview.Update;
       end else raise exception.create(Format(rsIDonTUnderstandWhatYouMeanWith, [assemblercode]));
     except

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -1640,6 +1640,7 @@ begin
     end;
   end;
 
+  laststate:=nil;
   if Value<>'??' then
   begin
     laststate:=cheatEntry.AppendChild(doc.CreateElement('LastState'));

--- a/Cheat Engine/PointerscannerSettingsFrm.pas
+++ b/Cheat Engine/PointerscannerSettingsFrm.pas
@@ -32,7 +32,7 @@ type
     property filename: string read ffilename write setFileName;
     property OnDelete: TNotifyEvent read fOnDelete write fOnDelete;
     property OnSetFileName: TNotifyEvent read fOnSetFileName write fOnSetFileName;
-    constructor create(imagelist: TImageList; AOwner: TComponent);
+    constructor create(imagelist: TImageList; AOwner: TComponent); overload;
     destructor destroy; override;
   end;
 
@@ -57,7 +57,7 @@ type
   private
     procedure AdjustPos(sender: tobject);
   public
-    constructor create(imagelist: TImageList; AOwner: TComponent; w: integer);
+    constructor create(imagelist: TImageList; AOwner: TComponent; w: integer); overload;
     destructor destroy; override;
 
     property OnEmptyList: TNotifyEvent read fOnEmptyList write fOnEmptyList;
@@ -692,7 +692,7 @@ begin
       exit;
     end;
   end;
-
+  comparecount:=0;
   if cbCompareToOtherPointermaps.checked then
   begin
     //check if the addresses are valid

--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -78,8 +78,8 @@ type
     procedure sectiontrack(HeaderControl: TCustomHeaderControl; Section: THeaderSection; Width: Integer; State: TSectionTrackState);
     procedure sectionClick(HeaderControl: TCustomHeaderControl; Section: THeaderSection);
     procedure FocusChange(sender: TObject);
-    procedure DragOver(Sender, Source: TObject; X,Y: Integer; State: TDragState; var Accept: Boolean);
-    procedure DragDrop(Sender, Source: TObject; X,Y: Integer);
+    procedure DragOver(Sender, Source: TObject; X,Y: Integer; State: TDragState; var Accept: Boolean); overload;
+    procedure DragDrop(Sender, Source: TObject; X,Y: Integer); overload;
     procedure DragEnd(Sender, Target: TObject; X,Y: Integer);
     procedure TreeviewOnCollapse(Sender: TObject; Node: TTreeNode; var AllowCollapse: Boolean);
     procedure TreeviewOnExpand(Sender: TObject; Node: TTreeNode; var AllowExpansion: Boolean);
@@ -100,7 +100,7 @@ type
     function GetSelcount: integer;
     function GetMemRecItemByIndex(i: integer): TMemoryRecord;
     procedure setPopupMenu(menu: TPopupMenu);
-    function getPopupMenu: TPopupMenu;
+    function getPopupMenu: TPopupMenu; override;
     function getSelectedRecord: TMemoryRecord;
     procedure setSelectedRecord(memrec: TMemoryrecord);
 

--- a/Cheat Engine/addresslisteditor.pas
+++ b/Cheat Engine/addresslisteditor.pas
@@ -45,7 +45,7 @@ type
     procedure DoExit; override;
   public
     procedure UpdatePosition(left: integer);
-    constructor create(owner: TTreeView; memrec: TMemoryrecord; left: integer);
+    constructor create(owner: TTreeView; memrec: TMemoryrecord; left: integer); overload;
     destructor destroy; override;
   published
     property memrec: TMemoryrecord read fmemrec;

--- a/Cheat Engine/asktorunluascript.pas
+++ b/Cheat Engine/asktorunluascript.pas
@@ -43,6 +43,7 @@ implementation
 
 function TfrmLuaScriptQuestion.getLuaScriptAction: integer;
 begin
+  result:=0;
   if rbAlways.checked then result:=0 else
   if rbSignedOnly.checked then result:=1 else
   if rbAlwaysAsk.checked then result:=2 else

--- a/Cheat Engine/autoassembler.pas
+++ b/Cheat Engine/autoassembler.pas
@@ -542,6 +542,7 @@ begin
   //remove comments
   instring:=false;
   incomment:=false;
+  bracecomment:=false;
   for i:=0 to code.count-1 do
   begin
     currentline:=code[i];

--- a/Cheat Engine/ceguicomponents.pas
+++ b/Cheat Engine/ceguicomponents.pas
@@ -620,7 +620,7 @@ type TCEForm=class(TCustomForm)
     procedure RestoreToDesignState;
     procedure SaveCurrentStateasDesign;
     function getVisible:boolean;
-    procedure setVisible(state: boolean);
+    procedure setVisibleCEF(state: boolean);
     destructor destroy; override;
 
     property  active: boolean read getActive write setActive;
@@ -704,7 +704,7 @@ type TCEForm=class(TCustomForm)
     property ShowInTaskBar;
   //  property UseDockManager;
  //   property LCLVersion: string read FLCLVersion write FLCLVersion stored LCLVersionIsStored;
-    property Visible read getVisible write setVisible;
+    property Visible read getVisible write setVisibleCEF;
     property WindowState;
 
     property DoNotSaveInTable: boolean read fDoNotSaveInTable write fDoNotSaveInTable default False;
@@ -1445,7 +1445,7 @@ begin
 
 end;
 
-procedure TCEForm.setVisible(state: boolean);
+procedure TCEForm.setVisibleCEF(state: boolean);
 begin
   fVisible:=state;
   if active=false then

--- a/Cheat Engine/debugeventhandler.pas
+++ b/Cheat Engine/debugeventhandler.pas
@@ -743,6 +743,7 @@ begin
 
 
   {$ifdef cpu32}
+  hasSetInt1Back:=false;
   if not (CurrentDebuggerInterface is TKernelDebugInterface) then
   begin
     if setint1back then

--- a/Cheat Engine/feces.pas
+++ b/Cheat Engine/feces.pas
@@ -92,6 +92,7 @@ end;
 
 function DecodePointerNI(p: pointer):pointer; stdcall;
 begin
+  result:=nil;
   if rv=0 then exit;
 
   result:=pointer(ptruint(p) xor rv);

--- a/Cheat Engine/formAddressChangeUnit.pas
+++ b/Cheat Engine/formAddressChangeUnit.pas
@@ -105,7 +105,7 @@ type
     procedure setupPositionsAndSizes;
 
 
-    constructor create(owner: TformAddressChange);
+    constructor create(owner: TformAddressChange); overload;
     destructor destroy; override;
 
   end;

--- a/Cheat Engine/formmemoryregionsunit.pas
+++ b/Cheat Engine/formmemoryregionsunit.pas
@@ -169,8 +169,9 @@ begin
       begin
         if processhandler.is64Bit then
         begin
+          {$IFDEF CPU64}
           if (address>=QWORD($8000000000000000)) then exit;
-
+          {$ENDIF}
         end
         else
           if (address>=$80000000) then exit;

--- a/Cheat Engine/frmUltimap2Unit.pas
+++ b/Cheat Engine/frmUltimap2Unit.pas
@@ -326,6 +326,7 @@ var self: TUltimap2Worker;
 
   s: integer;
 begin
+  result:=0;
   self:=TUltimap2Worker(context);
   //watch for page boundaries
 
@@ -413,7 +414,7 @@ var
 begin
   //read the memory and add it if necesary
   result:=nil;
-
+  endaddress:=0;
   ownerForm.regiontreeMREW.Beginwrite;
 
   try
@@ -1451,8 +1452,9 @@ var
   cpuid14_0: TCPUIDResult;
   cpuid14_1: TCPUIDResult;
 begin
-  if state=rsProcessing then exit;
-
+  if state=rsProcessing then
+    exit;
+  bsize:=0;
     //if ssCtrl in GetKeyShiftState then
     //  debugmode:=true;
 

--- a/Cheat Engine/frmUltimapUnit.pas
+++ b/Cheat Engine/frmUltimapUnit.pas
@@ -979,6 +979,7 @@ begin
   p:=PopupMenu1.PopupPoint;
   for i:=0 to listview1.Items.count-1 do
   begin
+    a:=0;
     if listview1.Items[i].Selected then
     begin
       if p.x>listview1.Column[0].Width then

--- a/Cheat Engine/frmWatchlistUnit.pas
+++ b/Cheat Engine/frmWatchlistUnit.pas
@@ -82,6 +82,7 @@ var
 
   vt: TvariableType;
 begin
+  vt:=TVariableType(0);
   for i:=0 to lvWatchlist.Items.Count-1 do
   begin
     //evaluate the expression

--- a/Cheat Engine/frmgroupscanalgoritmgeneratorunit.pas
+++ b/Cheat Engine/frmgroupscanalgoritmgeneratorunit.pas
@@ -61,7 +61,7 @@ type
     function getParameterPart(skipPicked: boolean=true): string;
     function bytesize: integer;
     procedure setPosition;
-    constructor Create(frm: TfrmGroupScanAlgoritmGenerator);
+    constructor Create(frm: TfrmGroupScanAlgoritmGenerator); overload;
     destructor destroy; override;
   end;
 

--- a/Cheat Engine/frmmemoryrecorddropdownsettingsunit.pas
+++ b/Cheat Engine/frmmemoryrecorddropdownsettingsunit.pas
@@ -52,7 +52,7 @@ type
 
   public
     { public declarations }
-    constructor create(memrec: TMemoryrecord);
+    constructor create(memrec: TMemoryrecord); overload;
   end;
 
 implementation

--- a/Cheat Engine/frmmemreccomboboxunit.pas
+++ b/Cheat Engine/frmmemreccomboboxunit.pas
@@ -28,7 +28,7 @@ type
     function getValue: string;
   public
     { public declarations }
-    constructor create(memrec: TMemoryrecord);
+    constructor create(memrec: TMemoryrecord); overload;
     property value: string read getValue;
   end;
 

--- a/Cheat Engine/gnuassembler.pas
+++ b/Cheat Engine/gnuassembler.pas
@@ -218,6 +218,7 @@ var
 
   bu: TBinUtils;
 begin
+  result:=true;
   if (binutilslist.count=0) then
     raise exception.create(rsConfigureAValidBinutilsSetupFirst);
 

--- a/Cheat Engine/jvdesign/jvdesignimp.pas
+++ b/Cheat Engine/jvdesign/jvdesignimp.pas
@@ -1,7 +1,7 @@
 unit JvDesignImp;
 
 {$mode objfpc}{$H+}
-
+{$WARNINGS OFF}
 interface
 
 uses
@@ -1575,6 +1575,8 @@ finalization
   {$IFDEF UNITVERSIONING}
   UnregisterUnitVersion(HInstance);
   {$ENDIF UNITVERSIONING}
+
+{$WARNINGS ON}
 
 end.
 

--- a/Cheat Engine/jvdesign/jvdesignsurface.pas
+++ b/Cheat Engine/jvdesign/jvdesignsurface.pas
@@ -33,7 +33,7 @@ Known Issues:
 // $Id: JvDesignSurface.pas 12931 2010-11-28 13:36:50Z ahuser $
 
 unit JvDesignSurface;
-
+{$WARNINGS OFF}
 {$mode objfpc}{$H+}
 {$DEFINE NO_DESIGNHOOK}
 interface
@@ -352,6 +352,7 @@ function TJvDesignCustomMessenger.IsDesignMessage(ASender: TControl;
   end;
 
 begin
+  result:=false;
   if not Assigned(FOnDesignMessage) then
     Result := False
   else
@@ -957,6 +958,7 @@ var
     i: integer;
 
 begin
+  p:=nil;
   s:=TStringStream.Create(clipboard.AsText);
   ms:=TMemoryStream.Create;
 
@@ -1409,6 +1411,6 @@ initialization
 finalization
   UnregisterUnitVersion(HInstance);
 {$ENDIF UNITVERSIONING}
-
+{$WARNINGS ON}
 end.
 

--- a/Cheat Engine/jvdesign/jvdesignutils.pas
+++ b/Cheat Engine/jvdesign/jvdesignutils.pas
@@ -3,6 +3,7 @@
 unit JvDesignUtils;
 
 {$mode objfpc}{$H+}
+{$WARNINGS OFF}
 
 interface
 uses
@@ -483,7 +484,7 @@ initialization
 finalization
   UnregisterUnitVersion(HInstance);
 {$ENDIF UNITVERSIONING}
-
+{$WARNINGS ON}
 end.
 
 

--- a/Cheat Engine/pointerscanconnector.pas
+++ b/Cheat Engine/pointerscanconnector.pas
@@ -134,6 +134,7 @@ var
   i: integer;
   entry: PConnectentry;
 begin
+  result:=0;
   if port=0 then exit; //do not allow port 0
 
   getmem(entry, sizeof(TConnectEntry));

--- a/Cheat Engine/pointerscancontroller.pas
+++ b/Cheat Engine/pointerscancontroller.pas
@@ -844,10 +844,10 @@ begin
         self.starttime:=GetTickCount64;
 
 
+        sent:=0;
         UpdateChildProgress(sent, totalsize);
         //update the child progress
 
-        sent:=0;
 
         for i:=0 to length(f)-1 do
         begin
@@ -1675,7 +1675,7 @@ begin
 
   listsize:=sizeof(dword)*(maxlevel+1);
   valuelistsize:=sizeof(qword)*(maxlevel+1);
-
+  offsetcountperlist:=0;
 
   pathqueueCS.enter;
   try
@@ -1895,6 +1895,7 @@ begin
 
 
   alldone:=false;
+  addedToQueue:=false;
 
 
   try

--- a/Cheat Engine/pointervaluelist.pas
+++ b/Cheat Engine/pointervaluelist.pas
@@ -1036,6 +1036,7 @@ begin
 
         while address<prangelist[i].endaddress do
         begin
+          valid:=false;
           pfn:=address shr 12;
           scannablepages.Add(pfn, valid);
           inc(address, 4096);

--- a/Cheat Engine/symbolhandler.pas
+++ b/Cheat Engine/symbolhandler.pas
@@ -626,8 +626,8 @@ LPIMAGEHLP_STACK_FRAME = PIMAGEHLP_STACK_FRAME;
 function symflagsToString(symflags: dword): string;
 var s: string;
 begin
-  {$IFNDEF UNIX}
   s:='';
+  {$IFNDEF UNIX}
   if (symFlags and SYMFLAG_VALUEPRESENT)>0 then
     s:=s+'VALUEPRESENT ';
   if (symFlags and SYMFLAG_REGISTER)>0 then
@@ -655,6 +655,7 @@ begin
   if (symflags and SYMFLAG_TLSREL)>0 then
     s:=s+'TLSREL ';
   {$ENDIF}
+  result:=s;
 end;
 
 function GetTypeName(h: HANDLE; modbase: UINT64; index: integer; infinitycheck: integer=50): string;
@@ -662,8 +663,8 @@ var x: dword;
     type_symtag: TSymTagEnum;
     name: PWCHAR;
 begin
-  {$IFNDEF UNIX}
   result:='';
+  {$IFNDEF UNIX}
   if infinitycheck<0 then exit;
 
   if SymGetTypeInfo(h, modbase, index, TI_GET_SYMTAG, @type_symtag) then
@@ -849,6 +850,7 @@ var
 
   esde: TExtraSymbolDataEntry;
 begin
+  result:=false;
   {$IFNDEF UNIX}
   if pSymInfo.NameLen=0 then
     exit(false);
@@ -3841,7 +3843,8 @@ var
 begin
   result:=false;
   tokenize(s, tokens);
-
+  err:=true;
+  t2start:=0;
   //first find the first part
   s1:='';
   for i:=0 to length(tokens)-2 do

--- a/Cheat Engine/tablist.pas
+++ b/Cheat Engine/tablist.pas
@@ -208,7 +208,7 @@ begin
   inherited Paint;
 
   lastx:=0;
-
+  selectedx:=0;
   //create a total of 'fTabs.count' tabs
   for j:=offset to fTabs.count-1 do
   begin

--- a/Cheat Engine/unrandomizer.pas
+++ b/Cheat Engine/unrandomizer.pas
@@ -149,7 +149,7 @@ begin
 
   setlength(buffer,length(genericreplace));
 
-
+  j:=0;
   a:=symhandler.getAddressFromName('msvcrt120.rand',true, e);
   if not e then
   begin


### PR DESCRIPTION
This contains fixes for certain types of warnings:
1. function result does not seem to be set
2. variable "X" read but nowhere assigned
3. local variable "X" does not seem to be initialized
4. inherited method is hidden by "X"

2 and 3 are the big ones where the code is using a variable before its been initialized.
4 required a bit of work in some places. I would like someone to check closely these files:
1. memorybrowserformunit.pas
2. ceguicomponents.pas
3. hexviewunit.pas