### PR TITLE
set 'referenced functions' window position to screen center instead of designed position

### DIFF
--- a/Cheat Engine/frmreferencedfunctionsunit.lfm
+++ b/Cheat Engine/frmreferencedfunctionsunit.lfm
@@ -7,6 +7,7 @@ object frmReferencedFunctions: TfrmReferencedFunctions
   ClientHeight = 353
   ClientWidth = 677
   OnShow = FormShow
+  Position = poScreenCenter
   LCLVersion = '1.6.4.0'
   object lvCallList: TListView
     Left = 0


### PR DESCRIPTION
The window:
Memory viewer -> view -> referenced functions
will appear where it was when designed when opened.
It seems that poScreenCenter is the usual position for the other forms and opens on the screen that CE is on. the window appears out of place when using multiple monitors and CE is placed on another monitor than the main desktop.