### PR TITLE
Fix dangling eprocess references in DBKKernel

### DIFF
--- a/DBKKernel/IOPLDispatcher.c
+++ b/DBKKernel/IOPLDispatcher.c
@@ -385,7 +385,7 @@ NTSTATUS DispatchIoctl(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp)
 
 		case IOCTL_CE_OPENPROCESS:
 			{					
-				PEPROCESS selectedprocess;
+				PEPROCESS selectedprocess = NULL;
 				ULONG processid=*(PULONG)Irp->AssociatedIrp.SystemBuffer;
 				HANDLE ProcessHandle = GetHandleForProcessID((HANDLE)processid);
 				struct out
@@ -428,6 +428,11 @@ NTSTATUS DispatchIoctl(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp)
 				{
 					//DbgPrint("ProcessHandle=%x", (int)ProcessHandle);
 					POutput->Special = 1;					
+				}
+
+				if (selectedprocess)
+				{
+					ObDereferenceObject(selectedprocess);
 				}
 				
 				POutput->h=(UINT64)ProcessHandle;

--- a/DBKKernel/processlist.c
+++ b/DBKKernel/processlist.c
@@ -168,7 +168,6 @@ VOID CreateProcessNotifyRoutine(IN HANDLE  ParentId, IN HANDLE  ProcessId, IN BO
 						*/
 						
 						KAPC_STATE oldstate;
-						ObReferenceObject(CurrentProcess);
 
 						
 						KeStackAttachProcess((PKPROCESS)WatcherProcess, &oldstate);						


### PR DESCRIPTION
The IOCTL_CE_OPENPROCESS handler and the process watcher CreateProcessNotifyRoutine callback are leaking EPROCESS references resulting in zombie processes.

**Platform**: Windows 7 x64 SP1
**Steps to reproduce**: 

1. Start a vm with WinDbg attached as a kernel debugger.
2. Launch cheat engine.
3. Enable process watcher in settings.
4. Start calc.exe and mspaint.exe
5. Close mspaint.exe
6. Close cheat engine.
7. Close calc.exe.
8. Inspect the global process list in WinDbg to see a zombie cheatengine-x86_64.exe.

WinDbg output showing the single dangling reference:

<pre>kd> !process 0 0
**** NT ACTIVE PROCESS DUMP ****
...
PROCESS fffffa80032f4060
    SessionId: 1  Cid: 0c20    Peb: 7fffffd4000  ParentCid: 0c10
    DirBase: 23657000  ObjectTable: 00000000  HandleCount:   0.
    Image: cheatengine-x86_64.exe

kd> dt nt!_OBJECT_HEADER
   +0x000 PointerCount     : Int8B
   +0x008 HandleCount      : Int8B
   +0x008 NextToFree       : Ptr64 Void
   +0x010 Lock             : _EX_PUSH_LOCK
   +0x018 TypeIndex        : UChar
   +0x019 TraceFlags       : UChar
   +0x01a InfoMask         : UChar
   +0x01b Flags            : UChar
   +0x020 ObjectCreateInfo : Ptr64 _OBJECT_CREATE_INFORMATION
   +0x020 QuotaBlockCharged : Ptr64 Void
   +0x028 SecurityDescriptor : Ptr64 Void
   +0x030 Body             : _QUAD
kd> dt nt!_OBJECT_HEADER (0xfffffa80032f4060 - 0x30)
   +0x000 PointerCount     : 0n1    <------------------------------- Dangling reference
   +0x008 HandleCount      : 0n0
   +0x008 NextToFree       : (null) 
   +0x010 Lock             : _EX_PUSH_LOCK
   +0x018 TypeIndex        : 0x7 ''
   +0x019 TraceFlags       : 0 ''
   +0x01a InfoMask         : 0x8 ''
   +0x01b Flags            : 0 ''
   +0x020 ObjectCreateInfo : 0xfffffa80`02c65840 _OBJECT_CREATE_INFORMATION
   +0x020 QuotaBlockCharged : 0xfffffa80`02c65840 Void
   +0x028 SecurityDescriptor : 0xfffff8a0`01d23a45 Void
   +0x030 Body             : _QUAD</pre>

**Note**: I found this bug on a local branch which was forked from master earlier this year. This branch causes zombie processes for every process created after process watcher is enabled. This seems to be fixed with the latest version of master (12.3.2017) despite the extra reference increment in CreateProcessNotifyRoutine. The cheat engine process still has the dangling reference issue in the latest version of master.