### PR TITLE
show proper custom type variable name

### DIFF
--- a/Cheat Engine/bin/celua.txt
+++ b/Cheat Engine/bin/celua.txt
@@ -1811,7 +1811,7 @@ properties
     If the type is vtByteArray then the following properties are available
       Aob.Size : Number of bytes
 
-  CustomTypeName: String - If the type is vtCustomType this will contain the name of the CustomType
+  CustomTypeName: String - If the type is vtCustom this will contain the name of the CustomType
   Script: String - If the type is vtAutoAssembler this will contain the auto assembler script
   Value: string - The value in stringform.
   Selected: boolean - Set to true if selected (ReadOnly)


### PR DESCRIPTION
the name used in defines.lua is vtCustom not vtCustomType, simple change for clarity.