### PR TITLE
fix createMultiReadExclusiveWriteSynchronizer

### DIFF
--- a/Cheat Engine/LuaThread.pas
+++ b/Cheat Engine/LuaThread.pas
@@ -243,13 +243,9 @@ end;
 function luaCreateMultiReadExclusiveWriteSynchronizer(L: PLua_State): integer; cdecl;
 var mrew: TMultiReadExclusiveWriteSynchronizer;
 begin
-  result:=0;
-  if lua_gettop(L)=1 then
-  begin
-    mrew:=TMultiReadExclusiveWriteSynchronizer.Create;
-    luaclass_newclass(L, mrew);
-    result:=1;
-  end;
+  mrew:=TMultiReadExclusiveWriteSynchronizer.Create;
+  luaclass_newclass(L, mrew);
+  result:=1;
 end;
 
 function lua_getCPUCount(L: PLua_State): integer; cdecl;


### PR DESCRIPTION
createMultiReadExclusiveWriteSynchronizer doesn't need an argument