### PR TITLE
memrecsLinkedToMe array instead of destroy event

### DIFF
--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -997,6 +997,9 @@ begin
   for i:=0 to length(memrecsLinkedToMe)-1 do
     if memrecsLinkedToMe[i]<>nil then
       memrecsLinkedToMe[i].linkedDropDownMemrec:=nil;
+
+  setlength(memrecsLinkedToMe,0);
+
   {-------------^^^DropDownList linking^^^-------------}
 
   if assigned(fOnDestroy) then


### PR DESCRIPTION
- detects loops
- fixed Lua OnDestroy overwriting
- setting DropDownLinkedMemrec will force refresh (added setDropDownLinkedMemrec setter)
- moved getlinkedDropDownMemrec to public section in TMemoryRecord class