### PR TITLE
32-bit Build Fix

### DIFF
--- a/Cheat Engine/dbk32/vmxfunctions.pas
+++ b/Cheat Engine/dbk32/vmxfunctions.pas
@@ -133,7 +133,7 @@ rsBigError = 'Error';
 rsSmallError = 'error';
 
 var vmcall :function(vmcallinfo:pointer; level1pass: dword): PtrUInt; stdcall;
-var vmcall2 :function(vmcallinfo:pointer; level1pass: dword; secondaryOut: PQWORD): PtrUInt; stdcall;
+var vmcall2 :function(vmcallinfo:pointer; level1pass: dword; secondaryOut: pptruint): PtrUInt; stdcall;
 
 function vmcallUnSupported(vmcallinfo:pointer; level1pass: dword): PtrUInt; stdcall;
 begin


### PR DESCRIPTION
One line fix for the following 32-bit build errors:

```
Compile Project, Mode: Release 32-Bit, Target: bin\cheatengine-i386.exe: Exit code 1, Errors: 2
vmxfunctions.pas(1215,5) Error: Incompatible types: got "vmcallSupported2_amd(Pointer;LongWord;PPtrUInt):DWord; StdCall;" expected "<procedure variable type of function(Pointer;LongWord;PQWord):DWord;StdCall>"
vmxfunctions.pas(1219,38) Error: Incompatible types: got "vmcallSupported2_intel(Pointer;LongWord;PPtrUInt):DWord; StdCall;" expected "<procedure variable type of function(Pointer;LongWord;PQWord):DWord;StdCall>"
```