### PR TITLE
Access Error on AOB Generation

### DIFF
--- a/Cheat Engine/foundlisthelper.pas
+++ b/Cheat Engine/foundlisthelper.pas
@@ -722,7 +722,7 @@ begin
   //log('TFoundList.Initialize');
   Deinitialize;
 
-  foundlist.itemindex:=-1;
+  //foundlist.itemindex:=-1;
   foundlist.items.count:=0;
 
 


### PR DESCRIPTION
For the past couple of months, I've been getting an "Access error" whenever I tried to generate an AOB injection script. (either through the built-in AOB injection template or through the ``generateAOBInjectionScript`` lua API) In the 64-bit CE, the error gets caught/shown and only the ``[ENABLE]`` & ``[DISABLE]`` lines are generated. On the 32-bit version, CE just crashes. Finally ran it in a debugger tonight and the results of that spawned the change in my pull request.

The errors stopped after I made this small change, but I don't know shit about LCL and will defer to you on whether or not this is a "fix". Could just be a bug/incompatibility specific to my compiler/library versions. Let me know if you're unable to reproduce the issue and I'll try recompiling with whatever version you're on.

* Lazarus Version #: 1.9.0
* FPC Version: 3.1.1

Built with [fpcup](https://github.com/LongDirtyAnimAlf/Reiniero-fpcup/)


**Stack Trace**

```
#0 SETSTATE(0x0, 3, false) at include\listitem.inc:732
#1 SETSELECTION(0xefed570, 0x0) at include\customlistview.inc:1673
#2 SETITEMINDEX(0xefed570, -1) at include\customlistview.inc:1632
#3 INITIALIZE(0xefefd70, VTBYTEARRAY, 0x0) at foundlisthelper.pas:725
#4 GETUNIQUEAOB({MODULENAME = 0xb09da78 'kenshi_x64.exe', MODULEPATH = 0x1196f4e8 'I:\Games\Steam\steamapps\common\Kenshi\kenshi_x64.exe', ISSYSTEMMODULE = false, BASEADDRESS = 5362941952, BASESIZE = 42536960, IS64BITMODULE = true, SYMBOLSLOADED = true, HASSTRUCTINFO = false, DATABASEMODULEID = 0}, 5371265695, 8, 1431655765) at frmautoinjectunit.pas:2761
#5 GENERATEAOBINJECTIONSCRIPT(0xf65daa0, 0xf65e838 '"kenshi_x64.exe"+7F029F', 0x10306468 'SelChar_Inject') at frmautoinjectunit.pas:2496
#6 MENUAOBINJECTIONCLICK(0xefcfc50, 0x109e20d0) at frmautoinjectunit.pas:2672
#7 CLICK(0x109e20d0) at include\menuitem.inc:83
#8 DOCLICKED(0x109e20d0, 0) at include\menuitem.inc:293
#9 SYSTEM$_$TOBJECT_$__$$_DISPATCH$formal at :0
#10 ?? at :0
#11 ?? at :0
```

**Debugger Output**
```
&"warning: i: 30 B=141B50000 S=4D7000 SA=00000000020D0000\n"
&"warning: i: 31 B=142027000 S=1F7000 SA=00000000025A7000\n"
&"warning: i: 32 B=14221E000 S=6000 SA=000000000279E000\n"
&"warning: i: 33 B=142224000 S=7000 SA=00000000027A4000\n"
&"warning: i: 34 B=14222B000 S=28000 SA=00000000027AB000\n"
&"warning: i: 35 B=142253000 S=BE000 SA=00000000027D3000\n"
&"warning: totalProcessMemorySize=2891000 (42536960)\n"
&"warning: Splitting up the workload between 1 threads\n"
&"warning: Blocksize = 2891000\n"
&"warning: Creating scanner 0\n"
&"warning: startregion = 0\n"
&"warning: stopregion = 35\n"
&"warning: startaddress = 13FA80000\n"
&"warning: stopaddress = 142311000\n"
&"warning: j = 36\n"
&"warning: leftfromprevious = 0\n"
&"warning: offsetincurrentregion = 0\n"
&"warning: maxregionsize = 80000\n"
=thread-created,id="19",group-id="i1"
~"[New Thread 12924.0x2c80]\n"
*running,thread-id="all"
&"warning: configurescanroutine\n"
&"warning: Config 1\n"
=thread-created,id="20",group-id="i1"
~"[New Thread 12924.0x2224]\n"
*running,thread-id="all"
&"warning: Config 2\n"
&"warning: Config 3\n"
&"warning: Config 3.1\n"
&"warning: scanOption=1\n"
&"warning: Config 6\n"
&"warning: configurescanroutine: Normal exit\n"
=thread-exited,id="19",group-id="i1"
&"warning: Scan ended\n"
&"warning: No exception on controller\n"
&"warning: ScanController: creating undo files\n"
&"warning: ScanController: Have set AddressFile.size to 359\n"
&"warning: ScanController: Have set MemoryFile.size to 0\n"
&"warning: It actually finished\n"
&"warning: ScanController: Destroying scanner threads\n"
&"warning: ScanController: Critical section \"scannersCS\" aquired\n"
*stopped,reason="signal-received",signal-name="SIGSEGV",signal-meaning="Segmentation fault",frame={addr="0x00000000008a4351",func="SETSTATE",args=[{name="this",value="0x0"},{name="ALISORD",value="3"},{name="AISSET",value="false"}],file="include/listitem.inc",fullname="C:/ShellEnv/j-tree/usr/sbin/develop/compilers/lazarus/dev/lazarus/lcl/include/listitem.inc",line="732"},thread-id="1",stopped-threads="all"
(gdb) 
<info program>
&"info program\n"
~"\tUsing the running image of child Thread 12924.0x26e0.\n"
~"Program stopped at 0x8a4351.\n"
~"It stopped with signal SIGSEGV, Segmentation fault.\n"
~"Type \"info stack\" or \"info registers\" for more information.\n"
^done
```
