### PR TITLE
VMCALL_GETPHYSICALADDRESSVM

### DIFF
--- a/dbvm/vmm/vmcall.c
+++ b/dbvm/vmm/vmcall.c
@@ -1686,7 +1686,12 @@ int _handleVMCallInstruction(pcpuinfo currentcpuinfo, VMRegisters *vmregisters, 
     	break;
     }
 #endif
-
+	case VMCALL_GETPHYSICALADDRESSVM:
+	{
+		int notpaged;
+		vmregisters->rax = getPhysicalAddressVM(currentcpuinfo, *(QWORD*)&vmcall_instruction[3], &notpaged);
+		break;
+	}
 
     default:
       vmregisters->rax = 0xcedead;

--- a/dbvm/vmm/vmcall.h
+++ b/dbvm/vmm/vmcall.h
@@ -83,7 +83,7 @@
 
 #define VMCALL_WATCH_EXECUTES 60
 
-
+#define VMCALL_GETPHYSICALADDRESSVM 1000
 
 
 extern int hasEPTsupport;

--- a/dbvm/vmm/vmeventhandler_amd.c
+++ b/dbvm/vmm/vmeventhandler_amd.c
@@ -493,6 +493,9 @@ int handleVMEvent_amd(pcpuinfo currentcpuinfo, VMRegisters *vmregisters)
 
         switch (vmregisters->rcx & 0xffffffff)
         {
+			case 0xC0010114: //VM_CR
+				value=(1<<3) | (1<<4); //set the Lock bit, set the SVME_DISABLE bit
+			  break;			
           case 0xc0000080://efer
             //update LMA
 

--- a/dbvm/vmm/vmxsetup.c
+++ b/dbvm/vmm/vmxsetup.c
@@ -152,6 +152,9 @@ void setupVMX_AMD(pcpuinfo currentcpuinfo)
     for (i=0; i<4096*2; i++)
       MSRBitmap[i]=0;
 
+	//protect 0xc0010114 (VM_CR)
+	MSRBitmap[0x1000+(0x0114*2)/8]|=3 << ((0x0114*2) % 8);
+	
     //Must protect 0xc0010117 (MSRPM_BASE_PA)
     MSRBitmap[0x1000+(0x0117*2)/8]|=3 << ((0x0117*2) % 8);
 


### PR DESCRIPTION
I want to get physical address only with dbvm without dbk kernel driver. 
Physical address is needed when I use ept memory cloaking.