### PR TITLE
SwitchToKernelMode CMEP, CMAP Problem

### DIFF
--- a/dbvm/vmm/vmcall.h
+++ b/dbvm/vmm/vmcall.h
@@ -83,7 +83,8 @@
 
 #define VMCALL_WATCH_EXECUTES 60
 
-
+#define VMCALL_KERNELMODE 100
+#define VMCALL_USERMODE 101
 
 
 extern int hasEPTsupport;

--- a/dbvm/vmm/vmmhelper.h
+++ b/dbvm/vmm/vmmhelper.h
@@ -600,6 +600,11 @@ typedef volatile struct tcpuinfo
   int eventcounter[56];
 #endif
 
+  struct {
+    UINT64 RFLAGS, CR4;
+    WORD CS, SS;
+  } SwitchKernel;
+
 } tcpuinfo, *pcpuinfo; //allocated when the number of cpu's is known
 
 typedef struct
@@ -679,6 +684,8 @@ typedef struct _regCR4
 #define CR4_FSGSBASE    (1<<16)
 #define CR4_PCIDE       (1<<17)
 #define CR4_OSXSAVE     (1<<18)
+#define CR4_SMEP		(1<<20)
+#define CR4_SMAP		(1<<21)
 
 #define CR0_PE          (1<<0)
 #define CR0_NE          (1<<5)


### PR DESCRIPTION
It's necessary to disable CMEP and CMAP bit in CR4 when enter kernel mode since windows 10. It's also necessary to restore CR4 when return to usermode because of patchguard.