### PR TITLE
Added memory search option to ceserver.

### DIFF
--- a/Cheat Engine/ceserver/api.c
+++ b/Cheat Engine/ceserver/api.c
@@ -2281,8 +2281,6 @@ int ReadProcessMemoryDebug(HANDLE hProcess, PProcessData p, void *lpAddress, voi
      // printf("After WaitForDebugEventNative (tid=%d)\n", event.threadid);
     }
 
-    //0=>/proc/pid/mem
-    //1=>ptrace_peekdata
     if(MEMORY_SEARCH_OPTION== 0)
     {
       

--- a/Cheat Engine/ceserver/api.h
+++ b/Cheat Engine/ceserver/api.h
@@ -219,4 +219,5 @@ void initAPI();
 
 extern pthread_mutex_t debugsocketmutex;
 
+#define MEMORY_SEARCH_OPTION 0
 #endif /* API_H_ */


### PR DESCRIPTION
Currently, ceserver opens /proc/pid/mem file when reading memory and reads it. 
This method of reading is fast, but malware may have file locks on /proc/pid/mem.
In other words, it has advantages but also disadvantages.
So I added an option to read memory with PTRACE_PEEKDATA only.