### PR TITLE
add build file for AndroidStudio

### DIFF
--- a/Cheat Engine/ceserver/AndroidStudio/Android.mk
+++ b/Cheat Engine/ceserver/AndroidStudio/Android.mk
@@ -1,0 +1,11 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CFLAGS += -fPIE
+LOCAL_LDFLAGS += -fPIE -pie
+LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
+LOCAL_MODULE    := ceserver
+LOCAL_SRC_FILES := api.c ceserver.c porthelp.c symbols.c threads.c context.c ceservertest.c extensionfunctions.c extensionloader.c
+LOCAL_LDLIBS := -lz
+
+include $(BUILD_EXECUTABLE)

--- a/Cheat Engine/ceserver/AndroidStudio/Application.mk
+++ b/Cheat Engine/ceserver/AndroidStudio/Application.mk
@@ -1,0 +1,3 @@
+APP_ABI :=  x86 armeabi-v7a arm64-v8a
+
+

--- a/Cheat Engine/ceserver/api.c
+++ b/Cheat Engine/ceserver/api.c
@@ -64,8 +64,9 @@
 
 
 #ifdef __arm__
-#include <linux/user.h>
-
+  #ifndef __ANDROID__
+    #include <linux/user.h>
+  #endif
 #endif
 
 //blatantly stolen from the kernel source


### PR DESCRIPTION
I added a build file for Android Studio.
Also with this fix, ndk-build is possible on AndroidStudio without errors.