### PR TITLE
Ceserver parse port from argv

### DIFF
--- a/Cheat Engine/ceserver/ceserver.c
+++ b/Cheat Engine/ceserver/ceserver.c
@@ -1189,8 +1189,6 @@ int main(int argc, char *argv[])
       {
         debug_log("TESTMODE\n");
         pthread_create(&pth, NULL, (void *)CESERVERTEST, argv);
-      }else if((strcmp(argv[1], "PORT")==0)){
-        
       }
     }
     #endif

--- a/Cheat Engine/ceserver/ceserver.c
+++ b/Cheat Engine/ceserver/ceserver.c
@@ -1130,7 +1130,6 @@ int main(int argc, char *argv[])
   #ifndef SHARED_LIBRARY
   if(argc >1 ){
     errno = 0;
-    char *g=NULL;
     int argv_port = strtol(argv[1],NULL , 10);
     if(errno != ERANGE && errno != EINVAL && argv_port != 0)
       PORT = argv_port;

--- a/Cheat Engine/ceserver/ceserver.c
+++ b/Cheat Engine/ceserver/ceserver.c
@@ -16,6 +16,10 @@
 #include <elf.h>
 #include <signal.h>
 #include <sys/prctl.h>
+
+#include <unistd.h>
+#include <errno.h>
+
 #include "ceserver.h"
 #include "porthelp.h"
 #include "api.h"
@@ -1123,6 +1127,20 @@ int main(int argc, char *argv[])
 
   PORT=52736;
 
+  #ifndef SHARED_LIBRARY
+  if(argc >1 ){
+    errno = 0;
+    char *g=NULL;
+    int argv_port = strtol(argv[1],NULL , 10);
+    if(errno != ERANGE && errno != EINVAL && argv_port != 0)
+      PORT = argv_port;
+    else
+      debug_log("cannot parse port from argument \"%s\". Usage: %s <port>",argv[1],argv[0]);
+  }
+  #endif
+
+  debug_log("listening on port %d\n",PORT);
+
   done=0;
 
   debug_log("&s=%p\n", &s);
@@ -1171,6 +1189,8 @@ int main(int argc, char *argv[])
       {
         debug_log("TESTMODE\n");
         pthread_create(&pth, NULL, (void *)CESERVERTEST, argv);
+      }else if((strcmp(argv[1], "PORT")==0)){
+        
       }
     }
     #endif


### PR DESCRIPTION
I use ceserver on linux to debug applications under wine.
I have to restart ceserver, if it does not response anymore.
Sometimes the port is still in use and I cannot restart ceserver it:

```bash
sudo ./ceserver 
&s=0x7ffe27e59644
main=0x558c653bb988
sizeof(off_t)=8
sizeof(off64_t)=8
CEServer. Waiting for client connection
IdentifierThread active
socket=3
bind failed
IdentifierThread exit
bind=-1
Terminate server
```

To fix this, one could set the hard coded `PORT` via command line arguments and choose multiple ports for multiple instances of ceserver:

```
sudo ./ceserver 1337
listening on port 1337
&s=0x7ffd71083618
main=0x55c46de0b9c8
sizeof(off_t)=8
sizeof(off64_t)=8
CEServer. Waiting for client connection
IdentifierThread active
socket=3
bind=0
listen=0
bind failed
IdentifierThread exit
```

There is already an argument check after the socket creation that I did not touch.