### PR TITLE
Fixed lua translation garbled

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -8342,7 +8342,7 @@ begin
         if (LRSTranslator is TPOTranslator) then
         begin
           pofile:=TPOTranslator(LRSTranslator).POFile;
-          pofile.ReadPOText(UTF8ToWinCP(postrings.text));
+          pofile.ReadPOText(postrings.text);
         end;
       end;
       lua_pushboolean(L, true);


### PR DESCRIPTION
Lua supports UTF8 by default.