### PR TITLE
ceserver add Execution options2

### DIFF
--- a/Cheat Engine/ceserver/api.c
+++ b/Cheat Engine/ceserver/api.c
@@ -137,6 +137,7 @@ typedef struct
 int VerboseLevel=0;
 
 int MEMORY_SEARCH_OPTION = 0;
+int ATTACH_PID = 0;
 
 //Implementation for shared library version ceserver.
 int debug_log(const char * format , ...)
@@ -3338,7 +3339,7 @@ HANDLE CreateToolhelp32Snapshot(DWORD dwFlags, DWORD th32ProcessID)
     return CreateHandleFromPointer(pl, htTHSProcess);
   }
   else
-  if (dwFlags & TH32CS_SNAPMODULE)
+  if ((dwFlags & TH32CS_SNAPMODULE) && (ATTACH_PID == 0 ||(ATTACH_PID != 0 && (th32ProcessID == ATTACH_PID))))
   {
     //make a list of all the modules loaded by processid th32ProcessID
     //the module list

--- a/Cheat Engine/ceserver/api.h
+++ b/Cheat Engine/ceserver/api.h
@@ -230,4 +230,5 @@ extern pthread_mutex_t debugsocketmutex;
 int debug_log(const char * format , ...); 
 long safe_ptrace(int request, pid_t pid, void * addr, void * data);
 extern int MEMORY_SEARCH_OPTION;
+extern int ATTACH_PID;
 #endif /* API_H_ */

--- a/Cheat Engine/ceserver/ceserver.c
+++ b/Cheat Engine/ceserver/ceserver.c
@@ -1134,13 +1134,20 @@ int main(int argc, char *argv[])
 
   opterr = 0;
 
+  int argv_attach_pid;
   int argv_search_option;
   int argv_port;
   int argv_pid;
-  while((opt = getopt(argc, argv, "m:p:t:")) != -1) 
+  while((opt = getopt(argc, argv, "a:m:p:t:")) != -1) 
   {
     switch(opt)
     {
+      case 'a':
+          errno = 0;
+          argv_attach_pid = strtol(optarg,NULL,10);
+          if(errno != ERANGE && errno != EINVAL)
+            ATTACH_PID = argv_attach_pid;
+          break;
       case 'm':
           errno = 0;
           argv_search_option = strtol(optarg,NULL,10);
@@ -1161,7 +1168,7 @@ int main(int argc, char *argv[])
             TEST_PID = argv_pid;
           break;
       default:
-          debug_log("Usage: %s [-m <search_option>] [-p <port>] [-t <pid>] arg1 ...\n", argv[0]);
+          debug_log("Usage: %s [-a <attach_pid>] [-m <search_option>] [-p <port>] [-t <pid>] arg1 ...\n", argv[0]);
           break;
     }
   }


### PR DESCRIPTION
Currently, CreateToolhelp32Snapshot lists all process modules.
Also, because OpenProcess is used during module enumeration, ceserver will stop depending on the target process.
Therefore, the execution option that enumerates only the specified process ID is added.

example:
sample_app:pid=5247
./ceserver -a 5247

ceserver enumerates only the modules with the corresponding process ID and skips all others.

 