### PR TITLE
Fix LuaCheckListBox addMetaData calling itself

### DIFF
--- a/Cheat Engine/LuaListbox.pas
+++ b/Cheat Engine/LuaListbox.pas
@@ -5,9 +5,10 @@ unit LuaListbox;
 interface
 
 uses
-  Classes, SysUtils,lua, lualib, lauxlib, stdctrls, controls;
+  Classes, SysUtils, lua, lualib, lauxlib, stdctrls, controls;
 
 procedure initializeLuaListbox;
+procedure listbox_addMetaData(L: PLua_state; metatable: integer; userdata: integer);
 
 implementation
 

--- a/Cheat Engine/luachecklistbox.pas
+++ b/Cheat Engine/luachecklistbox.pas
@@ -67,8 +67,7 @@ begin
   end;
 end;
 
-
-procedure listbox_addMetaData(L: PLua_state; metatable: integer; userdata: integer );
+procedure checklistbox_addMetaData(L: PLua_state; metatable: integer; userdata: integer );
 begin
   listbox_addMetaData(L, metatable, userdata);
   luaclass_addArrayPropertyToTable(L, metatable, userdata, 'Checked', checklistbox_getChecked, checklistbox_setChecked);
@@ -80,7 +79,7 @@ begin
 end;
 
 initialization
-  luaclass_register(TCustomCheckListBox, listbox_addMetaData);
+  luaclass_register(TCustomCheckListBox, checklistbox_addMetaData);
 
 end.
 


### PR DESCRIPTION
Manifested by Stack Overflow when placing CheckListBox on the form.

```
First log message: 24.8.2019
TAutoSizeCtrlData.FixControlProperties :TCECheckBox a=akTop old=:TEdit new=nil
TComponentTreeView.SetSelection: Updating component node values.
TComponentTreeView.SetSelection: Updating component node values.
Exception Stack overflow
  Stack trace:
  $0000000000771F58
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
  $0000000000771F5D
```