### PR TITLE
LuaSyntax - fix fStringLen calculation

### DIFF
--- a/Cheat Engine/LuaSyntax.pas
+++ b/Cheat Engine/LuaSyntax.pas
@@ -643,7 +643,7 @@ end;
 function TSynLuaSyn.KeyHash(ToHash: PChar): Integer;
 begin
   Result := 0;
-  while ToHash^ in ['.', '_', 'a'..'z', 'A'..'Z'] do
+  while ToHash^ in ['.', '_', 'a'..'z', 'A'..'Z', '0'..'9'] do
   begin
     inc(Result, mHashTable[ToHash^]);
     inc(ToHash);


### PR DESCRIPTION
LuaSyntax - fix fStringLen calculation for identifiers/keys with numbers.
![obraz](https://user-images.githubusercontent.com/9157726/67642952-86a17800-f911-11e9-89b3-29894f805d29.png)
