### PR TITLE
fix Error TControl.ChangeBounds loop detected

### DIFF
--- a/Cheat Engine/MainUnit.pas
+++ b/Cheat Engine/MainUnit.pas
@@ -2827,10 +2827,14 @@ begin
       cbsaferPhysicalMemory:=tcheckbox.create(self);
       cbsaferPhysicalMemory.Caption:=strSaferPhysicalMemory;
       cbsaferPhysicalMemory.Checked:=dbk32functions.saferQueryPhysicalMemory;
-      cbsaferPhysicalMemory.Parent:=cbPauseWhileScanning.Parent;
-      cbsaferPhysicalMemory.left:=cbPauseWhileScanning.left;
-      cbsaferPhysicalMemory.Top:=cbPauseWhileScanning.top;
+      cbsaferPhysicalMemory.AnchorSame(akTop,cbPauseWhileScanning);                    // trick with AnchorSame
+      cbsaferPhysicalMemory.AnchorSame(akLeft,cbPauseWhileScanning);
+      cbsaferPhysicalMemory.AnchorSame(akRight,cbPauseWhileScanning);
+      cbsaferPhysicalMemory.AnchorSame(akBottom,cbPauseWhileScanning);
+      cbsaferPhysicalMemory.BorderSpacing.Assign(cbPauseWhileScanning.BorderSpacing);  // clone spacing
       cbsaferPhysicalMemory.OnChange:=cbSaferPhysicalMemoryChange;
+      cbsaferPhysicalMemory.Parent:=cbPauseWhileScanning.Parent;
+      cbsaferPhysicalMemory.Name:='cbsaferPhysicalMemory';
     end;
   end
   else


### PR DESCRIPTION
Change cbsaferPhysicalMemory anchoring and spacing.

I couldn't reproduce it myself. Someone else has this issue and tested the fix:

>> mgr.inz.Player wrote:
>> just to be perfectly sure:
>> SHA1 8174718998EDFDC2960D5034B1E5DCEF8745BB77 cheatengine-i386.exe doesn't have ChangeBounds error?

> Yes. It doesn't have ChangeBounds error.
> https://funkyimg.com/i/2YDhb.jpg

>> mgr.inz.Player wrote:
>> SHA1 16EB45B92DB6DEBE9E557005C3177F2644B139B7 cheatengine-i386.exe still has this error?

> https://funkyimg.com/i/2YDha.jpg
> Yes. It still has this error https://funkyimg.com/i/2YDhc.jpg
> After ChangeBounds error, CE 7.0 looks like this: https://funkyimg.com/i/2YDhd.jpg
> Address list is not visible, even after restarting the CE.
> Also, same view becomes in versions 6.7 and 6.8.3.
> Such a change in the GUI does not happen if the error appears in versions 6.7 and 6.8.3.