### PR TITLE
Fix typo in memory region merging

### DIFF
--- a/Cheat Engine/memscan.pas
+++ b/Cheat Engine/memscan.pas
@@ -6361,7 +6361,7 @@ begin
         if memRegionPos>0 then
         begin
           //check if it can be appended to the previous region
-          if memRegion[memRegionPos-1].BaseAddress+memRegion[memRegionPos].MemorySize=PtrUint(mbi.baseaddress) then //yes, append
+          if memRegion[memRegionPos-1].BaseAddress+memRegion[memRegionPos-1].MemorySize=PtrUint(mbi.baseaddress) then //yes, append
           begin
             //yes, so append
             memRegion[memRegionPos-1].MemorySize:=memRegion[memRegionPos-1].MemorySize+mbi.RegionSize;


### PR DESCRIPTION
I think it’s a typo. You are trying to access a `memRegion` item that was not yet created. It does not fail because you are always preallocating `memRegion` but, it seems, it never worked as planned.