### PR TITLE
fix binutils Hide command prompt.

### DIFF
--- a/Cheat Engine/binutils.pas
+++ b/Cheat Engine/binutils.pas
@@ -344,12 +344,8 @@ begin
       setlength(params, p.parameters.Count);
       for i:=0 to p.parameters.count-1 do
         params[i]:=p.Parameters[i];
-
-      {$IF (FPC_FULLVERSION<0304000)}
-      if RunCommand(p.Executable, params, os) then
-      {$else}
+        
       if RunCommand(p.Executable, params, os,[poNoConsole]) then
-      {$endif}
       begin
         output:=TStringStream.create('');
         output.WriteString(os);


### PR DESCRIPTION
The currently distributed Cheat Engine displays a command prompt when disassembling with binutils.
The FPC_FULLVERSION macro may not be functioning properly.
Therefore, the corresponding part was deleted.
This will not display the command prompt.