### PR TITLE
Adding structure type to address list

### DIFF
--- a/Cheat Engine/CEFuncProc.pas
+++ b/Cheat Engine/CEFuncProc.pas
@@ -3036,6 +3036,7 @@ begin
   if s='custom' then  Result :=vtCustom else
   if s='grouped' then result:=vtGrouped else
   if s='auto assembler script' then result:=vtAutoAssembler;
+  if s='structure' then result:=vtStructure;
 end;
 
 

--- a/Cheat Engine/CEFuncProc.pas
+++ b/Cheat Engine/CEFuncProc.pas
@@ -2985,6 +2985,7 @@ begin
     vtPointer: result:=rs_vtPointer;
     vtAutoAssembler: Result:=rs_vtAutoAssembler;
     vtCustom: Result:=rs_vtCustom;
+    vtStructure: Result:=rs_vtStructure;
     else
      result:='Error';
   end;
@@ -3008,6 +3009,7 @@ begin
     vtPointer: result:='Pointer';
     vtAutoAssembler: Result:='Auto Assembler Script';
     vtCustom: Result:='Custom';
+    vtStructure: Result:='Structure';
     else
      result:='Error';
   end;

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -986,7 +986,31 @@ begin
     end
     else
     begin
-      childRecord.VarType := element.VarType;
+      case element.VarType of
+        vtUnicodeString:
+        begin
+          childRecord.VarType := vtString;
+          childRecord.Extra.stringData.length := Trunc(element.Bytesize / 2);
+          childRecord.Extra.stringData.unicode := true;
+        end;
+        vtString:
+        begin
+          childRecord.VarType := vtString;
+          childRecord.Extra.stringData.length := element.Bytesize;
+        end;
+        vtByteArray:
+        begin
+          childRecord.VarType := vtByteArray;
+          childRecord.Extra.byteData.bytelength := element.Bytesize;
+        end;
+        vtCustom:
+        begin
+          childRecord.VarType := vtCustom;
+          childRecord.CustomTypeName := element.CustomType.name;
+        end;
+        else
+          childRecord.VarType := element.VarType;
+      end;
     end;
   end;
   SetVisibleChildrenState;

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -189,6 +189,7 @@ type
 
 
     fDontSave: boolean;
+    fReadonly: boolean;
 
     fAsync: boolean;
     processingThread: TMemoryRecordProcessingThread; //not nil when doing work
@@ -369,6 +370,8 @@ type
     property Value: string read GetValue write SetValue;
     property DisplayValue: string read GetDisplayValue;
     property DontSave: boolean read fDontSave write fDontSave;
+    property IsReadonly : boolean read fReadonly;
+    
     property AllowDecrease: boolean read fallowDecrease write setAllowDecrease;
     property AllowIncrease: boolean read fallowIncrease write setAllowIncrease;
     property ShowAsHex: boolean read fShowAsHex write setShowAsHex;
@@ -930,6 +933,7 @@ begin
       childRecord:=TMemoryRecord.create(fOwner);
 
     childRecord.DontSave := true;
+    childRecord.fReadonly := true;
     childRecord.Description := element.Name;
     childRecord.interpretableaddress := '+'+IntToHex(element.Offset, 8);
     childRecord.VarType := element.VarType;

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -1234,6 +1234,7 @@ var
 
   hk: TMemoryRecordHotkey;
   memrec: TMemoryRecord;
+  struct: TDissectedStruct;
   a:TDOMNode;
 begin
   {$IFNDEF UNIX}
@@ -1448,6 +1449,16 @@ begin
 
           a:=tempnode.Attributes.GetNamedItem('Async');
           if (a<>nil) then fAsync:=a.TextContent='1';
+        end;
+      end;
+      vtStructure:
+      begin
+        tempnode:=CheatEntry.FindNode('Structure');
+        if tempnode<>nil then
+        begin
+          for struct in DissectedStructs do
+            if struct.GetName() = tempnode.TextContent then
+              extra.structureData.Struct:=struct;
         end;
       end;
 
@@ -1868,6 +1879,11 @@ begin
         end;
 
         n.TextContent:=AutoAssemblerData.script.Text;
+      end;
+      vtStructure:
+      begin
+        if(extra.structureData.Struct<>nil) then
+          cheatEntry.AppendChild(doc.CreateElement('Structure')).TextContent:=extra.structureData.Struct.GetName();
       end;
     end;
 

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -8,7 +8,7 @@ interface
 uses
   Windows, forms, graphics, Classes, SysUtils, controls, stdctrls, comctrls,symbolhandler,
   cefuncproc,newkernelhandler, hotkeyhandler, dom, XMLRead,XMLWrite,
-  customtypehandler, fileutil, LCLProc, commonTypeDefs, pointerparser, LazUTF8, LuaClass;
+  customtypehandler, fileutil, LCLProc, commonTypeDefs, pointerparser, LazUTF8, LuaClass, StructuresFrm2;
 {$endif}
 
 {$ifdef unix}
@@ -57,6 +57,10 @@ type TMemRecByteData=record
       bytelength: integer;
     end;
 
+type TMemRecStructureData=record
+    Struct : TDissectedStruct;
+  end;
+
 type TMemRecAutoAssemblerData=record
       script: tstringlist;
       allocs: TCEAllocArray;
@@ -71,6 +75,7 @@ type TMemRecExtraData=record
       1: (stringData: TMemrecStringData); //if this is the last level (maxlevel) this is an PPointerList
       2: (bitData: TMemRecBitData);   //else it's a PReversePointerListArray
       3: (byteData: TMemRecByteData);
+      4: (structureData: TMemRecStructureData);
   end;
 
 

--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -970,13 +970,24 @@ begin
     childRecord.fReadonly := true;
     childRecord.Description := element.Name;
     childRecord.interpretableaddress := '+'+IntToHex(element.Offset, 8);
-    childRecord.VarType := element.VarType;
     childRecord.ReinterpretAddress(true);
+
     if(treenode.IndexOf(childRecord.treenode) = -1) then
-      begin
-          childRecord.treenode:=treenode.owner.AddObject(nil,'',childRecord);
-          childRecord.treenode.MoveTo(treenode, naAddChild); //make it the last child of this node
-      end;
+    begin
+        childRecord.treenode:=treenode.owner.AddObject(nil,'',childRecord);
+        childRecord.treenode.MoveTo(treenode, naAddChild); //make it the last child of this node
+    end;
+
+    if element.isPointer then
+    begin
+      childRecord.offsetCount:=1;
+      childRecord.offsets[0].setOffsetText(IntToStr(element.getOffset));
+      childRecord.SetStructure(element.ChildStruct);
+    end
+    else
+    begin
+      childRecord.VarType := element.VarType;
+    end;
   end;
   SetVisibleChildrenState;
   structure.addOnStructureChangeEventHandler(self);

--- a/Cheat Engine/OpenSave.pas
+++ b/Cheat Engine/OpenSave.pas
@@ -420,6 +420,29 @@ begin
     if mainform.miResyncFormsWithLua<>nil then
       mainform.miResyncFormsWithLua.click;
 
+    if Structures<>nil then
+    begin
+      svstring:=TDOMElement(structures).GetAttribute('StructVersion');
+      if svstring='' then
+        sv:=1
+      else
+        sv:=StrToInt(svstring);
+
+      for i:=0 to Structures.ChildNodes.Count-1 do
+      begin
+        Structure:=Structures.ChildNodes[i];
+        if sv>=2 then
+          tempstruct:=TDissectedStruct.createFromXMLNode(structure)
+        else  //v1 structure(pre 6.2). Needs conversion
+          tempstruct:=TDissectedStruct.createFromOutdatedXMLNode(structure);
+
+        tempstruct.addToGlobalStructList;
+      end;
+
+      //fill in the structure references
+      for i:=0 to DissectedStructs.count-1 do
+        TDissectedStruct(DissectedStructs[i]).fillDelayLoadedChildstructs;
+    end;
 
     if entries<>nil then
       mainform.addresslist.loadTableXMLFromNode(entries);
@@ -597,32 +620,6 @@ begin
     end
     else
       setlength(definedstructures,0);  }
-
-    if Structures<>nil then
-    begin
-      svstring:=TDOMElement(structures).GetAttribute('StructVersion');
-      if svstring='' then
-        sv:=1
-      else
-        sv:=StrToInt(svstring);
-
-
-      for i:=0 to Structures.ChildNodes.Count-1 do
-      begin
-        Structure:=Structures.ChildNodes[i];
-        if sv>=2 then
-          tempstruct:=TDissectedStruct.createFromXMLNode(structure)
-        else  //v1 structure(pre 6.2). Needs conversion
-          tempstruct:=TDissectedStruct.createFromOutdatedXMLNode(structure);
-
-        tempstruct.addToGlobalStructList;
-      end;
-
-
-      //fill in the structure references
-      for i:=0 to DissectedStructs.count-1 do
-        TDissectedStruct(DissectedStructs[i]).fillDelayLoadedChildstructs;
-    end;
 
 
 

--- a/Cheat Engine/StructuresFrm2.pas
+++ b/Cheat Engine/StructuresFrm2.pas
@@ -142,6 +142,8 @@ type
     procedure setName(newname: string);
     function getElementCount: integer;
     function getElement(index: integer): TStructelement;
+
+    function getElements: TList;
     procedure fillDelayLoadedChildstructs;
 
     procedure beginUpdate;
@@ -1211,6 +1213,11 @@ begin
     result:=TStructelement(structelementlist.Items[index])
   else
     result:=nil;
+end;
+
+function TDissectedStruct.getElements: TList;
+begin
+  result := structelementlist;
 end;
 
 function TDissectedStruct.isUpdating: boolean;

--- a/Cheat Engine/TypePopup.lfm
+++ b/Cheat Engine/TypePopup.lfm
@@ -131,6 +131,58 @@ object TypeForm: TTypeForm
     ClientHeight = 76
     ClientWidth = 241
     TabOrder = 1
+    object StructurePanel: TPanel
+      AnchorSideLeft.Control = Panel3
+      AnchorSideTop.Control = Panel3
+      Left = 0
+      Height = 38
+      Top = 0
+      Width = 220
+      AutoSize = True
+      BevelOuter = bvNone
+      ClientHeight = 38
+      ClientWidth = 220
+      TabOrder = 2
+      object StructureLabel: TLabel
+        AnchorSideLeft.Control = StructurePanel
+        AnchorSideTop.Control = StructurePanel
+        Left = 10
+        Height = 15
+        Top = 0
+        Width = 48
+        BorderSpacing.Left = 10
+        Caption = 'Structure'
+        ParentColor = False
+      end
+      object StructureType: TComboBox
+        AnchorSideLeft.Control = StructurePanel
+        AnchorSideTop.Control = StructureLabel
+        AnchorSideTop.Side = asrBottom
+        Left = 10
+        Height = 23
+        Top = 15
+        Width = 200
+        BorderSpacing.Left = 10
+        BorderSpacing.Right = 10
+        Constraints.MinWidth = 200
+        DropDownCount = 9
+        ItemHeight = 15
+        Items.Strings = (
+          'Binary'
+          'Byte'
+          '2 Bytes'
+          '4 Bytes'
+          '8 Bytes'
+          'Float'
+          'Double'
+          'Text'
+          'Array of Bytes'
+        )
+        OnChange = VarTypeChange
+        Style = csDropDownList
+        TabOrder = 0
+      end
+    end
     object lengthlabel: TLabel
       AnchorSideLeft.Control = Panel3
       AnchorSideTop.Control = Panel3

--- a/Cheat Engine/TypePopup.pas
+++ b/Cheat Engine/TypePopup.pas
@@ -215,6 +215,7 @@ begin
     6: MemoryRecord.VarType:=vtDouble;
     7: MemoryRecord.Vartype:=vtString;
     8: MemoryRecord.VarType:=vtByteArray;
+    9: MemoryRecord.VarType:=vtStructure;
     else
     begin
       if Vartype.ItemIndex<>-1 then

--- a/Cheat Engine/TypePopup.pas
+++ b/Cheat Engine/TypePopup.pas
@@ -277,7 +277,7 @@ begin
   if memoryrecord.vartype=vtStructure then
   begin
       struct := TDissectedStruct(StructureType.Items.Objects[StructureType.ItemIndex]);
-      MemoryRecord.Extra.structureData.Struct:=struct;
+      MemoryRecord.SetStructure(struct);
   end;
 
   modalresult:=mryes;

--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -921,6 +921,7 @@ var i: integer;
 begin
   if assigned(fOnDescriptionChange) and fOnDescriptionChange(self,tmemoryrecord(node.data)) then exit;
 
+  if TMemoryRecord(node.data).IsReadonly then exit;
 
   description:=tmemoryrecord(node.data).description;
 
@@ -947,7 +948,7 @@ procedure TAddresslist.addressdblclick(node: TTreenode);
 begin
   if assigned(fOnAddressChange) and fOnAddressChange(self,tmemoryrecord(treeview.selected.Data)) then exit;
 
-  if TMemoryRecord(node.data).isGroupHeader then exit;
+  if TMemoryRecord(node.data).isGroupHeader or TMemoryRecord(node.data).IsReadonly then exit;
 
   with TFormaddresschange.Create(self) do
   begin
@@ -973,6 +974,7 @@ begin
   TypeForm.RefreshCustomTypes;
   memrec:=TMemoryRecord(node.data);
 
+  if memrec.IsReadonly then exit;
   if assigned(fOnTypeChange) and fOnTypeChange(self,memrec) then exit;
 
 

--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -1047,10 +1047,14 @@ begin
 
       if memrecitems[i].vartype<>newtype then
         MainForm.editedsincelastsave:=true;
-
-      MemRecItems[i].VarType:=newtype;
-      MemRecItems[i].Extra:=extra;
-      MemRecItems[i].CustomTypeName:=customtypename;
+      if newtype = vtStructure then
+        MemRecItems[i].SetStructure(extra.structureData.Struct)
+      else
+      begin
+        MemRecItems[i].VarType:=newtype;
+        MemRecItems[i].Extra:=extra;
+        MemRecItems[i].CustomTypeName:=customtypename;
+      end;
 
       MemRecItems[i].treenode.update;
     end;

--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -1021,6 +1021,13 @@ begin
       Typeform.cbunicode.visible:=false;
       Typeform.cbCodePage.visible:=false;
     end;
+    vtStructure:
+    begin
+      TypeForm.SetStructureType(memrec.Extra.structureData.Struct);
+      TypeForm.VarType.itemindex:=9;
+      Typeform.cbunicode.visible:=false;
+      Typeform.cbCodePage.visible:=false;
+    end;
   end;
 
   typeform.MemoryRecord:=memrec;
@@ -2098,7 +2105,14 @@ begin
               sender.Canvas.TextRect(rect(header.Sections[3].left, textrect.Top, header.Sections[3].right, textrect.bottom),header.sections[3].left, linetop, VariableTypeToTranslatedString(memrec.VarType)+':'+inttostr(memrec.Extra.bitData.Bit)+'->idiot')
             else
               sender.Canvas.TextRect(rect(header.Sections[3].left, textrect.Top, header.Sections[3].right, textrect.bottom),header.sections[3].left, linetop, VariableTypeToTranslatedString(memrec.VarType)+':'+inttostr(memrec.Extra.bitData.Bit)+'->'+inttostr(memrec.Extra.bitData.Bit+memrec.Extra.bitData.bitlength-1));
-          end
+          end;
+          vtStructure:
+          begin
+            if(memrec.Extra.structureData.Struct<>nil) then
+              sender.Canvas.TextRect(rect(header.Sections[3].left, textrect.Top, header.Sections[3].right, textrect.bottom),header.sections[3].left, linetop, memrec.Extra.structureData.Struct.GetName())
+            else
+              sender.Canvas.TextRect(rect(header.Sections[3].left, textrect.Top, header.Sections[3].right, textrect.bottom),header.sections[3].left, linetop, 'Unknown');
+          end;
           else
           begin
 

--- a/Cheat Engine/commontypedefs.pas
+++ b/Cheat Engine/commontypedefs.pas
@@ -12,7 +12,7 @@ uses
 type TScanOption=(soUnknownValue=0,soExactValue=1,soValueBetween=2,soBiggerThan=3,soSmallerThan=4, soIncreasedValue=5, soIncreasedValueBy=6, soDecreasedValue=7, soDecreasedValueBy=8, soChanged=9, soUnchanged=10, soForgot=11, soCustom);
 type TScanType=(stNewScan=0, stFirstScan=1, stNextScan=2);
 type TRoundingType=(rtRounded=0,rtExtremerounded=1,rtTruncated=2);
-type TVariableType=(vtByte=0, vtWord=1, vtDword=2, vtQword=3, vtSingle=4, vtDouble=5, vtString=6, vtUnicodeString=7, vtByteArray=8, vtBinary=9, vtAll=10, vtAutoAssembler=11, vtPointer=12, vtCustom=13, vtGrouped=14, vtByteArrays=15, vtCodePageString=16); //all ,grouped and MultiByteArray are special types
+type TVariableType=(vtByte=0, vtWord=1, vtDword=2, vtQword=3, vtSingle=4, vtDouble=5, vtString=6, vtUnicodeString=7, vtByteArray=8, vtBinary=9, vtAll=10, vtAutoAssembler=11, vtPointer=12, vtCustom=13, vtGrouped=14, vtByteArrays=15, vtCodePageString=16, vtStructure=17); //all ,grouped and MultiByteArray are special types
 type TCustomScanType=(cstNone, cstAutoAssembler, cstCPP, cstDLLFunction);
 type TFastScanMethod=(fsmNotAligned=0, fsmAligned=1, fsmLastDigits=2);
 

--- a/Cheat Engine/formAddressChangeUnit.lfm
+++ b/Cheat Engine/formAddressChangeUnit.lfm
@@ -122,14 +122,18 @@ object formAddressChange: TformAddressChange
     AnchorSideLeft.Control = Label1
     AnchorSideTop.Control = cbvarType
     AnchorSideTop.Side = asrBottom
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
     Left = 8
     Height = 87
     Top = 118
-    Width = 190
+    Width = 185
+    Anchors = [akTop, akLeft, akRight]
     AutoSize = True
+    BorderSpacing.Right = 8
     BevelOuter = bvNone
     ClientHeight = 87
-    ClientWidth = 190
+    ClientWidth = 185
     TabOrder = 3
     Visible = False
     object cbunicode: TCheckBox
@@ -162,6 +166,50 @@ object formAddressChange: TformAddressChange
       Width = 37
       Caption = 'Length'
       ParentColor = False
+    end
+    object pnlStructure: TPanel
+      AnchorSideLeft.Control = pnlExtra
+      AnchorSideTop.Control = edtSize
+      AnchorSideTop.Side = asrBottom
+      AnchorSideRight.Control = pnlExtra
+      AnchorSideRight.Side = asrBottom
+      Left = 0
+      Height = 23
+      Top = 46
+      Width = 185
+      Anchors = [akTop, akLeft, akRight]
+      AutoSize = True
+      BorderSpacing.Top = 8
+      BevelOuter = bvNone
+      ClientHeight = 23
+      ClientWidth = 185
+      TabOrder = 0
+      object lblStructure: TLabel
+        AnchorSideLeft.Control = pnlStructure
+        AnchorSideTop.Control = pnlStructure
+        Left = 10
+        Height = 15
+        Top = 0
+        Width = 48
+        BorderSpacing.Left = 10
+        Caption = 'Structure'
+        ParentColor = False
+      end
+      object cbStructure: TComboBox
+        AnchorSideLeft.Control = pnlStructure
+        AnchorSideTop.Control = pnlStructure
+        AnchorSideRight.Control = pnlStructure
+        AnchorSideRight.Side = asrBottom
+        Left = 0
+        Height = 23
+        Top = 0
+        Width = 185
+        Anchors = [akTop, akLeft, akRight]
+        DropDownCount = 9
+        ItemHeight = 15
+        Style = csDropDownList
+        TabOrder = 0
+      end
     end
     object pnlBitinfo: TPanel
       AnchorSideLeft.Control = pnlExtra

--- a/Cheat Engine/formAddressChangeUnit.pas
+++ b/Cheat Engine/formAddressChangeUnit.pas
@@ -1156,6 +1156,7 @@ begin
   Double
   Text
   Array of Bytes
+  Structure
   <custom types>
   }
   i:=cbvarType.ItemIndex;
@@ -1470,10 +1471,6 @@ begin
   cbvarType.items.add(rs_vtString);
   cbvarType.items.add(rs_vtByteArray);
 
-
-  for i:=0 to customTypes.Count-1 do
-    cbvarType.Items.AddObject(TCustomType(customtypes[i]).name, customtypes[i]);
-
   // Refresh structures as well
   cbStructure.Items.Clear;
   if DissectedStructs.Count > 0 then
@@ -1484,6 +1481,9 @@ begin
       cbStructure.ItemIndex := 0;
     cbvarType.Items.Add(rs_vtStructure);
   end;
+
+  for i:=0 to customTypes.Count-1 do
+    cbvarType.Items.AddObject(TCustomType(customtypes[i]).name, customtypes[i]);
 
   cbvarType.DropDownCount:=cbvarType.Items.Count;
 end;

--- a/Cheat Engine/formAddressChangeUnit.pas
+++ b/Cheat Engine/formAddressChangeUnit.pas
@@ -1418,7 +1418,7 @@ begin
     vtCustom:
       memoryrecord.CustomTypeName:=cbvarType.Caption;
     vtStructure:
-      memoryrecord.Extra.structureData.Struct:=TDissectedStruct(cbStructure.Items.Objects[cbStructure.ItemIndex]);
+      memoryrecord.SetStructure(TDissectedStruct(cbStructure.Items.Objects[cbStructure.ItemIndex]));
   end;
 
   memoryrecord.Description:=description;

--- a/Cheat Engine/vartypestrings.pas
+++ b/Cheat Engine/vartypestrings.pas
@@ -29,6 +29,7 @@ resourcestring
   rs_vtAutoAssembler='Auto Assembler Script';
   rs_vtCustom='Custom';
   rs_vtGrouped='Grouped';
+  rs_vtStructure='Structure';
 
 const
   eng_vtAll='All';


### PR DESCRIPTION
I have used Cheat-engine a few times where I ran into the case where I had multiple elements with the same structure that I wanted to add to the Address list. I have in the past wondered why it was not possible to reuse the structs defined in the Structure dissect view in the address list so that any subsequent updates would be reflected across all records with the given type. I am not sure if I am using it wrong or there is some other way you are supposed to handle this (I am not a fan of using the Structure dissect view directly), but I decided giving implementing it a go. I have tried not to be too invasive, but I can understand if you are apprehensive about a change this size, and maybe the functionality in this form is not desired.

This pull request is not ready to be merged, as there is still some work to be done. However I don't feel like putting in a lot more time if it is of no interest and will never be merged as it does what I need it to at this point.

Features (+ examples from Trails of Cold Steel):
- Added Structure type to type selectors:
  - It will be available both in the type selector form and the add/change address form. 
  - It will only be available if any types are defined in the Structure dissect. So users not using that functionality should not be affected.
  - It is retrieved when the dialog opens so adding and removing types is reflected correctly. 
![image](https://user-images.githubusercontent.com/4503036/69900028-d9d27480-136e-11ea-8338-a866c445120b.png)
![image](https://user-images.githubusercontent.com/4503036/69900036-fec6e780-136e-11ea-99ee-f805ed259e2d.png)

- Updated TMemoryRecord to handle new StructureType. When it has the structure type: 
  - It will display the name of the type in the Type column.
  - It will load the elements of the structure and add them as child records with correct type and offset.
  - Description, Address and Type on these child records will be read-only. (I added a fReadOnly field on TMemoryRecord so I imagine records created by scripts would be able to use this functionality as well)
  - It will be saved and reloaded from xml correctly
  - It will automatically be updated when the structure or any of its elements are changed. 
![image](https://user-images.githubusercontent.com/4503036/69900044-27e77800-136f-11ea-86b9-69154df6e724.png)

Concerns:
- When saved to a file the name of the structure is used as the identifier as it was the best thing I had. This should be fine though unless people are manipulating the xml on the side (at which point it will just show up as Unknown in the address list)
- The type form in Structure dissect doesn't match the ones on the address list which means there is nowhere to get values to fill the extra fields on TMemoryRecord. As they are not used in Structure dissect I think the goal should just be to make these work the same, but I could use a hand choosing sensible defaults.
- I am using an interface for TMemoryRecord but had to disable reference counting as there are still plenty of references to the instance itself. As such the functionality should work as before (and it should still be freed in the same places as before). I did most of my testing without the assigned checks on update in TDissectedStructs to make sure it handles it correctly, but added them afterwards for robustness. I would rather the record doesn't update correctly than the program crashing.
- Changing the order of elements in a Structure might have odd consequences. I reuse the child records as far as possible to avoid removing freezes added to them, but I do this by index so that also means that the freeze might suddenly be placed on the wrong record.

TODO:
- Protect records with structure type from:
  - Add
  - Copy/Cut + paste 
  - Delete
  - Drag and Drop
- Making sure unix build still works. (Maybe without the the new type, it looks like a lot of the tree stuff is not enabled there, or it just works very differently, input would be welcome)