### PR TITLE
search for first ancestor with valid interpretableaddress

### DIFF
--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -3288,9 +3288,18 @@ begin
 end;
 
 function TMemoryRecord.getBaseAddress: ptrUint;
+var parentMR: TMemoryRecord;
 begin
   if fIsOffset and hasParent then
-    result:=parent.RealAddress+baseaddress //assuming that the parent has had it's real address calculated first
+  begin
+    parentMR:=parent;
+    while ((parentMR.interpretableaddress='') or (parentMR.interpretableaddress='0')) and parentMR.hasParent do parentMR:=parentMR.parent; // find first ancestor with interpretableaddress
+
+    if not ((parentMR.interpretableaddress='') or (parentMR.interpretableaddress='0')) then
+      result:=parentMR.RealAddress+baseaddress //assuming that the ancestor has had it's real address calculated first
+    else
+      result:=BaseAddress;
+  end
   else
     result:=BaseAddress;
 end;


### PR DESCRIPTION
MemRec IsOffset=true (those with address starting with + sign).

Those will search for first ancestor with valid interpretableaddress, to get its RealAddress.
This PR will allow to use "Group memrec" and "AutoAssemble memrec" as parent.

![obraz](https://user-images.githubusercontent.com/9157726/71480791-42d8cb00-27fb-11ea-90cf-1989b7153d0b.png)