### PR TITLE
fix executeCodeLocalEx (64bit)

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -9726,19 +9726,19 @@ begin
         end;
 
         case valuetype of
-          0: pqword(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tointeger(L,i);
-          1: psingle(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tonumber(L,i);
-          2: pdouble(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tonumber(L,i);
+          0: pqword(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tointeger(L,-1);
+          1: psingle(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tonumber(L,-1);
+          2: pdouble(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=lua_tonumber(L,-1);
           3:
           begin
-            ts[i-2]:=Lua_ToString(L,i);
+            ts[i-2]:=Lua_ToString(L,-1);
             pqword(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=ptruint(pchar(ts[i-2]));
             valuetype:=0;
           end;
 
           4:
           begin
-            tws[i-2]:=Lua_ToString(L,i);
+            tws[i-2]:=Lua_ToString(L,-1);
             pqword(ptruint(paramstart)+(i-2)*sizeof(pointer))^:=ptruint(pwidechar(tws[i-2]));
             valuetype:=0;
           end;


### PR DESCRIPTION
This should spawn 5 console windows. Current revision doesn't do that. Here's the fix.
```Lua
local str = "/c echo testing & pause"

executeCodeLocalEx('ShellExecuteW', 0, {4,'open'}, {4,'cmd.exe'}, {4,str}, 0, 1)
executeCodeLocalEx('ShellExecuteA', 0, {3,'open'}, {3,'cmd.exe'}, {3,str}, 0, 1)
executeCodeLocalEx('ShellExecuteW', 0, {type=4,value='open'}, {type=4,value='cmd.exe'}, {type=4,value=str}, 0, 1)
executeCodeLocalEx('ShellExecuteA', 0, {type=3,value='open'}, {type=3,value='cmd.exe'}, {type=3,value=str}, 0, 1)
executeCodeLocalEx('ShellExecuteA', 0, 'open', 'cmd.exe', str, 0, 1)
```

Fixes this one too: #1048