### PR TITLE
Correction for rendering bug.Arm disassembly issue on ceserver.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Cheat Engine/ceserver/front-ceserver"]
-	path = Cheat Engine/ceserver/front-ceserver
-	url = https://github.com/KenjiroIchise/front-ceserver.git

--- a/Cheat Engine/disassemblerviewlinesunit.pas
+++ b/Cheat Engine/disassemblerviewlinesunit.pas
@@ -387,6 +387,13 @@ begin
   bytestring:=visibleDisassembler.getLastBytestring;
   opcodestring:=visibleDisassembler.LastDisassembleData.prefix+visibleDisassembler.LastDisassembleData.opcode;
 
+  //Correction for rendering bug.
+  if processhandler.isNetwork and processhandler.SystemArchitecture=archarm then
+  begin
+    bytestring+=' ';
+    opcodestring+=' ';
+  end;      
+
   parameterstring:=visibleDisassembler.LastDisassembleData.parameters+' ';
   specialstring:=visibleDisassembler.DecodeLastParametersToString;
 


### PR DESCRIPTION
When connecting in network mode, the opcode when disassembling the arm architecture was displayed one character less.
Although not essential, this problem has been fixed with single character increment support.

As another fix, I removed the submodule.