### PR TITLE
LuaSyntax - fix fStringLen calculation

### DIFF
--- a/Cheat Engine/LuaSyntax.pas
+++ b/Cheat Engine/LuaSyntax.pas
@@ -645,6 +645,7 @@ begin
   Result := 0;
   while ToHash^ in ['.', '_', 'a'..'z', 'A'..'Z', '0'..'9'] do
   begin
+    if (ToHash^='.') and ((ToHash+1)^='.') then break;
     inc(Result, mHashTable[ToHash^]);
     inc(ToHash);
   end;


### PR DESCRIPTION
Similar to #955.

before and after patch:
![obraz](https://user-images.githubusercontent.com/9157726/72669533-151a2700-3a33-11ea-8fbf-45741e891f7c.png)
