### PR TITLE
add shallow to getAddressSafe Lua function

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -4014,7 +4014,7 @@ function getAddressSafe(L: PLua_state): integer; cdecl;
 var parameters: integer;
   s: string;
 
-  local: boolean;
+  local,shallow,e: boolean;
 
 begin
   result:=0;
@@ -4034,14 +4034,18 @@ begin
     else
       local:=false;
 
+    if parameters>=3 then
+      shallow:=lua_toboolean(L, 3)
+    else
+      shallow:=false;
 
     lua_pop(L, lua_gettop(l));
 
     try
       if not local then
-        lua_pushinteger(L,symhandler.getAddressFromName(s, waitforsymbols))
+        lua_pushinteger(L,symhandler.getAddressFromName(s, waitforsymbols, e, nil, shallow))
       else
-        lua_pushinteger(L,selfsymhandler.getAddressFromName(s, waitforsymbols));
+        lua_pushinteger(L,selfsymhandler.getAddressFromName(s, waitforsymbols, e, nil, shallow));
 
       result:=1;
     except

--- a/Cheat Engine/bin/celua.txt
+++ b/Cheat Engine/bin/celua.txt
@@ -158,7 +158,7 @@ getDirectoryList(Path:string, SearchSubDirs: boolean OPTIONAL): Returns an index
 enableWindowsSymbols(): Will download the PDB files of Windows and load them (Takes a long time the first time)
 getAddress(string, local OPTIONAL): returns the address of a symbol. Can be a modulename or an export. set Local to true if you wish to querry the symboltable of the ce process
 enableKernelSymbols(): Will check the option for kernelmode symbols in memory view (Gets only the exports unless enableWindowsSymbols() is used)
-getAddressSafe(string, local OPTIONAL): returns the address of a symbol, or nil if not found. Similar to getAddress when errorOnLookup is false, but returns nil instead
+getAddressSafe(string, local OPTIONAL, shallow OPTIONAL): returns the address of a symbol, or nil if not found. Similar to getAddress when errorOnLookup is false, but returns nil instead
 getSymbolInfo(symbolname): Returns a table as defined by the SymbolList class object (modulename, searchkey, address, size)
 getModuleSize(modulename): Returns the size of a given module (Use getAddress to get the base address)
 getRTTIClassName(address): Returns the classname of a given structure based on RTTI information (assuming it can be found, returns nil if not or unknown)


### PR DESCRIPTION
getAddressSafe(string, local OPTIONAL, shallow OPTIONAL)

A way to prevent "C stack overflow" (infinite recursion) inside SymbolLookupCallback function:

before patch we have to use additional variable (probably not thread safe solution):
```Lua
function SLC(s)
 if SLC_SKIP then return end
 (snipped)
 SLC_SKIP = true
 address = getAddressSafe(thestring)
 SLC_SKIP = false
 return address
end
```
after patch:
```Lua
function SLC(s)
 (snipped)
 address = getAddressSafe(thestring, false, true) -- shallow=true, won't use callbacks
 return address
end
```