### PR TITLE
ceserver:add memory reading by process_vm_readv

### DIFF
--- a/Cheat Engine/ceserver/api.h
+++ b/Cheat Engine/ceserver/api.h
@@ -227,6 +227,11 @@ extern pthread_mutex_t debugsocketmutex;
   #define LOGD(fmt, args...) __android_log_vprint(ANDROID_LOG_DEBUG, LOG_TAG, fmt, ##args)
 #endif
 
+#ifdef __ANDROID__
+ssize_t process_vm_readv(pid_t pid,const struct iovec *local_iov,unsigned long liovcnt,const struct iovec *remote_iov,unsigned long riovcnt,unsigned long flags);
+ssize_t process_vm_writev(pid_t pid,const struct iovec *local_iov,unsigned long liovcnt,const struct iovec *remote_iov,unsigned long riovcnt,unsigned long flags);
+#endif
+
 int debug_log(const char * format , ...); 
 long safe_ptrace(int request, pid_t pid, void * addr, void * data);
 extern int MEMORY_SEARCH_OPTION;

--- a/Cheat Engine/ceserver/description.md
+++ b/Cheat Engine/ceserver/description.md
@@ -68,6 +68,7 @@ In the above state, move to the EXECUTABLE folder at the command prompt and exec
 Perform module enumeration only for the specified process ID.
  - `-m` 
 If `1` is specified, memory is read and written only with the ptrace privilege, not via the virtual file system.
+If `2` is specified, the memory is read using process_vm_readv.  
  - `-p`
 Listen on the specified port number instead of the default 52736.
 


### PR DESCRIPTION
1.add memory reading by process_vm_readv.
2.Fixed a mistake in the type definition of safe_ptrace when writing memory.