### PR TITLE
disabled ask to run lua script if its cetrainer/protected

### DIFF
--- a/Cheat Engine/OpenSave.pas
+++ b/Cheat Engine/OpenSave.pas
@@ -24,6 +24,7 @@ uses
 
 var CurrentTableVersion: dword=31;
     lastLoadedTableVersion: dword;
+    iscetrainer: integer=0;
 
 procedure protecttrainer(filename: string);
 procedure unprotecttrainer(filename: string; stream: TStream);
@@ -711,7 +712,7 @@ begin
 
     if mainform.frmLuaTableScript.assemblescreen.Text<>'' then
     begin
-      if not isTrainer then
+      if (not isTrainer) and (iscetrainer=0) then
       begin
         reg:=TRegistry.Create;
         try
@@ -1037,6 +1038,7 @@ begin
       else
       begin
         //protected
+        iscetrainer:=1;
         isProtected:=true;
         unprotectedstream:=tmemorystream.create;
 


### PR DESCRIPTION
if you turn on setting ask to run lua script, then if .cetrainer extension is changed to .ct, ce will ask to run lua script so i disabled that so it wont ask because it leak the code from protected cetrainer