### PR TITLE
fix pointerscannerfrm import/export for compressed with endwithoffset

### DIFF
--- a/Cheat Engine/pointerscannerfrm.pas
+++ b/Cheat Engine/pointerscannerfrm.pas
@@ -425,6 +425,7 @@ resourcestring
   rsPSExportAborted = 'Export aborted';
   rsPSImporting = 'Importing...';
   rsPSImporting_sortOrNot = 'Do you wish to sort pointerlist by level, then module, then offsets?';
+  rsPSImporting_sortMethod = 'Do you wish to use offsets sum for sorting?';
   rsPSStatistics = 'Statistics';
   rsPSUniquePointervaluesInTarget = 'Unique pointervalues in target:';
   rsPSScanDuration = 'Scan duration: ';
@@ -1392,7 +1393,7 @@ begin
       	                      '  PRIMARY KEY(ptrid,offsetnr)'+
                               ');');
 
-        sqlite3.ExecuteDirect('CREATE UNIQUE INDEX "ptrid_idx" ON pointerfiles_endwithoffsetlist( "ptrid" );');
+        sqlite3.ExecuteDirect('CREATE INDEX "ptrid_idx" ON pointerfiles_endwithoffsetlist( "ptrid" );');
       end;
 
 
@@ -1414,7 +1415,7 @@ begin
        if messagedlg(rsPSExportToDatabaseBiggerSizeOrNot, mtConfirmation, [mbyes, mbno], 0) = mryes then
         begin
           sqlite3.ExecuteDirect('create table results(ptrid integer not null, resultid integer, offsetcount integer, moduleid integer, moduleoffset integer '+offsetlist+', primary key (ptrid, resultid) );');
-          sqlite3.ExecuteDirect('CREATE UNIQUE INDEX "ptr_res_id_idx" ON "results"( ptrid, resultid );');
+          sqlite3.ExecuteDirect('CREATE INDEX "ptr_res_id_idx" ON "results"( ptrid, resultid );');
           sqlite3.ExecuteDirect('CREATE INDEX "modid_modoff_idx" ON "results"( moduleid, moduleoffset );');
         end
         else
@@ -1503,23 +1504,19 @@ begin
         BaseScanRange:='NULL';
 
       s:='INSERT INTO pointerfiles (name, maxlevel, compressedptr, unalligned, MaxBitCountModuleIndex, MaxBitCountModuleOffset, MaxBitCountLevel, MaxBitCountOffset, DidBaseRangeScan, BaseScanRange) values ("'+name+'", '+maxlevel+','+compressedptr+','+unalligned+','+MaxBitCountModuleIndex+','+MaxBitCountModuleOffset+','+MaxBitCountLevel+','+MaxBitCountOffset+','+DidBaseRangeScan+','+BaseScanRange+')';
-
       sqlite3.ExecuteDirect(s);
+
+
+      SQLQuery.SQL.Text:='Select max(ptrid) as max from pointerfiles';
+      SQLQuery.Active:=true;
+      ptrid:=SQLQuery.FieldByName('max').AsString;
+      SQLQuery.active:=false;
+
       for i:=0 to Pointerscanresults.EndsWithOffsetListCount-1 do
       begin
         s:='INSERT INTO pointerfiles_endwithoffsetlist (ptrid, offsetnr, offsetvalue) values ("'+ptrid+'", '+inttostr(i)+','+inttostr(Pointerscanresults.EndsWithOffsetList[i])+')';
         sqlite3.ExecuteDirect(s);
       end;
-
-
-
-      SQLQuery.SQL.Text:='Select max(ptrid) as max from pointerfiles';
-      SQLQuery.Active:=true;
-
-      ptrid:=SQLQuery.FieldByName('max').AsString;
-
-      SQLQuery.active:=false;
-
 
       for i:=0 to Pointerscanresults.modulelistCount-1 do
         sqlite3.ExecuteDirect('INSERT INTO modules(ptrid, moduleid, name) values ('+ptrid+','+inttostr(i)+',"'+Pointerscanresults.getModulename(i)+'")');
@@ -1535,10 +1532,10 @@ begin
         offsetvalues:='';
         p:=Pointerscanresults.getPointer(j);
 
-        for i:=1 to p.offsetcount do
+        for i:=1 to p.offsetcount-Pointerscanresults.EndsWithOffsetListCount do
         begin
           offsetlist:=offsetlist+',offset'+inttostr(i);
-          offsetvalues:=offsetvalues+','+inttostr(p.offsets[i-1]);
+          offsetvalues:=offsetvalues+','+inttostr(p.offsets[i-1+Pointerscanresults.EndsWithOffsetListCount]);
         end;
 
         if resultidcolumnsave then
@@ -1551,7 +1548,7 @@ begin
         if j mod 50=0 then
         begin
           progressbar1.position:=ceil(j / Pointerscanresults.count * 100);
-          progressbar1.Update;
+          application.ProcessMessages;
         end;
         inc(j);
       end;
@@ -1813,10 +1810,18 @@ begin
 
 
     offsetlist:='';
-    for i:=1 to maxlevel do offsetlist:=offsetlist+', offset'+inttostr(i);
 
     if messagedlg(rsPSImporting_sortOrNot, mtConfirmation, [mbyes, mbno], 0) = mryes then
-      sqlquery.sql.text:='select * from results where ptrid='+ptrid+' order by offsetcount, moduleid'+offsetlist
+      if messagedlg(rsPSImporting_sortMethod, mtConfirmation, [mbyes, mbno], 0) = mryes then
+      begin
+        for i:=maxlevel downto 1 do offsetlist:=offsetlist+'+ coalesce(offset'+inttostr(i)+',0)';
+        sqlquery.sql.text:='select *,(0'+offsetlist+') as suma from results where ptrid='+ptrid+' order by offsetcount, suma, moduleid';
+      end
+      else
+      begin
+        for i:=maxlevel downto 1 do offsetlist:=offsetlist+', offset'+inttostr(i);
+        sqlquery.sql.text:='select * from results where ptrid='+ptrid+' order by offsetcount, moduleid'+offsetlist;
+      end
     else
       sqlquery.sql.text:='select * from results where ptrid='+ptrid;
 
@@ -1903,7 +1908,7 @@ begin
         if importedcount mod 25=0 then
         begin
           progressbar1.Position:=ceil(importedcount/totalcount*100);
-          progressbar1.update;
+          application.ProcessMessages;
         end;
       end;
     finally


### PR DESCRIPTION
- pointerfiles_endwithoffsetlist table now has proper ptrid
- application.ProcessMessages called when importing exporting
- new sort method

Changes tested with those steps:
- do pointer scan with: compressed, mustendwithoffset with two offsets (bigger than max offset), aligned
- saved as PlayerHealth.PTR (plus PlayerHealth.PTR.results.0 PlayerHealth.PTR.results.1 PlayerHealth.PTR.results.2)
- export PlayerHealth.PTR to database whatever.sqlite
- import (without sorting) from whatever.sqlite database and save it under importTest.PTR (plus importTest.PTR.results.0)
- merge PlayerHealth.PTR.results.0 up to PlayerHealth.PTR.results.2 into one file: PlayerHealth.PTR.results.TOTAL
- calculate SHA256 checksum for importTest.PTR.results.0 and PlayerHealth.PTR.results.TOTAL