### PR TITLE
Shorten custom type display in hex view

### DIFF
--- a/Cheat Engine/hexviewunit.pas
+++ b/Cheat Engine/hexviewunit.pas
@@ -1965,6 +1965,8 @@ begin
     i:=customtype.ConvertDataToInteger(@bytes[0],a);
     result:=format('%d',[i]);
   end;
+  if (not full) and (length(result)>11) then
+    result:=copy(result,1,8)+'...';       
 end;
 
 function THexView.getChar(a: ptrUint; out charlength: integer): string;


### PR DESCRIPTION

![ugly_hex](https://user-images.githubusercontent.com/47719641/90451372-46360500-e0b1-11ea-8250-bc91dbfe8ecb.png)
If the custom type in coverts to a long number string the output in the hex view is unreadable. Added code to shorten.