### PR TITLE
Improving Form Structure Dissect.

### DIFF
--- a/Cheat Engine/StructuresFrm2.lfm
+++ b/Cheat Engine/StructuresFrm2.lfm
@@ -1,18 +1,18 @@
 object frmStructures2: TfrmStructures2
-  Left = 870
-  Height = 381
-  Top = 524
-  Width = 542
+  Left = 794
+  Height = 589
+  Top = 231
+  Width = 1043
   Caption = 'Structure dissect'
-  ClientHeight = 361
-  ClientWidth = 542
+  ClientHeight = 569
+  ClientWidth = 1043
   Menu = MainMenu1
   OnClose = FormClose
   OnCreate = FormCreate
   OnDestroy = FormDestroy
   OnShow = FormShow
   Position = poScreenCenter
-  LCLVersion = '2.0.0.4'
+  LCLVersion = '2.0.10.0'
   object tvStructureView: TTreeView
     AnchorSideLeft.Control = Owner
     AnchorSideTop.Control = HeaderControl1
@@ -22,9 +22,9 @@ object frmStructures2: TfrmStructures2
     AnchorSideBottom.Control = Owner
     AnchorSideBottom.Side = asrBottom
     Left = 0
-    Height = 290
+    Height = 498
     Top = 71
-    Width = 542
+    Width = 1043
     Anchors = [akTop, akLeft, akRight, akBottom]
     BorderStyle = bsNone
     Font.CharSet = ANSI_CHARSET
@@ -56,7 +56,7 @@ object frmStructures2: TfrmStructures2
     Left = 0
     Height = 21
     Top = 50
-    Width = 542
+    Width = 641
     DragReorder = False
     Sections = <    
       item
@@ -74,7 +74,7 @@ object frmStructures2: TfrmStructures2
     Left = 0
     Height = 50
     Top = 0
-    Width = 542
+    Width = 1043
     HorzScrollBar.Increment = 1
     HorzScrollBar.Page = 1
     HorzScrollBar.Smooth = True
@@ -88,7 +88,7 @@ object frmStructures2: TfrmStructures2
   end
   object MainMenu1: TMainMenu
     Images = sdImageList
-    left = 512
+    Left = 512
     object File1: TMenuItem
       Caption = 'File'
       object miNewWindow: TMenuItem
@@ -126,7 +126,7 @@ object frmStructures2: TfrmStructures2
         Caption = 'Rearrange structurelist'
         OnClick = MenuItem8Click
       end
-      object MenuItem2: TMenuItem
+      object N14: TMenuItem
         Caption = '-'
       end
       object MenuItem3: TMenuItem
@@ -181,7 +181,7 @@ object frmStructures2: TfrmStructures2
         ShortCut = 16456
         OnClick = miShowAddressesClick
       end
-      object MenuItem7: TMenuItem
+      object N15: TMenuItem
         Caption = '-'
       end
       object miExpandAllDefined: TMenuItem
@@ -293,13 +293,18 @@ object frmStructures2: TfrmStructures2
   object pmStructureView: TPopupMenu
     Images = sdImageList
     OnPopup = pmStructureViewPopup
-    left = 48
-    top = 120
+    Left = 48
+    Top = 120
     object miChangeValue: TMenuItem
       Caption = 'Change value'
       ImageIndex = 5
       ShortCut = 13
       OnClick = miChangeValueClick
+    end
+    object miChangeRowAllValues: TMenuItem
+      Caption = 'Change all values in row'
+      ImageIndex = 5
+      OnClick = miChangeAllValuesInRowClick
     end
     object miChangeType: TMenuItem
       Caption = 'Change Type'
@@ -315,6 +320,13 @@ object frmStructures2: TfrmStructures2
       object miChangeType4Byte: TMenuItem
         Caption = '4 Byte'
         OnClick = OnChangeTypeMenuItemClick
+      end
+      object miChangeType8Byte: TMenuItem
+        Caption = '8 Byte'
+        OnClick = OnChangeTypeMenuItemClick
+      end
+      object N9: TMenuItem
+        Caption = '-'
       end
       object miChangeTypeByteHex: TMenuItem
         Caption = 'Byte (Hex)'
@@ -332,6 +344,9 @@ object frmStructures2: TfrmStructures2
         Caption = '8 Byte (Hex)'
         OnClick = OnChangeTypeMenuItemClick
       end
+      object N10: TMenuItem
+        Caption = '-'
+      end
       object miChangeTypeFloat: TMenuItem
         Caption = 'Float'
         OnClick = OnChangeTypeMenuItemClick
@@ -340,6 +355,9 @@ object frmStructures2: TfrmStructures2
         Caption = 'Double'
         OnClick = OnChangeTypeMenuItemClick
       end
+      object N11: TMenuItem
+        Caption = '-'
+      end
       object miChangeTypeString: TMenuItem
         Caption = 'String'
         OnClick = OnChangeTypeMenuItemClick
@@ -347,6 +365,9 @@ object frmStructures2: TfrmStructures2
       object miChangeTypeUnicode: TMenuItem
         Caption = 'Unicode'
         OnClick = OnChangeTypeMenuItemClick
+      end
+      object N12: TMenuItem
+        Caption = '-'
       end
       object miChangeTypeArrayOfByte: TMenuItem
         Caption = 'Array Of Byte'
@@ -391,14 +412,34 @@ object frmStructures2: TfrmStructures2
       ShortCut = 49231
       OnClick = miOpenInNewWindowClick
     end
+    object N13: TMenuItem
+      Caption = '-'
+    end
+    object miFindOutWhatAccessesThisAddress: TMenuItem
+      Caption = 'Find out what accesses this address'
+      ImageIndex = 9
+      ShortCut = 116
+      OnClick = miFindOutWhatAccessesThisAddressClick
+    end
+    object miFindOutWhatWritesThisAddress: TMenuItem
+      Caption = 'Find out what writes to this address'
+      ImageIndex = 9
+      ShortCut = 117
+      OnClick = miFindOutWhatWritesThisAddressClick
+    end
     object N2: TMenuItem
       Caption = '-'
     end
-    object miAddToAddresslist: TMenuItem
+    object miAddToAddressList: TMenuItem
       Caption = 'Add to address list'
       ImageIndex = 1
       ShortCut = 65
-      OnClick = miAddToAddresslistClick
+      OnClick = miAddToAddressListClick
+    end
+    object miAddAllInRowToAddressList: TMenuItem
+      Caption = 'Add all in row to address list'
+      ImageIndex = 1
+      OnClick = miAddAllInRowToAddressListClick
     end
     object miBrowsePointer: TMenuItem
       Caption = 'Memory browse pointer'
@@ -467,43 +508,43 @@ object frmStructures2: TfrmStructures2
   object updatetimer: TTimer
     Interval = 500
     OnTimer = updatetimerTimer
-    left = 264
-    top = 80
+    Left = 264
+    Top = 80
   end
   object OpenDialog1: TOpenDialog
     DefaultExt = '.CSX'
     Filter = 'Cheat Engine structure files (*.CES;*.CSX)|*.CES;*.CSX;*.XML|All Files (*.*)|*.*'
-    left = 48
-    top = 192
+    Left = 48
+    Top = 192
   end
   object SaveDialog1: TSaveDialog
     DefaultExt = '.CSX'
     Filter = 'Cheat Engine structure files (*.CSX)|*.CSX|All Files (*.*)|*.*'
     Options = [ofOverwritePrompt, ofHideReadOnly, ofEnableSizing]
-    left = 152
-    top = 192
+    Left = 152
+    Top = 192
   end
   object saveValues: TSaveDialog
     DefaultExt = '.txt'
     Filter = 'Text Files (*.txt)|*.txt'
-    left = 152
-    top = 264
+    Left = 152
+    Top = 264
   end
   object FindDialog1: TFindDialog
     Options = [frDown, frDisableWholeWord, frHideEntireScope]
     OnFind = FindDialog1Find
-    left = 152
-    top = 128
+    Left = 152
+    Top = 128
   end
   object tmFixGui: TTimer
     Interval = 100
     OnTimer = tmFixGuiTimer
-    left = 360
-    top = 84
+    Left = 360
+    Top = 84
   end
   object sdImageList: TImageList
-    left = 318
-    top = 272
+    Left = 318
+    Top = 272
     Bitmap = {
       4C69130000001000000010000000C47B27FFE08D2CFFE08D2CFFE08D2CFFE08D
       2CFFE08D2CFFE08D2CFFE08D2CFFE08D2CFFE0872CFFE0832CFFE0892CFFE082

--- a/Cheat Engine/StructuresFrm2.pas
+++ b/Cheat Engine/StructuresFrm2.pas
@@ -6,25 +6,31 @@ unit StructuresFrm2;
 interface
 
 uses
-  windows, win32proc, Classes, LCLProc, SysUtils, FileUtil, Forms, Controls, Graphics, Dialogs, ExtCtrls, math,
-  StdCtrls, ComCtrls, Menus, lmessages, scrolltreeview, byteinterpreter, symbolhandler, symbolhandlerstructs, cefuncproc,
-  newkernelhandler, frmSelectionlistunit, frmStructuresConfigUnit, registry, Valuechange, DOM,
-  XMLRead, XMLWrite, Clipbrd, CustomTypeHandler, strutils, dotnetpipe, DotNetTypes, commonTypeDefs,
+  Windows, win32proc, Classes, LCLProc, SysUtils, FileUtil, Forms, CEDebugger, debughelper,
+  Controls, Graphics, Dialogs, ExtCtrls, Math,
+  StdCtrls, ComCtrls, Menus, lmessages, scrolltreeview, byteinterpreter,
+  symbolhandler, symbolhandlerstructs, cefuncproc,
+  newkernelhandler, frmSelectionlistunit, frmStructuresConfigUnit,
+  registry, Valuechange, DOM,
+  XMLRead, XMLWrite, Clipbrd, CustomTypeHandler, strutils, dotnetpipe,
+  DotNetTypes, commonTypeDefs,
   contnrs, cvconst, frmStructuresNewStructureUnit;
 
+const
+  structureversion = 2;
 
-const structureversion=2;
-
-  { TfrmStructures2 }
+{ TfrmStructures2 }
 type
-  TdisplayMethod=(dtUnsignedInteger, dtSignedInteger, dtHexadecimal );
-  TStructOperation=(soAdd, soDelete, soSort);
+  TdisplayMethod = (dtUnsignedInteger, dtSignedInteger, dtHexadecimal);
+  TStructOperation = (soAdd, soDelete, soSort);
 
-  TDissectedStruct=class;
-  TStructureDissectOverride=function(structure: TObject; address: ptruint): boolean of object;
-  TStructureNameLookup=function(var address: ptruint; var name: string): boolean of object;
+  TDissectedStruct = class;
+  TStructureDissectOverride = function(structure: TObject;
+    address: ptruint): boolean of object;
+  TStructureNameLookup = function(var address: ptruint;
+    var Name: string): boolean of object;
 
-  TStructelement=class
+  TStructelement = class
   private
     fparent: TDissectedStruct;
     foffset: integer;
@@ -35,13 +41,14 @@ type
     fCustomType: TCustomtype;
     fdisplayMethod: TdisplayMethod;
     fchildstruct: TDissectedStruct;
-    fchildstructstart: integer; //offset into the childstruct where this pointer starts. Always 0 for local structs, can be higher than 0 for other defined structs
+    fchildstructstart: integer;
+    //offset into the childstruct where this pointer starts. Always 0 for local structs, can be higher than 0 for other defined structs
     fExpandChangesAddress: boolean;
   public
     delayLoadedStructname: string;
-    constructor createFromXMLElement(parent:TDissectedStruct; element: TDOMElement);
-    constructor create(parent:TDissectedStruct);
-    destructor destroy; override;
+    constructor createFromXMLElement(parent: TDissectedStruct; element: TDOMElement);
+    constructor Create(parent: TDissectedStruct);
+    destructor Destroy; override;
     function getParent: TDissectedStruct;
     function getOffset: integer;
     procedure setOffset(newOffset: integer);
@@ -57,10 +64,11 @@ type
     procedure setBytesize(newByteSize: integer);
     function getBackgroundColor: integer;
     procedure setBackgroundColor(c: TColor);
-    function getValue(address: ptruint; hashexprefix: boolean=false; showAsHexOverride: boolean=false): string;
-    procedure setvalue(address: ptruint; value: string);
+    function getValue(address: ptruint; hashexprefix: boolean = False;
+      showAsHexOverride: boolean = False): string;
+    procedure setvalue(address: ptruint; Value: string);
     function getValueFromBase(baseaddress: ptruint): string;
-    procedure setValueFromBase(baseaddress: ptruint; value: string);
+    procedure setValueFromBase(baseaddress: ptruint; Value: string);
     function isPointer: boolean;
     function getChildStruct: TDissectedStruct;
     procedure setChildStruct(newChildStruct: TDissectedStruct);
@@ -68,7 +76,7 @@ type
 
     function getIndex: integer;
 
-    procedure AutoCreateChildStruct(name: string; address: ptruint);
+    procedure AutoCreateChildStruct(Name: string; address: ptruint);
 
     procedure WriteToXMLNode(elementnodes: TDOMNode);
 
@@ -84,15 +92,16 @@ type
     property ChildStructStart: integer read fchildstructstart write setChildStructStart;
     property index: integer read getIndex;
     property parent: TDissectedStruct read getParent;
-    property ExpandChangesAddress: boolean read fExpandChangesAddress write fExpandChangesAddress;
+    property ExpandChangesAddress: boolean read fExpandChangesAddress
+      write fExpandChangesAddress;
   end;
 
 
 
-  TDissectedStruct=class
+  TDissectedStruct = class
   private
     structname: string;
-    structelementlist: tlist;
+    structelementlist: TList;
 
     fAutoCreate: boolean;
     fAutoCreateStructsize: integer;
@@ -108,7 +117,7 @@ type
 
     updatecalledSort: boolean;
     updateChangedInformation: boolean;
-    updatedelements: Tlist;
+    updatedelements: TList;
 
 
 
@@ -127,13 +136,13 @@ type
     procedure setDefaultHex(state: boolean);
     procedure setRLECompression(state: boolean);
   public
-    constructor create(name: string);
+    constructor Create(Name: string);
     constructor createFromXMLNode(structure: TDOMNode);
     constructor createFromOutdatedXMLNode(structure: TDOMNode);
 
     procedure WriteToXMLNode(node: TDOMNode);
 
-    destructor destroy; override;
+    destructor Destroy; override;
 
 
 
@@ -151,10 +160,12 @@ type
     procedure OnDeleteStructNotification(structtodelete: TDissectedStruct; path: TList);
 
     procedure sortElements;
-    function addElement(name: string=''; offset: integer=0; vartype: TVariableType=vtByte; customtype:TCustomtype=nil; bytesize: integer=0; childstruct: TDissectedStruct=nil): TStructelement;
+    function addElement(Name: string = ''; offset: integer = 0;
+      vartype: TVariableType = vtByte; customtype: TCustomtype = nil;
+      bytesize: integer = 0; childstruct: TDissectedStruct = nil): TStructelement;
     procedure removeElement(element: TStructelement);
-    procedure delete(index: integer);
-    procedure fillFromDotNetAddressData(const data: TAddressData);
+    procedure Delete(index: integer);
+    procedure fillFromDotNetAddressData(const Data: TAddressData);
     procedure autoGuessStruct(baseaddress: ptruint; offset: integer; bytesize: integer);
     procedure fillGaps(structbase: ptruint; askiftoobig: boolean);
     procedure addToGlobalStructList;
@@ -162,30 +173,31 @@ type
     function isInGlobalStructList: boolean;
     function getIndexOf(element: TStructElement): integer;
     function getIndexOfOffset(offset: dword): integer;
-    property structuresize : integer read getStructureSize;
-    property name: string read getName write setName;
+    property structuresize: integer read getStructureSize;
+    property Name: string read getName write setName;
 
     //these properties are just for the gui
     property DoNotSaveLocal: boolean read fDoNotSaveLocal write setDoNotSaveLocal;
-    property AutoCreateStructsize: integer read fAutoCreateStructsize write setAutoCreateStructsize;
+    property AutoCreateStructsize: integer read fAutoCreateStructsize
+      write setAutoCreateStructsize;
     property AutoCreate: boolean read fAutoCreate write setAutoCreate;
     property AutoDestroy: boolean read fAutoDestroy write setAutoDestroy;
     property AutoFill: boolean read fAutoFill write setAutoFill;
-    property count: integer read getElementCount;
-    property element[Index: Integer]: TStructelement read getElement; default;
+    property Count: integer read getElementCount;
+    property element[Index: integer]: TStructelement read getElement; default;
     property RLECompression: boolean read fRLECompression write setRLECompression;
   published
     property DefaultHex: boolean read fDefaultHex write setDefaultHex;
   end;
 
-  PDissectedStruct=^TDissectedStruct;
+  PDissectedStruct = ^TDissectedStruct;
 
   //TDissectedStructs=TFPGList<TDissectedStruct>;
 
-  TfrmStructures2=class;
-  TStructColumn=class;
+  TfrmStructures2 = class;
+  TStructColumn = class;
 
-  TStructGroup=class //Will handle the group compares for each group
+  TStructGroup = class //Will handle the group compares for each group
   private
     parent: TfrmStructures2;
     fcolumns: TList;
@@ -202,32 +214,33 @@ type
 
     function getColumnCount: integer;
     function getColumn(i: integer): TStructColumn;
-    procedure RenameClick(sender: tobject);
-    procedure DeleteClick(sender: Tobject);
+    procedure RenameClick(Sender: TObject);
+    procedure DeleteClick(Sender: TObject);
     procedure setGroupName(newname: string);
-    procedure groupboxresize(sender: TObject);
+    procedure groupboxresize(Sender: TObject);
   public
     function getParent: TfrmStructures2;
     function AColumnHasSetCaption: boolean;
     procedure setPositions;
-    constructor create(parent: TfrmStructures2; GroupName: string);
-    destructor destroy; override;
+    constructor Create(parent: TfrmStructures2; GroupName: string);
+    destructor Destroy; override;
 
-    procedure clear; //sets matches to true
+    procedure Clear; //sets matches to true
     property Matches: boolean read fMatches;
-    procedure addString(s:string); //sets matches to false if it doesn't match the previous string (also sets currentStrign to '' on false)
+    procedure addString(s: string);
+    //sets matches to false if it doesn't match the previous string (also sets currentStrign to '' on false)
 
   published
     property currentString: string read fCurrentString;
     property groupname: string read fGroupName write setGroupName;
-    property name: string read fGroupName write setGroupName;
+    property Name: string read fGroupName write setGroupName;
     property box: TGroupbox read GroupBox;
     property columnCount: integer read getColumnCount;
     property columns[index: integer]: TStructColumn read Getcolumn;
   end;
 
 
-  TStructColumn=class
+  TStructColumn = class
   private
     parent: TStructGroup;
 
@@ -256,20 +269,20 @@ type
 
     backlist: Tstack;
 
-    procedure ChangeGroupClick(sender: tobject);
-    procedure DeleteClick(sender: TObject);
-    procedure ToggleLockClick(sender: TObject);
+    procedure ChangeGroupClick(Sender: TObject);
+    procedure DeleteClick(Sender: TObject);
+    procedure ToggleLockClick(Sender: TObject);
 
-    procedure CutClick(sender: TObject);
-    procedure CopyClick(sender: TObject);
-    procedure PasteClick(sender: TObject);
-    procedure SpiderClick(sender: TObject);
-    procedure SetCaptionClick(sender: TObject);
+    procedure CutClick(Sender: TObject);
+    procedure CopyClick(Sender: TObject);
+    procedure PasteClick(Sender: TObject);
+    procedure SpiderClick(Sender: TObject);
+    procedure SetCaptionClick(Sender: TObject);
 
-    procedure MenuPopup(sender: TObject);
+    procedure MenuPopup(Sender: TObject);
 
 
-    procedure edtAddressChange(sender: TObject);
+    procedure edtAddressChange(Sender: TObject);
     function getAddress: ptruint;
     procedure setAddress(address: ptruint);
     function getAddressText: string;
@@ -289,20 +302,23 @@ type
     currentNodeValue: string;
     currentNodeColor: Tcolor;
 
-    constructor create(parent: TStructGroup);
-    destructor destroy; override;
+    constructor Create(parent: TStructGroup);
+    destructor Destroy; override;
 
 
     procedure focus;
-    procedure edtAddressEnter(sender: tobject);
-    procedure edtaddressMousedown(Sender: TObject; Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+    procedure edtAddressEnter(Sender: TObject);
+    procedure edtaddressMousedown(Sender: TObject; Button: TMouseButton;
+      Shift: TShiftState; X, Y: integer);
 
     procedure clearSavedState;
     function saveState: boolean;
     function getSavedState: ptruint;
     procedure setSavedState(p: ptruint);
     function getSavedStateSize: integer;
-    function LockAddress(shownaddress: ptruint; memoryblock: pointer; size: integer): boolean; //call this when you wish to set a specific lock state based on locally saved data
+    function LockAddress(shownaddress: ptruint; memoryblock: pointer;
+      size: integer): boolean;
+    //call this when you wish to set a specific lock state based on locally saved data
 
 
     function getEditWidth: integer;
@@ -322,19 +338,28 @@ type
     property GlobalIndex: integer read getGlobalIndex;
     property AddressText: string read getAddressText write setAddressText;
     property Name: string read getName;
-    property SavedState: ptruint read getSavedState write setSavedState; //hack to expose a raw pointer as property
+    property SavedState: ptruint read getSavedState write setSavedState;
+    //hack to expose a raw pointer as property
     property SavedStateSize: integer read fsavedstatesize write fsavedstatesize;
 
   end;
 
   TfrmStructures2 = class(TForm)
     FindDialog1: TFindDialog;
+    N9: TMenuItem;
+    N11: TMenuItem;
+    N12: TMenuItem;
+    miFindOutWhatAccessesThisAddress: TMenuItem;
+    N13: TMenuItem;
+    miFindOutWhatWritesThisAddress: TMenuItem;
+    N10: TMenuItem;
+    miChangeRowAllValues: TMenuItem;
     miOpenInNewWindow: TMenuItem;
     sdImageList: TImageList;
     miCommonalityScan: TMenuItem;
     MenuItem5: TMenuItem;
     MenuItem6: TMenuItem;
-    MenuItem7: TMenuItem;
+    N15: TMenuItem;
     MenuItem8: TMenuItem;
     miSeperatorCommonalityScanner: TMenuItem;
     miChangeTypeArrayOfByte: TMenuItem;
@@ -347,6 +372,7 @@ type
     miChangeType4ByteHex: TMenuItem;
     miChangeType2ByteHex: TMenuItem;
     miChangeTypeByteHex: TMenuItem;
+    miChangeType8Byte: TMenuItem;
     miChangeType4Byte: TMenuItem;
     miChangeType2Byte: TMenuItem;
     miChangeTypeByte: TMenuItem;
@@ -371,13 +397,15 @@ type
     miAutoFillGaps: TMenuItem;
     miFillGaps: TMenuItem;
     miChangeValue: TMenuItem;
+    miChangeAllValuesInRow: TMenuItem;
     miShowAddresses: TMenuItem;
     miDoNotSaveLocal: TMenuItem;
     miFullUpgrade: TMenuItem;
     miAddChildElement: TMenuItem;
     miAddElement: TMenuItem;
     Addextraaddress1: TMenuItem;
-    miAddToAddresslist: TMenuItem;
+    miAddToAddressList: TMenuItem;
+    miAddAllInRowToAddressList: TMenuItem;
     miAutoGuess: TMenuItem;
     miChangeElement: TMenuItem;
     miCommands: TMenuItem;
@@ -390,7 +418,7 @@ type
     miBrowsePointer: TMenuItem;
     miBrowseAddress: TMenuItem;
     miView: TMenuItem;
-    MenuItem2: TMenuItem;
+    N14: TMenuItem;
     MenuItem3: TMenuItem;
     MenuItem4: TMenuItem;
     miAutoCreate: TMenuItem;
@@ -417,6 +445,8 @@ type
     tmFixGui: TTimer;
     updatetimer: TTimer;
     tvStructureView: TTreeView;
+    procedure miFindOutWhatAccessesThisAddressClick(Sender: TObject);
+    procedure miFindOutWhatWritesThisAddressClick(Sender: TObject);
     procedure miOpenInNewWindowClick(Sender: TObject);
     procedure miCommonalityScanClick(Sender: TObject);
     procedure MenuItem8Click(Sender: TObject);
@@ -441,9 +471,11 @@ type
     procedure miAutoDestroyLocalClick(Sender: TObject);
     procedure miAutoFillGapsClick(Sender: TObject);
     procedure miChangeValueClick(Sender: TObject);
+    procedure miChangeAllValuesInRowClick(Sender: TObject);
     procedure miBrowseAddressClick(Sender: TObject);
     procedure miBrowsePointerClick(Sender: TObject);
-    procedure miAddToAddresslistClick(Sender: TObject);
+    procedure miAddToAddressListClick(Sender: TObject);
+    procedure miAddAllInRowToAddressListClick(Sender: TObject);
     procedure Deletecurrentstructure1Click(Sender: TObject);
     procedure miAutoGuessClick(Sender: TObject);
     procedure miAutostructsizeClick(Sender: TObject);
@@ -462,7 +494,7 @@ type
     procedure FormDestroy(Sender: TObject);
     procedure FormShow(Sender: TObject);
     procedure HeaderControl1SectionTrack(HeaderControl: TCustomHeaderControl;
-      Section: THeaderSection; Width: Integer; State: TSectionTrackState);
+      Section: THeaderSection; Width: integer; State: TSectionTrackState);
     procedure miAddChildElementClick(Sender: TObject);
     procedure miAddElementClick(Sender: TObject);
     procedure miPasteClick(Sender: TObject);
@@ -481,54 +513,63 @@ type
     procedure tmFixGuiTimer(Sender: TObject);
     procedure tvStructureViewAdvancedCustomDrawItem(Sender: TCustomTreeView;
       Node: TTreeNode; State: TCustomDrawState; Stage: TCustomDrawStage;
-      var PaintImages, DefaultDraw: Boolean);
+      var PaintImages, DefaultDraw: boolean);
     procedure tvStructureViewDblClick(Sender: TObject);
     procedure tvStructureViewMouseDown(Sender: TObject; Button: TMouseButton;
-      Shift: TShiftState; X, Y: Integer);
+      Shift: TShiftState; X, Y: integer);
     procedure updatetimerTimer(Sender: TObject);
     procedure tvStructureViewCollapsed(Sender: TObject; Node: TTreeNode);
     procedure tvStructureViewCollapsing(Sender: TObject; Node: TTreeNode;
-      var AllowCollapse: Boolean);
+      var AllowCollapse: boolean);
     procedure tvStructureViewExpanded(Sender: TObject; Node: TTreeNode);
     procedure tvStructureViewExpanding(Sender: TObject; Node: TTreeNode;
-      var AllowExpansion: Boolean);
+      var AllowExpansion: boolean);
   private
     { private declarations }
     fmainStruct: TDissectedStruct;
-    fgroups: Tlist;
+    fgroups: TList;
 
 
     fDefaultColor: TColor;
     fNoMatchColor: TColor; //The color to use when not all elements have the same color
     fMatchColor: tcolor; //The color to use when all elements in the group match
-    fAllMatchColorSame: TColor; //The color to use when all groups have matching elements AND the same value
-    fAllMatchColorDiff: TColor; //The color to use when all groups have matching alements but different values between groups
+    fAllMatchColorSame: TColor;
+    //The color to use when all groups have matching elements AND the same value
+    fAllMatchColorDiff: TColor;
+    //The color to use when all groups have matching alements but different values between groups
 
     fDefaultColorHighlighted: TColor;
-    fNoMatchColorHighlighted: TColor; //The color to use when not all elements have the same color
-    fMatchColorHighlighted: tcolor; //The color to use when all elements in the group match
-    fAllMatchColorSameHighlighted: TColor; //The color to use when all groups have matching elements AND the same value
-    fAllMatchColorDiffHighlighted: TColor; //The color to use when all groups have matching alements but different values between groups
+    fNoMatchColorHighlighted: TColor;
+    //The color to use when not all elements have the same color
+    fMatchColorHighlighted: tcolor;
+    //The color to use when all elements in the group match
+    fAllMatchColorSameHighlighted: TColor;
+    //The color to use when all groups have matching elements AND the same value
+    fAllMatchColorDiffHighlighted: TColor;
+    //The color to use when all groups have matching alements but different values between groups
 
     frmStructuresNewStructure: TfrmStructuresNewStructure;
 
     procedure UpdateCurrentStructOptions;
     procedure setupColors;
 
-    procedure miSelectStructureClick(Sender: tobject);
-    function getHorizontalScrollbarString: String; //returns a string out of spaces that fills up the length of all the columns combined
+    procedure miSelectStructureClick(Sender: TObject);
+    function getHorizontalScrollbarString: string;
+    //returns a string out of spaces that fills up the length of all the columns combined
     procedure SetupFirstNodeLength;
     procedure InitializeFirstNode;
     procedure RefreshStructureList;
-    procedure TreeViewHScroll(sender: TObject; scrolledleft, maxscrolledleft: integer);
-    procedure TreeViewVScroll(sender: TObject);
+    procedure TreeViewHScroll(Sender: TObject; scrolledleft, maxscrolledleft: integer);
+    procedure TreeViewVScroll(Sender: TObject);
 
     procedure removeColumn(columnid: integer);
     procedure FillTreenodeWithStructData(currentnode: TTreenode);
     function getDisplayedDescription(se: TStructelement): string;
     procedure setupNodeWithElement(node: TTreenode; element: TStructElement);
-    procedure setCurrentNodeStringsInColumns(node: TTreenode; element: TStructElement; highlighted: boolean=false);  //sets the value for the current node into the columns
-    
+    procedure setCurrentNodeStringsInColumns(node: TTreenode;
+      element: TStructElement; highlighted: boolean = False);
+    //sets the value for the current node into the columns
+
     procedure setMainStruct(struct: TDissectedStruct);
     function getColumn(i: integer): TStructColumn;
     function getColumnCount: integer;
@@ -536,41 +577,48 @@ type
     function getGroup(i: integer): TStructGroup;
     function getGroupCount: integer;
 
-    procedure getValues(f: Tstrings); //fills a strings object with all the values
+    procedure getValues(f: TStrings); //fills a strings object with all the values
     function searchString(search: string; findoptions: TFindOptions): integer;
 
-    procedure EditValueOfSelectedNodes(c:TStructColumn);
+    procedure EditValueOfSelectedNodes(focusColumn: TStructColumn);
+    procedure EditAllValuesInRowOfSelectedNodes(focusColumn: TStructColumn);
     procedure expandtree(all: boolean);
   public
     { public declarations }
     initialaddress: PtrUInt;
     lastresizecheck: dword;
 
-    function DefineNewStructureDialog(recommendedSize: integer=4096): TDissectedStruct;
-    function DefineNewStructure(recommendedSize: integer=4096): TDissectedStruct;
-    procedure addLockedAddress(shownaddress: ptruint; memoryblock: pointer; size: integer); //call this to add a locked address, and copy the memoryblock to the target process)
+    function DefineNewStructureDialog(recommendedSize: integer = 4096): TDissectedStruct;
+    function DefineNewStructure(recommendedSize: integer = 4096): TDissectedStruct;
+    procedure addLockedAddress(shownaddress: ptruint; memoryblock: pointer;
+      size: integer);
+    //call this to add a locked address, and copy the memoryblock to the target process)
     procedure RefreshVisibleNodes;
 
     function addColumn: TStructColumn;
     function getFocusedColumn: TStructColumn;
     function getColumnAtXPos(x: integer): TStructColumn;
     procedure changeNodes;
-    procedure addFromNode(n: TTreenode; asChild: boolean=false);
+    procedure addFromNode(n: TTreenode; asChild: boolean = False);
     function getStructElementFromNode(node: TTreenode): TStructelement;
     function getStructFromNode(node: TTreenode): TDissectedStruct;
     function getChildStructFromNode(node: TTreenode): TDissectedStruct;
     function getMainStruct: TDissectedStruct;
 
-    procedure getPointerFromNode(node: TTreenode; column:TStructcolumn; var baseaddress: ptruint; var offsetlist: toffsetlist);
-    function getAddressFromNode(node: TTreenode; column: TStructColumn; var hasError: boolean): ptruint;
+    procedure getPointerFromNode(node: TTreenode; column: TStructcolumn;
+      var baseaddress: ptruint; var offsetlist: toffsetlist);
+    function getAddressFromNode(node: TTreenode; column: TStructColumn;
+      var hasError: boolean): ptruint;
 
     procedure onStructListChange;
-    procedure onAddedToStructList(sender: TDissectedStruct);
-    procedure onRemovedFromStructList(sender: TDissectedStruct);
-    procedure onFullStructChange(sender: TDissectedStruct);   //called when a structure is changed (sort/add/remove entry)
-    procedure onStructOptionsChange(sender: TDissectedStruct);
-    procedure onElementChange(struct:TDissectedStruct; element: TStructelement); //called when an element of a structure is changed
-    procedure onStructureDelete(sender: TDissectedStruct);
+    procedure onAddedToStructList(Sender: TDissectedStruct);
+    procedure onRemovedFromStructList(Sender: TDissectedStruct);
+    procedure onFullStructChange(Sender: TDissectedStruct);
+    //called when a structure is changed (sort/add/remove entry)
+    procedure onStructOptionsChange(Sender: TDissectedStruct);
+    procedure onElementChange(struct: TDissectedStruct; element: TStructelement);
+    //called when an element of a structure is changed
+    procedure onStructureDelete(Sender: TDissectedStruct);
 
     procedure FixPositions;
   published
@@ -580,7 +628,7 @@ type
     property AllMatchColorSame: TColor read fAllMatchColorSame;
     property AllMatchColorDiff: TColor read fAllMatchColorDiff;
 
-    property mainStruct : TDissectedStruct read fmainStruct write setMainStruct;
+    property mainStruct: TDissectedStruct read fmainStruct write setMainStruct;
     property columnCount: integer read getColumnCount;
     property columns[index: integer]: TStructColumn read Getcolumn;
     property groupcount: integer read getGroupCount;
@@ -594,7 +642,7 @@ var
 
 function registerStructureDissectOverride(m: TStructureDissectOverride): integer;
 procedure unregisterStructureDissectOverride(id: integer);
-function lookupStructureName(address: ptruint; defaultName: string) : string;
+function lookupStructureName(address: ptruint; defaultName: string): string;
 
 function registerStructureNameLookup(m: TStructureNameLookup): integer;
 procedure unregisterStructureNameLookup(id: integer);
@@ -605,83 +653,90 @@ implementation
 
 uses MainUnit, mainunit2, frmStructures2ElementInfoUnit, MemoryBrowserFormUnit,
   frmStructureLinkerUnit, frmgroupscanalgoritmgeneratorunit, frmStringPointerScanUnit,
-  ProcessHandlerUnit, Parsers, LuaCaller, frmRearrangeStructureListUnit, frmstructurecompareunit;
+  ProcessHandlerUnit, Parsers, LuaCaller, frmRearrangeStructureListUnit,
+  frmstructurecompareunit;
 
 resourcestring
   rsAddressValue = 'Address: Value';
   rsUndefined = 'undefined';
 
-  rsThisIsQuiteABigStructureHowManyBytesDoYouWantToSav = 'This is quite a big '
-     +'structure. How many bytes do you want to save?';
-   rsStructureViewLock = 'Structure view lock';
-   rsPointerTo = 'Pointer';
-   rsUnnamedStructure = 'unnamed structure';
-   rsStructureDefine = 'Structure define';
-   rsStructAlreadyExists = 'The structure named %s already exists. Are you sure you want to make another structure with this name ?';
-   rsGiveTheNameForThisStructure = 'Give the name for this structure';
-   rsDoYouWantCheatEngineToTryAndFillInTheMostBasicType = 'Do you want Cheat '
-     +'Engine to try and fill in the most basic types of the struct using the '
-     +'current address?';
-   rsPleaseGiveAStartingSizeOfTheStructYouCanChangeThis = 'Please give a '
-     +'starting size of the struct (You can change this later if needed)';
+  rsThisIsQuiteABigStructureHowManyBytesDoYouWantToSav =
+    'This is quite a big ' + 'structure. How many bytes do you want to save?';
+  rsStructureViewLock = 'Structure view lock';
+  rsPointerTo = 'Pointer';
+  rsUnnamedStructure = 'unnamed structure';
+  rsStructureDefine = 'Structure define';
+  rsStructAlreadyExists =
+    'The structure named %s already exists. Are you sure you want to make another structure with this name ?';
+  rsGiveTheNameForThisStructure = 'Give the name for this structure';
+  rsDoYouWantCheatEngineToTryAndFillInTheMostBasicType =
+    'Do you want Cheat ' +
+    'Engine to try and fill in the most basic types of the struct using the ' +
+    'current address?';
+  rsPleaseGiveAStartingSizeOfTheStructYouCanChangeThis =
+    'Please give a ' + 'starting size of the struct (You can change this later if needed)';
 
-   rsMemoryDissect = 'Memory dissect';
-   rsFirstSelectAStructureYouWantToModifyOrDefine = 'First select a structure '
-     +'you want to modify or define one first';
-   rsUpdateInterval = 'Update interval';
-   rsNewInterval = 'New interval';
-   rsDissectData = 'Dissect Data';
-   rsHowManyBytesDoYouWantToShiftThisAndFollowingOffset = 'How many bytes do '
-     +'you want to shift this and following offsets? (Decimal)';
-   rsAreYouSureYouWantToDelete = 'Are you sure you want to delete %s?';
-   rsThisIsNotAValidStructureFile = 'This is not a valid structure file';
-   rsWrongVersion = 'This structure file was generated with a newer version of '
-     +'Cheat Engine. (That means there''s more than likely a new version so '
-     +'please update....)';
-   rsUnkownFileExtension = 'Unknown file extension';
-   rsAreYouSureYouWantToRemoveAllStructures = 'Are you sure you want to remove '
-     +'all structures?';
-   rsRecalculateBaseOfStructure = 'Recalculate base of structure';
-   rsGiveTheAddressOfThisElement = 'Give the address of this element';
-   rsIHaveNoIdeaWhatMeans = 'I have no idea what %s means';
-   rsChangeGroup = 'Change group';
-   rsLockMemory = 'Lock memory';
-   rsUnlockMemory = 'Unlock memory';
-   rsRenameStructure = 'Rename structure';
-   rsGiveTheNewNameOfThisStructure = 'Give the new name of this structure';
-   rsPleaseGiveAStartingOffsetToEvaluate = 'Please give a starting offset to '
-     +'evaluate';
-   rsPleaseGiveTheSizeOfTheBlockToEvaluate = 'Please give the size of the '
-     +'block to evaluate';
-   rsStructureDefiner = 'Structure definer';
-   rsWhichGroupDoYouWantToSetThisAddressTo = 'Which group do you want to set '
-     +'this address to?';
-   rsAutogeneratedFor = 'Autogenerated for %s';
-   rsStructureDissect = 'Structure dissect';
-   rsLock = 'Lock';
-   rsChangeGroup2 = 'Change Group';
-   rsDeleteAddress = 'Delete address';
+  rsMemoryDissect = 'Memory dissect';
+  rsFirstSelectAStructureYouWantToModifyOrDefine =
+    'First select a structure ' + 'you want to modify or define one first';
+  rsUpdateInterval = 'Update interval';
+  rsNewInterval = 'New interval';
+  rsDissectData = 'Dissect Data';
+  rsHowManyBytesDoYouWantToShiftThisAndFollowingOffset =
+    'How many bytes do ' + 'you want to shift this and following offsets? (Decimal)';
+  rsAreYouSureYouWantToDelete = 'Are you sure you want to delete %s?';
+  rsThisIsNotAValidStructureFile = 'This is not a valid structure file';
+  rsWrongVersion = 'This structure file was generated with a newer version of ' +
+    'Cheat Engine. (That means there''s more than likely a new version so ' +
+    'please update....)';
+  rsUnkownFileExtension = 'Unknown file extension';
+  rsAreYouSureYouWantToRemoveAllStructures =
+    'Are you sure you want to remove ' + 'all structures?';
+  rsRecalculateBaseOfStructure = 'Recalculate base of structure';
+  rsGiveTheAddressOfThisElement = 'Give the address of this element';
+  rsIHaveNoIdeaWhatMeans = 'I have no idea what %s means';
+  rsChangeGroup = 'Change group';
+  rsLockMemory = 'Lock memory';
+  rsUnlockMemory = 'Unlock memory';
+  rsRenameStructure = 'Rename structure';
+  rsGiveTheNewNameOfThisStructure = 'Give the new name of this structure';
+  rsPleaseGiveAStartingOffsetToEvaluate =
+    'Please give a starting offset to ' + 'evaluate';
+  rsPleaseGiveTheSizeOfTheBlockToEvaluate =
+    'Please give the size of the ' + 'block to evaluate';
+  rsStructureDefiner = 'Structure definer';
+  rsWhichGroupDoYouWantToSetThisAddressTo =
+    'Which group do you want to set ' + 'this address to?';
+  rsAutogeneratedFor = 'Autogenerated for %s';
+  rsStructureDissect = 'Structure dissect';
+  rsLock = 'Lock';
+  rsChangeGroup2 = 'Change Group';
+  rsDeleteAddress = 'Delete address';
 
-   rsCut = 'Cut';
-   rsCopy = 'Copy';
-   rsPaste = 'Paste';
-   rsSpider = 'Spider';
-   rsSF2GiveTheNewNameForThisStructure = 'Give the new name for this structure';
-   rsSF2StructureRename = 'Structure rename';
-   rsSF2AreYouSureYouWantToDeleteTheStructureNamed = 'Are you sure you want to delete the structure named :';
-   rsSF2AreYouSureYouWantToDeleteAllTheDefinedStructures = 'Are you sure you want to delete all the defined structures ?';
-   rsSF2AutocreateStructureSize = 'Autocreate structure size: ';
-   rsSF2ChangeValue = 'Change Value';
-   rsSF2NewValueForThisAddress = 'New value for this address:';
-   rsSF2Group1 = 'Group 1';
-   rsSF2Group = 'Group ';
-   rsSF2Group2 = 'Group ';
-   rsSF2Rename = 'Rename';
-   rsSF2DeleteGroup = 'Delete group';
-  rsSF2TheGapBetweenOffset = 'The gap between offset %x and %x is %d bytes long. Autofill this?';
+  rsCut = 'Cut';
+  rsCopy = 'Copy';
+  rsPaste = 'Paste';
+  rsSpider = 'Spider';
+  rsSF2GiveTheNewNameForThisStructure = 'Give the new name for this structure';
+  rsSF2StructureRename = 'Structure rename';
+  rsSF2AreYouSureYouWantToDeleteTheStructureNamed =
+    'Are you sure you want to delete the structure named :';
+  rsSF2AreYouSureYouWantToDeleteAllTheDefinedStructures =
+    'Are you sure you want to delete all the defined structures ?';
+  rsSF2AutocreateStructureSize = 'Autocreate structure size: ';
+  rsSF2ChangeValue = 'Change Value';
+  rsSF2NewValueForThisAddress = 'New value for this address:';
+  rsSF2Group1 = 'Group 1';
+  rsSF2Group = 'Group ';
+  rsSF2Group2 = 'Group ';
+  rsSF2Rename = 'Rename';
+  rsSF2DeleteGroup = 'Delete group';
+  rsSF2TheGapBetweenOffset =
+    'The gap between offset %x and %x is %d bytes long. Autofill this?';
   rsSF2NewGroup = '<New group>';
   rsSF2GroupPicker = 'Group picker';
-  rsSF2SecletTheGroupThisColumnShouldBecomePartOf = 'Select the group this column should become part of';
+  rsSF2SecletTheGroupThisColumnShouldBecomePartOf =
+    'Select the group this column should become part of';
   rsSF2NewGroup2 = 'New group';
   rsSF2GiveTheNewName = 'Give the new name';
   rsSF2ShadowcopyAt = 'Lock ( Shadowcopy at %s )';
@@ -694,7 +749,8 @@ resourcestring
   rsSF2AutocreatedFrom = 'Autocreated from ';
   rsSF2NameForThisGroup = 'Name for this group';
   rsFS2StructureDefine = 'Structure define';
-  rsSF2TheGroupscanCommandHasBeenCopiedToTheClipboard = 'The groupscan command has been copied to the clipboard';
+  rsSF2TheGroupscanCommandHasBeenCopiedToTheClipboard =
+    'The groupscan command has been copied to the clipboard';
   rsSF2AutocreateStructure = 'Autocreate structure';
   rsSF2DefaultSize = 'Default size:';
   rsSF2UnknownCustomType = 'Unknown custom type';
@@ -713,8 +769,9 @@ resourcestring
   rsPointer = 'Pointer';
   rsByteWithValue = 'Byte: %s';
   rs2ByteWithValue2 = '2 Byte: %s';
-  rsWarnAboutLessThan2Addresses = 'It''s not recommended to run the structure '
-    +'compare with just one address in a group';
+  rsWarnAboutLessThan2Addresses =
+    'It''s not recommended to run the structure ' +
+    'compare with just one address in a group';
 
 
 var
@@ -722,96 +779,105 @@ var
   StructureNameLookups: array of TStructureNameLookup;
 
 function registerStructureNameLookup(m: TStructureNameLookup): integer;
-var i: integer;
+var
+  i: integer;
 begin
-  for i:=0 to length(StructureNameLookups)-1 do
+  for i := 0 to length(StructureNameLookups) - 1 do
   begin
-    if assigned(StructureNameLookups[i])=false then
+    if assigned(StructureNameLookups[i]) = False then
     begin
-      StructureNameLookups[i]:=m;
-      result:=i;
+      StructureNameLookups[i] := m;
+      Result := i;
       exit;
-    end
+    end;
   end;
 
-  result:=length(StructureNameLookups);
-  setlength(StructureNameLookups, result+1);
-  StructureNameLookups[result]:=m;
+  Result := length(StructureNameLookups);
+  setlength(StructureNameLookups, Result + 1);
+  StructureNameLookups[Result] := m;
 end;
 
 procedure unregisterStructureNameLookup(id: integer);
 begin
-  if id<length(StructureNameLookups) then
+  if id < length(StructureNameLookups) then
   begin
     CleanupLuaCall(TMethod(StructureNameLookups[id]));
-    StructureNameLookups[id]:=nil;
+    StructureNameLookups[id] := nil;
   end;
 end;
 
 function registerStructureDissectOverride(m: TStructureDissectOverride): integer;
-var i: integer;
+var
+  i: integer;
 begin
-  for i:=0 to length(StructureDissectOverrides)-1 do
+  for i := 0 to length(StructureDissectOverrides) - 1 do
   begin
-    if assigned(StructureDissectOverrides[i])=false then
+    if assigned(StructureDissectOverrides[i]) = False then
     begin
-      StructureDissectOverrides[i]:=m;
-      result:=i;
+      StructureDissectOverrides[i] := m;
+      Result := i;
       exit;
-    end
+    end;
   end;
 
-  result:=length(StructureDissectOverrides);
-  setlength(StructureDissectOverrides, result+1);
-  StructureDissectOverrides[result]:=m;
+  Result := length(StructureDissectOverrides);
+  setlength(StructureDissectOverrides, Result + 1);
+  StructureDissectOverrides[Result] := m;
 end;
 
 procedure unregisterStructureDissectOverride(id: integer);
 begin
-  if id<length(StructureDissectOverrides) then
+  if id < length(StructureDissectOverrides) then
   begin
     CleanupLuaCall(TMethod(StructureDissectOverrides[id]));
-    StructureDissectOverrides[id]:=nil;
+    StructureDissectOverrides[id] := nil;
   end;
 end;
 
-function lookupStructureName(address: ptruint; defaultName: string) : string;
+function lookupStructureName(address: ptruint; defaultName: string): string;
 var
   structName: string;
   i: integer;
   found: boolean;
 begin
-  found:=false;
-  for i:=0 to length(StructureNameLookups)-1 do
+  found := False;
+  for i := 0 to length(StructureNameLookups) - 1 do
   begin
     if assigned(StructureNameLookups[i]) then
     begin
       found := StructureNameLookups[i](address, structname);
-      if found then break;
+      if found then
+        break;
     end;
   end;
-  if not found then structname:=defaultName;
-  result := structname;
+  if not found then
+    structname := defaultName;
+  Result := structname;
 end;
 
-function DisplaymethodToString(d:TdisplayMethod): string;
+function DisplaymethodToString(d: TdisplayMethod): string;
 begin
-  result:='';
+  Result := '';
   case d of
-    dtUnsignedInteger: result:=rsUnsignedInteger;
-    dtSignedInteger: result:=rsSignedInteger;
-    dtHexadecimal: result:=rsHexadecimal;
+    dtUnsignedInteger: Result := rsUnsignedInteger;
+    dtSignedInteger: Result := rsSignedInteger;
+    dtHexadecimal: Result := rsHexadecimal;
   end;
 end;
 
 function StringToDisplayMethod(s: string): TdisplayMethod;
 begin
-  s:=LowerCase(s);
-  result:=dtUnsignedInteger;
+  s := LowerCase(s);
+  Result := dtUnsignedInteger;
 
-  if s='unsigned integer' then result:=dtUnsignedInteger else
-  if s='signed integer' then result:=dtSignedInteger else
-  if s='hexadecimal' then result:=dtHexadecimal;
+  if s = 'unsigned integer' then
+    Result := dtUnsignedInteger
+  else
+  if s = 'signed integer' then
+    Result := dtSignedInteger
+  else
+  if s = 'hexadecimal' then
+    Result := dtHexadecimal;
 end;
 
 {Struct}
@@ -821,31 +887,36 @@ var
   doc: TDOMDocument;
   elementnode: TDOMElement;
 begin
-  doc:=elementnodes.OwnerDocument;
-  elementnode:=TDOMElement(elementnodes.AppendChild(doc.CreateElement('Element')));
+  doc := elementnodes.OwnerDocument;
+  elementnode := TDOMElement(elementnodes.AppendChild(doc.CreateElement('Element')));
 
   elementnode.SetAttribute('Offset', IntToStr(self.Offset));
-  if self.Name<>'' then
+
+  elementnode.SetAttribute('OffsetHex', IntToHex(self.Offset, 4));
+
+  elementnode.SetAttribute('Bytesize', IntToStr(self.Bytesize));
+
+  elementnode.SetAttribute('Vartype', VariableTypeToString(self.VarType));
+
+  if self.Name <> '' then
     elementnode.SetAttribute('Description', utf8toansi(self.Name));
 
   if ExpandChangesAddress then
     elementnode.SetAttribute('ExpandChangesAddress', '1');
 
-  elementnode.SetAttribute('Vartype', VariableTypeToString(self.VarType));
-  if self.CustomType<>nil then
-    elementnode.SetAttribute('Customtype', self.CustomType.name);
+  if self.CustomType <> nil then
+    elementnode.SetAttribute('Customtype', self.CustomType.Name);
 
-  elementnode.SetAttribute('Bytesize', IntToStr(self.Bytesize));
   elementnode.SetAttribute('DisplayMethod', DisplaymethodToString(self.DisplayMethod));
 
-  if self.ChildStructStart<>0 then
+  if self.ChildStructStart <> 0 then
     elementnode.SetAttribute('ChildStructStart', IntToStr(self.ChildStructStart));
 
-  if backgroundcolor<>clWindow then
+  if backgroundcolor <> clWindow then
     elementnode.SetAttribute('BackgroundColor', IntToHex(backgroundcolor, 6));
 
 
-  if (self.isPointer) and (self.ChildStruct<>nil) then
+  if (self.isPointer) and (self.ChildStruct <> nil) then
   begin
     if (self.ChildStruct.isInGlobalStructList) then
     begin
@@ -855,9 +926,10 @@ begin
     else
     begin
       //local struct, only save if allowed
-      if (parent<>nil) and (parent.doNotSaveLocal=false) then  //save this whole struct
+      if (parent <> nil) and (parent.doNotSaveLocal = False) then
+        //save this whole struct
       begin
-       ChildStruct.fRLECompression:=parent.fRLECompression;
+        ChildStruct.fRLECompression := parent.fRLECompression;
         ChildStruct.WriteToXMLNode(elementnode);
       end;
     end;
@@ -867,74 +939,74 @@ end;
 
 function TStructelement.getParent: TDissectedStruct;
 begin
-  result:=fParent;
+  Result := fParent;
 end;
 
 function TStructelement.getOffset: integer;
 begin
-  result:=fOffset;
+  Result := fOffset;
 end;
 
 procedure TStructelement.setOffset(newOffset: integer);
 begin
-  if newOffset<>fOffset then
+  if newOffset <> fOffset then
   begin
-    fOffset:=newOffset;
+    fOffset := newOffset;
     parent.sortElements;
   end;
 end;
 
 function TStructelement.getName: string;
 begin
-  result:=fname;
+  Result := fname;
 end;
 
 procedure TStructelement.setName(newname: string);
 begin
-  if newname<>fname then
+  if newname <> fname then
   begin
-    fname:=newname;
+    fname := newname;
     parent.DoElementChangeNotification(Self);
   end;
 end;
 
 function TStructelement.getVartype: TVariableType;
 begin
-  result:=fVartype;
+  Result := fVartype;
 end;
 
 procedure TStructelement.setVartype(newVartype: TVariableType);
 begin
-  if newVartype<>fVartype then
+  if newVartype <> fVartype then
   begin
-    fVartype:=newVartype;
+    fVartype := newVartype;
     parent.DoElementChangeNotification(self);
   end;
 end;
 
 function TStructelement.getCustomType: TCustomType;
 begin
-  result:=fCustomType;
+  Result := fCustomType;
 end;
 
 procedure TStructelement.setCustomType(newCustomtype: TcustomType);
 begin
-  if newCustomtype<>fCustomType then
+  if newCustomtype <> fCustomType then
   begin
-    fCustomType:=newCustomtype;
+    fCustomType := newCustomtype;
     parent.DoElementChangeNotification(self);
   end;
 end;
 
 function TStructelement.getDisplayMethod: TdisplayMethod;
 begin
-  result:=fDisplayMethod;
+  Result := fDisplayMethod;
 end;
 
 procedure TStructelement.setDisplayMethod(newDisplayMethod: TdisplayMethod);
 begin
-  if newDisplayMethod<>fDisplayMethod then
-    fDisplayMethod:=newDisplayMethod;
+  if newDisplayMethod <> fDisplayMethod then
+    fDisplayMethod := newDisplayMethod;
 
   parent.DoElementChangeNotification(self);
 end;
@@ -942,99 +1014,104 @@ end;
 function TStructelement.getBytesize: integer;
 begin
   if vartype in [vtByteArray, vtString, vtUnicodeString] then
-    result:=fbytesize
+    Result := fbytesize
   else
   begin
-    result:=1;
+    Result := 1;
     case vartype of
-      vtByte: result:=1;
-      vtWord: result:=2;
-      vtDword: result:=4;
-      vtQword: result:=8;
-      vtSingle: result:=4;
-      vtDouble: result:=8;
-      vtPointer: result:=processhandler.pointersize;
-      vtCustom: if customtype<>nil then result:=CustomType.bytesize;
+      vtByte: Result := 1;
+      vtWord: Result := 2;
+      vtDword: Result := 4;
+      vtQword: Result := 8;
+      vtSingle: Result := 4;
+      vtDouble: Result := 8;
+      vtPointer: Result := processhandler.pointersize;
+      vtCustom: if customtype <> nil then
+          Result := CustomType.bytesize;
     end;
   end;
 end;
 
 procedure TStructelement.setBytesize(newByteSize: integer);
 begin
-  if newByteSize<>fbytesize then
+  if newByteSize <> fbytesize then
   begin
-    fbytesize:=max(1,newByteSize); //at least 1 byte
+    fbytesize := max(1, newByteSize); //at least 1 byte
     parent.DoElementChangeNotification(self);
   end;
 end;
 
 function TStructelement.getBackgroundColor: integer;
 begin
-  result:=fBackgroundColor;
+  Result := fBackgroundColor;
 end;
 
 procedure TStructelement.setBackgroundColor(c: TColor);
 begin
-  fBackgroundColor:=c;
+  fBackgroundColor := c;
   parent.DoElementChangeNotification(self);
 end;
 
-function TStructelement.getValue(address: ptruint; hashexprefix: boolean=false; showAsHexOverride: boolean=false): string;
-var vt: TVariableType;
+function TStructelement.getValue(address: ptruint; hashexprefix: boolean = False;
+  showAsHexOverride: boolean = False): string;
+var
+  vt: TVariableType;
   ashex: boolean;
 begin
-  if vartype=vtPointer then
+  if vartype = vtPointer then
   begin
-    ashex:=true;
-    result:=rsP;
+    ashex := True;
+    Result := rsP;
 
     if processhandler.is64Bit then
-      vt:=vtQword
+      vt := vtQword
     else
-      vt:=vtDword;
+      vt := vtDword;
   end
   else
   begin
-    result:='';
-    vt:=vartype;
-    ashex:=displaymethod=dtHexadecimal;
+    Result := '';
+    vt := vartype;
+    ashex := displaymethod = dtHexadecimal;
   end;
 
 
   if showAsHexOverride then
-    ashex:=true;
+    ashex := True;
 
   if hashexprefix and ashex then
-    result:='0x'; //also takes care of P->
+    Result := '0x'; //also takes care of P->
 
 
-  result:=result+readAndParseAddress(address, vt,  fCustomType, ashex, displayMethod=dtSignedInteger, bytesize);
+  Result := Result + readAndParseAddress(address, vt, fCustomType,
+    ashex, displayMethod = dtSignedInteger, bytesize);
 end;
 
-procedure TStructelement.setvalue(address: ptruint; value: string);
-var hex: boolean;
+procedure TStructelement.setvalue(address: ptruint; Value: string);
+var
+  hex: boolean;
   vt: TVariableType;
 begin
-  if vartype=vtPointer then
+  if vartype = vtPointer then
   begin
     if processhandler.is64Bit then
-      vt:=vtQword
+      vt := vtQword
     else
-      vt:=vtDword;
-    hex:=true;
+      vt := vtDword;
+    hex := True;
 
     //strip optional P-> part
-    if copy(value, 1,3)=rsP then
-      value:=copy(value,4, length(value)-3);
+    if copy(Value, 1, 3) = rsP then
+      Value := copy(Value, 4, length(Value) - 3);
   end
   else
   begin
-    vt:=vartype;
-    hex:=displaymethod=dtHexadecimal;
+    vt := vartype;
+    hex := displaymethod = dtHexadecimal;
   end;
 
   try
-    ParseStringAndWriteToAddress(value, address, vt, hex, fCustomType);
+    ParseStringAndWriteToAddress(Value, address, vt, hex, fCustomType);
     parent.DoElementChangeNotification(self);
   except
   end;
@@ -1042,104 +1119,108 @@ end;
 
 function TStructelement.getValueFromBase(baseaddress: ptruint): string;
 begin
-  result:=getvalue(baseaddress+offset);
+  Result := getvalue(baseaddress + offset);
 end;
 
-procedure TStructelement.setValueFromBase(baseaddress: ptruint; value: string);
+procedure TStructelement.setValueFromBase(baseaddress: ptruint; Value: string);
 begin
-  setvalue(baseaddress+offset, value);
+  setvalue(baseaddress + offset, Value);
 end;
 
 function TStructelement.isPointer: boolean;
 begin
-  result:=vartype=vtPointer;
+  Result := vartype = vtPointer;
 end;
 
 function TStructelement.getChildStruct: TDissectedStruct;
 begin
-  result:=fchildstruct;
+  Result := fchildstruct;
 end;
 
 procedure TStructelement.setChildStruct(newChildStruct: TDissectedStruct);
 begin
-  fchildstruct:=newChildStruct;
+  fchildstruct := newChildStruct;
   parent.DoElementChangeNotification(self);
 end;
 
 procedure TStructelement.setChildStructStart(offset: integer);
 begin
-  fchildstructstart:=offset;
+  fchildstructstart := offset;
   parent.DoElementChangeNotification(self);
 end;
 
 function TStructelement.getIndex: integer;
 begin
-  result:=parent.getIndexOf(self);
+  Result := parent.getIndexOf(self);
 end;
 
-procedure TStructelement.AutoCreateChildStruct(name: string; address: ptruint);
-var c: TDissectedStruct;
+procedure TStructelement.AutoCreateChildStruct(Name: string; address: ptruint);
+var
+  c: TDissectedStruct;
   addressdata: TAddressData;
   UsedOverride: boolean;
   i: integer;
 begin
-  if isPointer and (ChildStruct=nil) then
+  if isPointer and (ChildStruct = nil) then
   begin
-    c:=TDissectedStruct.create(name);
+    c := TDissectedStruct.Create(Name);
 
     if symhandler.GetLayoutFromAddress(address, addressdata) then
     begin
       c.fillFromDotNetAddressData(addressdata);
-      c.name:=addressdata.classname;
-      if c.count>0 then
+      c.Name := addressdata.ClassName;
+      if c.Count > 0 then
       begin
-        ChildStruct:=c;
-        ChildStructStart:=address-addressdata.startaddress;
+        ChildStruct := c;
+        ChildStructStart := address - addressdata.startaddress;
       end
       else
       begin
-        freeandnil(c);
+        FreeAndNil(c);
       end;
     end
     else
     begin
-      UsedOverride:=false;
-      for i:=0 to length(StructureDissectOverrides)-1 do
+      UsedOverride := False;
+      for i := 0 to length(StructureDissectOverrides) - 1 do
       begin
         if assigned(StructureDissectOverrides[i]) then
         begin
-          UsedOverride:=StructureDissectOverrides[i](c, address);
-          if UsedOverride then break;
+          UsedOverride := StructureDissectOverrides[i](c, address);
+          if UsedOverride then
+            break;
         end;
       end;
-      
+
       if not UsedOverride then
         c.autoGuessStruct(address, 0, parent.autoCreateStructsize);
 
-      if c.count>0 then
-        ChildStruct:=c
+      if c.Count > 0 then
+        ChildStruct := c
       else
-        freeandnil(c);
+        FreeAndNil(c);
     end;
 
   end;
 end;
 
-destructor TStructelement.destroy;
+destructor TStructelement.Destroy;
 begin
   parent.removeElement(self);
-  inherited destroy;
+  inherited Destroy;
 end;
 
-constructor TStructelement.create(parent:TDissectedStruct);
+constructor TStructelement.Create(parent: TDissectedStruct);
 begin
-  fparent:=parent;
-  fbytesize:=1;
-  fbackgroundcolor:=clWindow;
+  fparent := parent;
+  fbytesize := 1;
+  fbackgroundcolor := clWindow;
 end;
 
-constructor TStructelement.createFromXMLElement(parent:TDissectedStruct; element: tdomelement);
-var ChildStructStartS: string;
+constructor TStructelement.createFromXMLElement(parent: TDissectedStruct;
+  element: tdomelement);
+var
+  ChildStructStartS: string;
   childnode: TDOMElement;
   childname: string;
 
@@ -1147,37 +1228,37 @@ var ChildStructStartS: string;
 
   e: TDOMAttr;
 begin
-  fparent:=parent;
-  fbackgroundcolor:=clWindow;
-  self.foffset:=strtoint(element.GetAttribute('Offset'));
-  self.fname:=AnsiToUtf8(element.GetAttribute('Description'));
-  self.fvartype:=StringToVariableType(element.GetAttribute('Vartype'));
-  self.fCustomType:=GetCustomTypeFromName(element.GetAttribute('Customtype'));
-  self.fdisplayMethod:=StringToDisplayMethod(element.GetAttribute('DisplayMethod'));
-  self.fbytesize:=strtoint(element.GetAttribute('Bytesize'));
-  s:=element.GetAttribute('BackgroundColor');
-  if s<>'' then
-    self.fbackgroundcolor:=HexStrToInt(s);
+  fparent := parent;
+  fbackgroundcolor := clWindow;
+  self.foffset := StrToInt(element.GetAttribute('Offset'));
+  self.fname := AnsiToUtf8(element.GetAttribute('Description'));
+  self.fvartype := StringToVariableType(element.GetAttribute('Vartype'));
+  self.fCustomType := GetCustomTypeFromName(element.GetAttribute('Customtype'));
+  self.fdisplayMethod := StringToDisplayMethod(element.GetAttribute('DisplayMethod'));
+  self.fbytesize := StrToInt(element.GetAttribute('Bytesize'));
+  s := element.GetAttribute('BackgroundColor');
+  if s <> '' then
+    self.fbackgroundcolor := HexStrToInt(s);
 
-  self.fExpandChangesAddress:=element.GetAttribute('ExpandChangesAddress')='1';
+  self.fExpandChangesAddress := element.GetAttribute('ExpandChangesAddress') = '1';
 
 
-  ChildStructStartS:=element.GetAttribute('ChildStructStart');
-  if ChildStructStartS<>'' then
-    fChildStructStart:=strtoint(ChildStructStartS)
+  ChildStructStartS := element.GetAttribute('ChildStructStart');
+  if ChildStructStartS <> '' then
+    fChildStructStart := StrToInt(ChildStructStartS)
   else
-    fChildStructStart:=0;
+    fChildStructStart := 0;
 
 
 
-  if fvartype=vtPointer then
+  if fvartype = vtPointer then
   begin
     //check if it has a child struct
-    childnode:=TDOMElement(element.FindNode('Structure'));
-    if childnode<>nil then
-      fchildstruct:=TDissectedStruct.createFromXMLNode(childnode)
+    childnode := TDOMElement(element.FindNode('Structure'));
+    if childnode <> nil then
+      fchildstruct := TDissectedStruct.createFromXMLNode(childnode)
     else
-      delayLoadedStructname:=AnsiToUtf8(element.GetAttribute('ChildStruct'));
+      delayLoadedStructname := AnsiToUtf8(element.GetAttribute('ChildStruct'));
   end;
 
 end;
@@ -1187,157 +1268,165 @@ end;
 
 function TDissectedStruct.getName: string;
 begin
-  result:=structname;
+  Result := structname;
 end;
 
 procedure TDissectedStruct.setName(newname: string);
 begin
-  structname:=newname;
+  structname := newname;
   DoFullStructChangeNotification;
 end;
 
 function TDissectedStruct.getElementCount: integer;
 begin
-  if structelementlist<>nil then
-    result:=structelementlist.Count
+  if structelementlist <> nil then
+    Result := structelementlist.Count
   else
-    result:=0;
+    Result := 0;
 end;
 
 function TDissectedStruct.getElement(index: integer): TStructelement;
 begin
 
-  if (structelementlist<>nil) and ((index>=0) and (index<structelementlist.Count)) then
-    result:=TStructelement(structelementlist.Items[index])
+  if (structelementlist <> nil) and ((index >= 0) and
+    (index < structelementlist.Count)) then
+    Result := TStructelement(structelementlist.Items[index])
   else
-    result:=nil;
+    Result := nil;
 end;
 
 function TDissectedStruct.isUpdating: boolean;
 begin
 
-  result:=fUpdateCounter>0;
+  Result := fUpdateCounter > 0;
 end;
 
-function elementsort(Item1, Item2: Pointer): Integer;
+function elementsort(Item1, Item2: Pointer): integer;
 begin
-  result:=CompareValue(TStructelement(item1).offset, TStructelement(item2).offset);
+  Result := CompareValue(TStructelement(item1).offset, TStructelement(item2).offset);
 end;
 
 
 procedure TDissectedStruct.sortElements;
 begin
-  if isUpdating=false then
+  if isUpdating = False then
   begin
     structelementlist.Sort(elementsort);
     DoFullStructChangeNotification;
   end
   else
-    updateCalledSort:=true;
+    updateCalledSort := True;
 
 end;
 
 procedure TDissectedStruct.DoOptionsChangedNotification;
 //update all windows with this as the current structure
-var i: integer;
+var
+  i: integer;
 begin
-  for i:=0 to frmStructures2.Count-1 do
+  for i := 0 to frmStructures2.Count - 1 do
     TfrmStructures2(frmStructures2[i]).onStructOptionsChange(self);
 
 end;
 
 
 procedure TDissectedStruct.DoFullStructChangeNotification;
-var i: integer;
+var
+  i: integer;
 begin
-  if isUpdating=false then
+  if isUpdating = False then
   begin
-    for i:=0 to frmStructures2.Count-1 do
+    for i := 0 to frmStructures2.Count - 1 do
       TfrmStructures2(frmStructures2[i]).onFullStructChange(self);
   end
   else
-    fullstructupdate:=true;
+    fullstructupdate := True;
 end;
 
 
 
 procedure TDissectedStruct.DoElementChangeNotification(element: TStructelement);
-var i: integer;
+var
+  i: integer;
 begin
-  mainform.editedsincelastsave:=true;
+  mainform.editedsincelastsave := True;
 
-  if isUpdating=false then
+  if isUpdating = False then
   begin
-    for i:=0 to frmStructures2.Count-1 do
+    for i := 0 to frmStructures2.Count - 1 do
       TfrmStructures2(frmStructures2[i]).onElementChange(self, element);
   end
   else
   begin
-    if updatedelements.IndexOf(element)=-1 then  //add this element to the list of updated elements that endupdate should then update
+    if updatedelements.IndexOf(element) = -1 then
+      //add this element to the list of updated elements that endupdate should then update
       updatedelements.Add(element);
 
-    updateChangedInformation:=true;
+    updateChangedInformation := True;
   end;
 end;
 
 procedure TDissectedStruct.beginUpdate;
 begin
-  inc(fUpdateCounter);
-  updatecalledSort:=false;
-  updateChangedInformation:=false;
-  fullstructupdate:=false;
+  Inc(fUpdateCounter);
+  updatecalledSort := False;
+  updateChangedInformation := False;
+  fullstructupdate := False;
 
-  if updatedelements=nil then
-    updatedelements:=TList.Create;
+  if updatedelements = nil then
+    updatedelements := TList.Create;
 
-  updatedelements.clear;
+  updatedelements.Clear;
 end;
 
 procedure TDissectedStruct.endUpdate;
-var i: integer;
+var
+  i: integer;
 begin
   if isUpdating then
-    dec(fUpdateCounter);
+    Dec(fUpdateCounter);
 
-  if fUpdateCounter=0 then
+  if fUpdateCounter = 0 then
   begin
     if updatecalledsort then
     begin
       sortElements; //sort them now
-      updatecalledSort:=false;
+      updatecalledSort := False;
     end
     else
     if fullstructupdate then
     begin
       DoFullStructChangeNotification;
-      fullstructupdate:=false;
+      fullstructupdate := False;
     end
     else //no need to call the individual updates if sort was done.
-    if updateChangedInformation then //not set for changing the offset, only for other visual stuff
+    if updateChangedInformation then
+      //not set for changing the offset, only for other visual stuff
     begin
-      for i:=0 to updatedelements.count-1 do
+      for i := 0 to updatedelements.Count - 1 do
         DoElementChangeNotification(TStructelement(updatedelements[i]));
 
-      updatedelements.clear;
-      updateChangedInformation:=false;
+      updatedelements.Clear;
+      updateChangedInformation := False;
     end;
-
 
   end;
 end;
 
-function TDissectedStruct.addElement(name: string=''; offset: integer=0; vartype: TVariableType=vtByte; customType: TCustomtype=nil; bytesize: integer=0; childstruct: TDissectedStruct=nil): TStructelement;
+function TDissectedStruct.addElement(Name: string = ''; offset: integer = 0;
+  vartype: TVariableType = vtByte; customType: TCustomtype = nil;
+  bytesize: integer = 0; childstruct: TDissectedStruct = nil): TStructelement;
 begin
   beginUpdate;
-  result:=TStructelement.create(self);
-  structelementlist.Add(result);
+  Result := TStructelement.Create(self);
+  structelementlist.Add(Result);
 
-  result.name:=name;
-  result.offset:=offset;
-  result.vartype:=vartype;
-  result.CustomType:=customType;
-  result.childstruct:=childstruct;
-  result.bytesize:=bytesize;
+  Result.Name := Name;
+  Result.offset := offset;
+  Result.vartype := vartype;
+  Result.CustomType := customType;
+  Result.childstruct := childstruct;
+  Result.bytesize := bytesize;
 
   sortElements;
   endUpdate;
@@ -1350,14 +1439,15 @@ begin
   DoFullStructChangeNotification;
 end;
 
-procedure TDissectedStruct.delete(index: integer);
+procedure TDissectedStruct.Delete(index: integer);
 begin
   removeElement(element[index]);
 end;
 
 procedure TDissectedStruct.fillGaps(structbase: ptruint; askiftoobig: boolean);
 //Will find gaps and fill them up. If a gap is bigger than 512, ask the user, or skip if not asked
-var i,j: integer;
+var
+  i, j: integer;
   size: integer;
   smallestacceptedsize: integer;
   v: TVariableType;
@@ -1365,52 +1455,57 @@ var i,j: integer;
   newoffset: integer;
   e: TStructelement;
 begin
-  i:=1;
-  smallestacceptedsize:=512;
-  while i<count do
+  i := 1;
+  smallestacceptedsize := 512;
+  while i < Count do
   begin
-    size:=element[i].Offset-(element[i-1].Offset+element[i-1].Bytesize);
-    if size>0 then
+    size := element[i].Offset - (element[i - 1].Offset + element[i - 1].Bytesize);
+    if size > 0 then
     begin
-      if size>smallestacceptedsize then
+      if size > smallestacceptedsize then
       begin
-        if (askiftoobig=false) or (MessageDlg(format(rsSF2TheGapBetweenOffset, [element[i-1].Offset, element[i-1].Offset, size]), mtConfirmation, [mbyes,mbno],0)<>mryes) then
+        if (askiftoobig = False) or
+          (MessageDlg(format(rsSF2TheGapBetweenOffset,
+          [element[i - 1].Offset, element[i - 1].Offset, size]),
+          mtConfirmation, [mbYes, mbNo], 0) <> mrYes) then
         begin
-          inc(i);
+          Inc(i);
           continue;
         end;
       end;
-      smallestacceptedsize:=max(smallestacceptedsize, size); //update the smallestacceptedsize
+      smallestacceptedsize := max(smallestacceptedsize, size);
+      //update the smallestacceptedsize
 
       //and fill this range
-      v:=element[i-1].VarType;
-      newoffset:=element[i-1].Offset+element[i-1].Bytesize;
-      if (v in [vtDword, vtSingle]) and (size in [4,8,12,16,20,24,32]) then //previous was a 4 byte type and nicely aligned, so fill with the same type
+      v := element[i - 1].VarType;
+      newoffset := element[i - 1].Offset + element[i - 1].Bytesize;
+      if (v in [vtDword, vtSingle]) and (size in [4, 8, 12, 16, 20, 24, 32]) then
+        //previous was a 4 byte type and nicely aligned, so fill with the same type
       begin
-        for j:=0 to (size div 4)-1 do
+        for j := 0 to (size div 4) - 1 do
         begin
-          e:=addElement('', newOffset, v);
+          e := addElement('', newOffset, v);
 
           if fDefaultHex and (v in [vtByte..vtQword]) then
-            e.DisplayMethod:=dtHexadecimal;
+            e.DisplayMethod := dtHexadecimal;
 
-          inc(newOffset,4);
+          Inc(newOffset, 4);
         end;
       end
       else
       begin
         //not really sure what to fill it with so use the autoguess method
-        autoGuessStruct(structbase+newoffset, newoffset, size);
+        autoGuessStruct(structbase + newoffset, newoffset, size);
       end;
     end;
 
-    inc(i);
+    Inc(i);
   end;
 end;
 
-procedure TDissectedStruct.fillFromDotNetAddressData(const data: TAddressData);
+procedure TDissectedStruct.fillFromDotNetAddressData(const Data: TAddressData);
 var
-  i,j: integer;
+  i, j: integer;
   x: ptruint;
   e: TStructelement;
   buf: pbytearray;
@@ -1424,117 +1519,161 @@ var
   elemsize: integer;
 begin
 
-  if (frmStructuresConfig<>nil) and frmStructuresConfig.cbAutoGuessCustomTypes.checked then
-    ctp:=@customtype
+  if (frmStructuresConfig <> nil) and
+    frmStructuresConfig.cbAutoGuessCustomTypes.Checked then
+    ctp := @customtype
   else
-    ctp:=nil;
+    ctp := nil;
 
 
-  e:=addElement('Vtable',0, vtPointer);
+  e := addElement('Vtable', 0, vtPointer);
 
-  if (data.objecttype = ELEMENT_TYPE_ARRAY) or  (data.objecttype = ELEMENT_TYPE_SZARRAY) then //elements are integral, rather than named fields
+  if (Data.objecttype = ELEMENT_TYPE_ARRAY) or (Data.objecttype = ELEMENT_TYPE_SZARRAY)
+  then //elements are integral, rather than named fields
   begin
-    readprocessmemory(processhandle,pointer(data.startaddress+data.countoffset),@j,sizeof(j),x); //read array length (always flat addressing, regardless of rank)
-    addElement('Number of Elements', data.countoffset, vtDword);
+    readprocessmemory(processhandle, pointer(Data.startaddress + Data.countoffset),
+      @j, sizeof(j), x); //read array length (always flat addressing, regardless of rank)
+    addElement('Number of Elements', Data.countoffset, vtDword);
     //arbitrarily decide that we only want to see the first 100 elements...
-    if j > 100 then //maybe prompt instead, but it's easy enough to add elements later and some
-      j := 100; //structures (Terraria's tiles, eg, are 2*10^9 elements) and it's either too slow or not possible to diagram
-    for i:=0 to j-1 do
+    if j > 100 then
+      //maybe prompt instead, but it's easy enough to add elements later and some
+      j := 100;
+    //structures (Terraria's tiles, eg, are 2*10^9 elements) and it's either too slow or not possible to diagram
+    for i := 0 to j - 1 do
     begin
-      e:=addElement(data.classname + '['+inttostr(i)+']', data.firstelementoffset+i*data.elementsize, vtPointer);
-      case data.elementtype of
-        ELEMENT_TYPE_END            : e.VarType:=vtDword;
-        ELEMENT_TYPE_VOID           : e.VarType:=vtDword;
-        ELEMENT_TYPE_BOOLEAN        : e.VarType:=vtByte;
-        ELEMENT_TYPE_CHAR           : begin e.VarType:=vtUnicodeString; e.setBytesize(256); end;
-        ELEMENT_TYPE_I1             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtByte; end;
-        ELEMENT_TYPE_U1             : e.VarType:=vtByte;
-        ELEMENT_TYPE_I2             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtWord; end;
-        ELEMENT_TYPE_U2             : e.VarType:=vtWord;
-        ELEMENT_TYPE_I4             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtDWord; end;
-        ELEMENT_TYPE_U4             : e.VarType:=vtDWord;
-        ELEMENT_TYPE_I8             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtQWord; end;
-        ELEMENT_TYPE_U8             : e.VarType:=vtQWord;
-        ELEMENT_TYPE_R4             : e.VarType:=vtSingle;
-        ELEMENT_TYPE_R8             : e.VarType:=vtDouble;
-      end
+      e := addElement(Data.ClassName + '[' + IntToStr(i) + ']',
+        Data.firstelementoffset + i * Data.elementsize, vtPointer);
+      case Data.elementtype of
+        ELEMENT_TYPE_END: e.VarType := vtDword;
+        ELEMENT_TYPE_VOID: e.VarType := vtDword;
+        ELEMENT_TYPE_BOOLEAN: e.VarType := vtByte;
+        ELEMENT_TYPE_CHAR:
+        begin
+          e.VarType := vtUnicodeString;
+          e.setBytesize(256);
+        end;
+        ELEMENT_TYPE_I1:
+        begin
+          e.DisplayMethod := dtSignedInteger;
+          e.VarType := vtByte;
+        end;
+        ELEMENT_TYPE_U1: e.VarType := vtByte;
+        ELEMENT_TYPE_I2:
+        begin
+          e.DisplayMethod := dtSignedInteger;
+          e.VarType := vtWord;
+        end;
+        ELEMENT_TYPE_U2: e.VarType := vtWord;
+        ELEMENT_TYPE_I4:
+        begin
+          e.DisplayMethod := dtSignedInteger;
+          e.VarType := vtDWord;
+        end;
+        ELEMENT_TYPE_U4: e.VarType := vtDWord;
+        ELEMENT_TYPE_I8:
+        begin
+          e.DisplayMethod := dtSignedInteger;
+          e.VarType := vtQWord;
+        end;
+        ELEMENT_TYPE_U8: e.VarType := vtQWord;
+        ELEMENT_TYPE_R4: e.VarType := vtSingle;
+        ELEMENT_TYPE_R8: e.VarType := vtDouble;
+      end;
     end;
   end;
 
-  if length(data.fields)>0 then
+  if length(Data.fields) > 0 then
   begin
-    bufsize:=data.fields[length(data.fields)-1].offset+16;
+    bufsize := Data.fields[length(Data.fields) - 1].offset + 16;
     getmem(buf, bufsize);
-    readprocessmemory(processhandle,pointer(data.startaddress),@buf[0],bufsize,x);
+    readprocessmemory(processhandle, pointer(Data.startaddress), @buf[0], bufsize, x);
 
 
     beginupdate;
     try
-      for i:=0 to length(data.fields)-1 do
+      for i := 0 to length(Data.fields) - 1 do
       begin
-        e:=addElement(data.fields[i].name, data.fields[i].offset);
+        e := addElement(Data.fields[i].Name, Data.fields[i].offset);
 
-        e.DisplayMethod:=dtUnSignedInteger;
+        e.DisplayMethod := dtUnSignedInteger;
 
 
-        case data.fields[i].fieldtype of
-          ELEMENT_TYPE_END            : e.VarType:=vtDword;
-          ELEMENT_TYPE_VOID           : e.VarType:=vtDword;
-          ELEMENT_TYPE_BOOLEAN        : e.VarType:=vtByte;
-          ELEMENT_TYPE_CHAR           : begin e.VarType:=vtUnicodeString; e.setBytesize(256); end;
-          ELEMENT_TYPE_I1             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtByte; end;
-          ELEMENT_TYPE_U1             : e.VarType:=vtByte;
-          ELEMENT_TYPE_I2             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtWord; end;
-          ELEMENT_TYPE_U2             : e.VarType:=vtWord;
-          ELEMENT_TYPE_I4             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtDWord; end;
-          ELEMENT_TYPE_U4             : e.VarType:=vtDWord;
-          ELEMENT_TYPE_I8             : begin e.DisplayMethod:=dtSignedInteger; e.VarType:=vtQWord; end;
-          ELEMENT_TYPE_U8             : e.VarType:=vtQWord;
-          ELEMENT_TYPE_R4             : e.VarType:=vtSingle;
-          ELEMENT_TYPE_R8             : e.VarType:=vtDouble;
-          ELEMENT_TYPE_STRING         : e.VarType:=vtPointer;
-          ELEMENT_TYPE_PTR            : e.VarType:=vtPointer;
-          ELEMENT_TYPE_BYREF          : e.VarType:=vtPointer;
-         // ELEMENT_TYPE_VALUETYPE      : e.VarType:=vtPointer;
-          ELEMENT_TYPE_CLASS          : e.VarType:=vtPointer;
-          ELEMENT_TYPE_VAR            : e.VarType:=vtPointer;
-          ELEMENT_TYPE_ARRAY          : e.VarType:=vtPointer;
-          ELEMENT_TYPE_GENERICINST    : e.VarType:=vtPointer;
-          ELEMENT_TYPE_TYPEDBYREF     : e.VarType:=vtPointer;
-          ELEMENT_TYPE_FNPTR          : e.VarType:=vtPointer;
-          ELEMENT_TYPE_OBJECT         : e.VarType:=vtPointer;
-          ELEMENT_TYPE_SZARRAY        : e.VarType:=vtPointer;
+        case Data.fields[i].fieldtype of
+          ELEMENT_TYPE_END: e.VarType := vtDword;
+          ELEMENT_TYPE_VOID: e.VarType := vtDword;
+          ELEMENT_TYPE_BOOLEAN: e.VarType := vtByte;
+          ELEMENT_TYPE_CHAR:
+          begin
+            e.VarType := vtUnicodeString;
+            e.setBytesize(256);
+          end;
+          ELEMENT_TYPE_I1:
+          begin
+            e.DisplayMethod := dtSignedInteger;
+            e.VarType := vtByte;
+          end;
+          ELEMENT_TYPE_U1: e.VarType := vtByte;
+          ELEMENT_TYPE_I2:
+          begin
+            e.DisplayMethod := dtSignedInteger;
+            e.VarType := vtWord;
+          end;
+          ELEMENT_TYPE_U2: e.VarType := vtWord;
+          ELEMENT_TYPE_I4:
+          begin
+            e.DisplayMethod := dtSignedInteger;
+            e.VarType := vtDWord;
+          end;
+          ELEMENT_TYPE_U4: e.VarType := vtDWord;
+          ELEMENT_TYPE_I8:
+          begin
+            e.DisplayMethod := dtSignedInteger;
+            e.VarType := vtQWord;
+          end;
+          ELEMENT_TYPE_U8: e.VarType := vtQWord;
+          ELEMENT_TYPE_R4: e.VarType := vtSingle;
+          ELEMENT_TYPE_R8: e.VarType := vtDouble;
+          ELEMENT_TYPE_STRING: e.VarType := vtPointer;
+          ELEMENT_TYPE_PTR: e.VarType := vtPointer;
+          ELEMENT_TYPE_BYREF: e.VarType := vtPointer;
+          // ELEMENT_TYPE_VALUETYPE      : e.VarType:=vtPointer;
+          ELEMENT_TYPE_CLASS: e.VarType := vtPointer;
+          ELEMENT_TYPE_VAR: e.VarType := vtPointer;
+          ELEMENT_TYPE_ARRAY: e.VarType := vtPointer;
+          ELEMENT_TYPE_GENERICINST: e.VarType := vtPointer;
+          ELEMENT_TYPE_TYPEDBYREF: e.VarType := vtPointer;
+          ELEMENT_TYPE_FNPTR: e.VarType := vtPointer;
+          ELEMENT_TYPE_OBJECT: e.VarType := vtPointer;
+          ELEMENT_TYPE_SZARRAY: e.VarType := vtPointer;
           else
           begin
             //unknown type. Guess
 
-            offset:=data.fields[i].offset;
+            offset := Data.fields[i].offset;
 
-            if i<length(data.fields)-1 then
-              elemsize:=data.fields[i+1].offset-data.fields[i].offset
+            if i < length(Data.fields) - 1 then
+              elemsize := Data.fields[i + 1].offset - Data.fields[i].offset
             else
-              elemsize:=bufsize-offset;
+              elemsize := bufsize - offset;
 
-            j:=1;
-            while elemsize>0 do
+            j := 1;
+            while elemsize > 0 do
             begin
 
-              vt:=FindTypeOfData(data.startaddress+offset,@buf[data.fields[i].offset],elemsize, ctp, [biNoString]);
-              e.vartype:=vt;
-              if vt=vtCustom then
-                e.CustomType:=customtype;
+              vt := FindTypeOfData(Data.startaddress + offset,
+                @buf[Data.fields[i].offset], elemsize, ctp, [biNoString]);
+              e.vartype := vt;
+              if vt = vtCustom then
+                e.CustomType := customtype;
 
-              inc(offset, e.Bytesize);
-              dec(elemsize, e.bytesize);
-              inc(j);
+              Inc(offset, e.Bytesize);
+              Dec(elemsize, e.bytesize);
+              Inc(j);
 
-              if elemsize>0 then
-                e:=addElement(data.fields[i].name+'_'+inttostr(j), offset);
-
+              if elemsize > 0 then
+                e := addElement(Data.fields[i].Name + '_' + IntToStr(j), offset);
 
             end;
-
-
 
           end;
 
@@ -1550,13 +1689,14 @@ begin
   DoFullStructChangeNotification;
 end;
 
-procedure TDissectedStruct.autoGuessStruct(baseaddress: ptruint; offset: integer; bytesize: integer);
+procedure TDissectedStruct.autoGuessStruct(baseaddress: ptruint;
+  offset: integer; bytesize: integer);
 var
   buf: pbytearray;
 
   currentOffset: integer;
-  x,o: ptruint;
-  i,j: integer;
+  x, o: ptruint;
+  i, j: integer;
   bs: integer;
   vt: TVariableType;
 
@@ -1567,10 +1707,10 @@ var
 
   s: boolean;
 begin
-  if frmStructuresConfig.cbAutoGuessCustomTypes.checked then
-    ctp:=@customtype
+  if frmStructuresConfig.cbAutoGuessCustomTypes.Checked then
+    ctp := @customtype
   else
-    ctp:=nil;
+    ctp := nil;
 
   //figure out the structure for this base address
   getmem(buf, bytesize);
@@ -1581,82 +1721,87 @@ begin
 
 
 
-    x:=0;
-    s:=readprocessmemory(processhandle,pointer(baseaddress),@buf[0],bytesize,x);
+    x := 0;
+    s := readprocessmemory(processhandle, pointer(baseaddress), @buf[0], bytesize, x);
 
-    if not s then beep;
+    if not s then
+      beep;
 
-    if (x=0) or (x>bytesize) then
+    if (x = 0) or (x > bytesize) then
     begin
-      if x>bytesize then bytesize:=0;
+      if x > bytesize then
+        bytesize := 0;
 
-      dec(bytesize, baseaddress mod 4096);
-      readprocessmemory(processhandle,pointer(baseaddress),@buf[0],bytesize,x);
+      Dec(bytesize, baseaddress mod 4096);
+      readprocessmemory(processhandle, pointer(baseaddress), @buf[0], bytesize, x);
 
-      if x=0 then
+      if x = 0 then
       begin
-        o:=0;
-        while o<bytesize do
+        o := 0;
+        while o < bytesize do
         begin
-          i:=4096-((baseaddress+o) and $fff) ;
+          i := 4096 - ((baseaddress + o) and $fff);
 
-          i:=min(i,bytesize-integer(o));
+          i := min(i, bytesize - integer(o));
 
-          readprocessmemory(processhandle,pointer(baseaddress+o),@buf[o],i,x);
-          inc(o,x);
-          if x=0 then break;
+          readprocessmemory(processhandle, pointer(baseaddress + o), @buf[o], i, x);
+          Inc(o, x);
+          if x = 0 then
+            break;
         end;
 
-        x:=o;
+        x := o;
       end;
     end;
 
-    if (x>0) and (x<=bytesize) then
+    if (x > 0) and (x <= bytesize) then
     begin
-      currentOffset:=offset;
+      currentOffset := offset;
 
-      i:=0;
-      while i<x do
+      i := 0;
+      while i < x do
       begin
-        vt:=FindTypeOfData(baseAddress+i,@buf[i],bytesize-i, ctp);
-        e:=addElement();
-        e.Offset:=currentOffset;
-        e.vartype:=vt;
-        if vt=vtCustom then
-          e.CustomType:=customtype;
+        vt := FindTypeOfData(baseAddress + i, @buf[i], bytesize - i, ctp);
+        e := addElement();
+        e.Offset := currentOffset;
+        e.vartype := vt;
+        if vt = vtCustom then
+          e.CustomType := customtype;
 
         if vt in [vtByte..vtQword] then
         begin
-          if fDefaultHex or ((vt=vtDword) and (not isHumanReadableInteger(pinteger(@buf[i])^))) then
-            e.DisplayMethod:=dtHexadecimal;
+          if fDefaultHex or ((vt = vtDword) and
+            (not isHumanReadableInteger(pinteger(@buf[i])^))) then
+            e.DisplayMethod := dtHexadecimal;
 
         end
         else
         if vt in [vtString, vtUnicodeString] then
         begin
           //find out the size of the string
-          bs:=0;
-          j:=i;
+          bs := 0;
+          j := i;
 
 
-          while (j<bytesize) and (buf[j]>=32) and (buf[j]<=127) do
+          while (j < bytesize) and (buf[j] >= 32) and (buf[j] <= 127) do
           begin
-            if vt=vtString then
-              inc(j)
+            if vt = vtString then
+              Inc(j)
             else
-              inc(j,2);
+              Inc(j, 2);
 
-            inc(bs);
+            Inc(bs);
           end;
 
-          if (j<bytesize-1) and (buf[j]=0) then //add the zero terminator if one exists
-            inc(bs);
+          if (j < bytesize - 1) and (buf[j] = 0) then
+            //add the zero terminator if one exists
+            Inc(bs);
 
-          e.Bytesize:=bs;
+          e.Bytesize := bs;
         end;
 
-        inc(i, e.Bytesize);
-        inc(currentOffset, e.ByteSize);
+        Inc(i, e.Bytesize);
+        Inc(currentOffset, e.ByteSize);
       end;
     end;
   finally
@@ -1667,88 +1812,95 @@ begin
 end;
 
 function TDissectedStruct.getStructureSize: integer;
-var e: TStructelement;
+var
+  e: TStructelement;
 begin
-  result:=0;
-  if getElementCount>0 then
+  Result := 0;
+  if getElementCount > 0 then
   begin
-    e:=getElement(getElementCount-1);
-    result:=e.Offset+e.Bytesize;
+    e := getElement(getElementCount - 1);
+    Result := e.Offset + e.Bytesize;
   end;
 end;
 
 procedure TDissectedStruct.addToGlobalStructList;
-var i: integer;
+var
+  i: integer;
 begin
   if not isInGlobalStructList then
   begin
     DissectedStructs.Add(self);
 
     //notify that this structure has been added
-    for i:=0 to frmStructures2.Count-1 do
-       TfrmStructures2(frmStructures2[i]).onAddedToStructList(self);
+    for i := 0 to frmStructures2.Count - 1 do
+      TfrmStructures2(frmStructures2[i]).onAddedToStructList(self);
   end;
 end;
 
 procedure TDissectedStruct.removeFromGlobalStructList;
-var i: integer;
+var
+  i: integer;
 begin
   if isInGlobalStructList then
   begin
     DissectedStructs.Remove(self);
 
     //notify that this structure has been removed
-    for i:=0 to frmStructures2.Count-1 do
-       TfrmStructures2(frmStructures2[i]).onRemovedFromStructList(self);
+    for i := 0 to frmStructures2.Count - 1 do
+      TfrmStructures2(frmStructures2[i]).onRemovedFromStructList(self);
   end;
 end;
 
 function TDissectedStruct.isInGlobalStructList: boolean;
 begin
-  result:=DissectedStructs.IndexOf(self)<>-1;
+  Result := DissectedStructs.IndexOf(self) <> -1;
 end;
 
 function TDissectedStruct.getIndexOf(element: TStructElement): integer;
 begin
-  result:=structelementlist.IndexOf(element);
+  Result := structelementlist.IndexOf(element);
 end;
 
 function TDissectedStruct.getIndexOfOffset(offset: dword): integer;
-//Find the first index where the offset is equal or bigger than the searched for index
+  //Find the first index where the offset is equal or bigger than the searched for index
 begin
-  result:=0;
-  while result<count do
+  Result := 0;
+  while Result < Count do
   begin
-    if element[result].Offset>=offset then break; //found it
-    inc(result);
+    if element[Result].Offset >= offset then
+      break; //found it
+    Inc(Result);
   end;
   //if nothing is found result will contain the current count, resulting in nothing
 end;
 
-procedure TDissectedStruct.OnDeleteStructNotification(structtodelete: TDissectedStruct; path: TList);
+procedure TDissectedStruct.OnDeleteStructNotification(structtodelete: TDissectedStruct;
+  path: TList);
 var
   i: integer;
   s: TDissectedStruct;
 begin
   //remove all mentioning of this struct
-  if structtodelete=self then exit;
+  if structtodelete = self then
+    exit;
 
-  if structelementlist=nil then exit; //destroyed structure called (bug)
+  if structelementlist = nil then
+    exit; //destroyed structure called (bug)
 
   beginUpdate;
 
-  for i:=0 to count-1 do
+  for i := 0 to Count - 1 do
   begin
-    s:=element[i].ChildStruct;
+    s := element[i].ChildStruct;
 
-    if s<>nil then
+    if s <> nil then
     begin
-      if element[i].ChildStruct=structtodelete then
-        element[i].ChildStruct:=nil
+      if element[i].ChildStruct = structtodelete then
+        element[i].ChildStruct := nil
       else
       begin
         //a struct but not the deleted one. Make sure it is a LOCAL one to prevent an infinite loop (a global struct can point to itself)
-        if (not s.isInGlobalStructList) and (path.IndexOf(self)=-1) then
+        if (not s.isInGlobalStructList) and (path.IndexOf(self) = -1) then
         begin
           path.Add(self); //prevents infinite loops
           s.OnDeleteStructNotification(structtodelete, path);
@@ -1763,111 +1915,122 @@ end;
 procedure TDissectedStruct.DoDeleteStructNotification;
 var
   i: integer;
-  infiniteLoopProtection: tlist;
+  infiniteLoopProtection: TList;
 begin
   //tell each structure that it should remove all the childstruct mentions of this structure
 
-  for i:=0 to DissectedStructs.count-1 do
+  for i := 0 to DissectedStructs.Count - 1 do
   begin
-    if DissectedStructs[i]<>self then
+    if DissectedStructs[i] <> self then
     begin
-      infiniteLoopProtection:=TList.create;
+      infiniteLoopProtection := TList.Create;
       try
-        TDissectedStruct(DissectedStructs[i]).OnDeleteStructNotification(self, infiniteLoopProtection);
+        TDissectedStruct(DissectedStructs[i]).OnDeleteStructNotification(self,
+          infiniteLoopProtection);
       finally
-        freeandnil(infiniteLoopProtection);
+        FreeAndNil(infiniteLoopProtection);
       end;
     end;
   end;
 
   //tell each form that it should close this structure
-  for i:=0 to frmStructures2.Count-1 do
+  for i := 0 to frmStructures2.Count - 1 do
     TfrmStructures2(frmStructures2[i]).OnStructureDelete(self);
-
 
 end;
 
 
 procedure TDissectedStruct.WriteToXMLNode(node: TDOMNode);
 var
-  i,j: integer;
+  i, j: integer;
   RLECount: integer;
   doc: TDOMDocument;
 
   structnode: TDOMElement;
   elementnodes: TDOMElement;
 begin
-  doc:=node.OwnerDocument;
+  doc := node.OwnerDocument;
 
-  structnode:=TDOMElement(node.AppendChild(doc.CreateElement('Structure')));
-  TDOMElement(structnode).SetAttribute('Name',Utf8ToAnsi(name));
-
-
-  TDOMElement(structnode).SetAttribute('DoNotSaveLocal',BoolToStr(fDoNotSaveLocal,'1','0'));
-  TDOMElement(structnode).SetAttribute('AutoCreate',BoolToStr(fAutoCreate,'1','0'));
-  TDOMElement(structnode).SetAttribute('AutoCreateStructsize',inttostr(fAutoCreateStructsize));
-  TDOMElement(structnode).SetAttribute('AutoDestroy',BoolToStr(fAutoDestroy,'1','0'));
-  TDOMElement(structnode).SetAttribute('AutoFill',BoolToStr(fAutoFill,'1','0'));
-  TDOMElement(structnode).SetAttribute('DefaultHex',BoolToStr(fDefaultHex,'1','0'));
-  TDOMElement(structnode).SetAttribute('RLECompression',BoolToStr(fRLECompression,'1','0'));
-
-  elementnodes:=TDOMElement(structnode.AppendChild(TDOMNode(doc.CreateElement('Elements'))));
+  structnode := TDOMElement(node.AppendChild(doc.CreateElement('Structure')));
+  TDOMElement(structnode).SetAttribute('Name', Utf8ToAnsi(Name));
 
 
-  RLECount:=0;
-  for i:=0 to count-1 do
+  TDOMElement(structnode).SetAttribute('DoNotSaveLocal', BoolToStr(
+    fDoNotSaveLocal, '1', '0'));
+  TDOMElement(structnode).SetAttribute('AutoCreate', BoolToStr(fAutoCreate, '1', '0'));
+  TDOMElement(structnode).SetAttribute('AutoCreateStructsize', IntToStr(
+    fAutoCreateStructsize));
+  TDOMElement(structnode).SetAttribute('AutoDestroy', BoolToStr(fAutoDestroy, '1', '0'));
+  TDOMElement(structnode).SetAttribute('AutoFill', BoolToStr(fAutoFill, '1', '0'));
+  TDOMElement(structnode).SetAttribute('DefaultHex', BoolToStr(fDefaultHex, '1', '0'));
+  TDOMElement(structnode).SetAttribute('RLECompression', BoolToStr(
+    fRLECompression, '1', '0'));
+
+  elementnodes := TDOMElement(structnode.AppendChild(
+    TDOMNode(doc.CreateElement('Elements'))));
+
+
+  RLECount := 0;
+  for i := 0 to Count - 1 do
   begin
-    if RLECount>0 then begin dec(RLECount); Continue; end;
+    if RLECount > 0 then
+    begin
+      Dec(RLECount);
+      Continue;
+    end;
 
     if fRLECompression then
-    for j:=i to count-2 do
-      if ( element[j].Bytesize=element[j+1].Bytesize ) and
-         ( element[j].Name=element[j+1].Name ) and
-         ( element[j].DisplayMethod=element[j+1].DisplayMethod ) and
-         ( element[j].BackgroundColor=element[j+1].BackgroundColor ) and
-         ( (element[j].Bytesize+element[j].Offset) = element[j+1].Offset ) and
-         ( element[j].VarType=element[j+1].VarType ) and
-         ( element[j].ChildStruct=nil ) and ( element[j+1].ChildStruct=nil ) and
-
-         ( ((element[j].CustomType=nil) and (element[j+1].CustomType=nil)) or
-           ((element[j].CustomType<>nil) and (element[j+1].CustomType<>nil) and
-            (element[j].CustomType.name=element[j+1].CustomType.name)) )
-
-      then Inc(RLECount) else break;
+      for j := i to Count - 2 do
+        if (element[j].Bytesize = element[j + 1].Bytesize) and
+          (element[j].Name = element[j + 1].Name) and
+          (element[j].DisplayMethod = element[j + 1].DisplayMethod) and
+          (element[j].BackgroundColor = element[j + 1].BackgroundColor) and
+          ((element[j].Bytesize + element[j].Offset) = element[j + 1].Offset) and
+          (element[j].VarType = element[j + 1].VarType) and
+          (element[j].ChildStruct = nil) and (element[j + 1].ChildStruct = nil) and
+          (((element[j].CustomType = nil) and (element[j + 1].CustomType = nil)) or
+          ((element[j].CustomType <> nil) and (element[j + 1].CustomType <> nil) and
+          (element[j].CustomType.Name = element[j + 1].CustomType.Name))) then
+          Inc(RLECount)
+        else
+          break;
 
     element[i].WriteToXMLNode(elementnodes);
 
-    if RLECount<>0 then
-      TDOMElement(elementnodes.LastChild).SetAttribute('RLECount',IntToStr(RLECount+1));
+    if RLECount <> 0 then
+      TDOMElement(elementnodes.LastChild).SetAttribute('RLECount',
+        IntToStr(RLECount + 1));
   end;
 end;
 
 procedure TDissectedStruct.fillDelayLoadedChildstructs;
 //call this when all structures have been loaded
 var
-  i,j: integer;
+  i, j: integer;
   sn: string;
 begin
   beginUpdate;
-  for i:=0 to count-1 do
+  for i := 0 to Count - 1 do
   begin
-    sn:=element[i].delayLoadedStructname;
-    if sn<>'' then
+    sn := element[i].delayLoadedStructname;
+    if sn <> '' then
     begin
       //find and fill in the struct
-      for j:=0 to DissectedStructs.count-1 do
+      for j := 0 to DissectedStructs.Count - 1 do
       begin
-        if TDissectedStruct(DissectedStructs[j]).name=sn then
+        if TDissectedStruct(DissectedStructs[j]).Name = sn then
         begin
           //found it, set the struct
-          element[i].ChildStruct:=TDissectedStruct(DissectedStructs[j]);
+          element[i].ChildStruct := TDissectedStruct(DissectedStructs[j]);
           break;
         end;
       end;
     end
     else
     begin
-      if (element[i].isPointer) and (element[i].ChildStruct<>nil) and (element[i].ChildStruct.isInGlobalStructList=false) then //local structure, scan this one as well
+      if (element[i].isPointer) and (element[i].ChildStruct <> nil) and
+        (element[i].ChildStruct.isInGlobalStructList = False) then
+        //local structure, scan this one as well
         element[i].ChildStruct.fillDelayLoadedChildstructs;
     end;
   end;
@@ -1876,75 +2039,83 @@ end;
 
 procedure TDissectedStruct.setDoNotSaveLocal(state: boolean);
 begin
-  fDoNotSaveLocal:=state;
+  fDoNotSaveLocal := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setAutoCreateStructsize(size: integer);
 begin
-  fAutoCreateStructsize:=size;
+  fAutoCreateStructsize := size;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setAutoCreate(state: boolean);
 begin
-  fAutoCreate:=state;
+  fAutoCreate := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setAutoDestroy(state: boolean);
 begin
-  fAutoDestroy:=state;
+  fAutoDestroy := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setAutoFill(state: boolean);
 begin
-  fAutoFill:=state;
+  fAutoFill := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setDefaultHex(state: boolean);
 begin
-  fDefaultHex:=state;
+  fDefaultHex := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setRLECompression(state: boolean);
 begin
-  fRLECompression:=state;
+  fRLECompression := state;
   DoOptionsChangedNotification;
 end;
 
 procedure TDissectedStruct.setupDefaultSettings;
 //loads the default settings for new structures
-var reg: Tregistry;
+var
+  reg: Tregistry;
 begin
-  fAutoCreate:=true; //default settings in case of no previous settings
-  fAutoCreateStructsize:=4096;
-  fRLECompression:=true;
+  fAutoCreate := True; //default settings in case of no previous settings
+  fAutoCreateStructsize := 4096;
+  fRLECompression := True;
 
-  reg:=tregistry.create;
+  reg := tregistry.Create;
   try
     Reg.RootKey := HKEY_CURRENT_USER;
-    if Reg.OpenKey('\Software\Cheat Engine\DissectData',false) then
+    if Reg.OpenKey('\Software\Cheat Engine\DissectData', False) then
     begin
-      if reg.ValueExists('Autocreate') then fAutoCreate:=reg.ReadBool('Autocreate');
-      if reg.ValueExists('Autocreate Size') then fAutoCreateStructsize:=reg.ReadInteger('Autocreate Size');
-      if reg.ValueExists('Autodestroy') then fAutoDestroy:=reg.ReadBool('Autodestroy');
-      if reg.ValueExists('Don''t save local') then fDoNotSaveLocal:=reg.ReadBool('Don''t save local');
-      if reg.ValueExists('Autofill') then fAutoFill:=reg.ReadBool('Autofill');
-      if reg.ValueExists('DefaultHex') then fDefaultHex:=reg.ReadBool('DefaultHex');
+      if reg.ValueExists('Autocreate') then
+        fAutoCreate := reg.ReadBool('Autocreate');
+      if reg.ValueExists('Autocreate Size') then
+        fAutoCreateStructsize := reg.ReadInteger('Autocreate Size');
+      if reg.ValueExists('Autodestroy') then
+        fAutoDestroy := reg.ReadBool('Autodestroy');
+      if reg.ValueExists('Don''t save local') then
+        fDoNotSaveLocal := reg.ReadBool('Don''t save local');
+      if reg.ValueExists('Autofill') then
+        fAutoFill := reg.ReadBool('Autofill');
+      if reg.ValueExists('DefaultHex') then
+        fDefaultHex := reg.ReadBool('DefaultHex');
 
     end;
   finally
-    freeandnil(reg);
+    FreeAndNil(reg);
   end;
 end;
 
 constructor TDissectedStruct.createFromOutdatedXMLNode(structure: TDOMNode);
-//Constructor for loading old V1 structures
-var tempnode: TDOMNode;
+  //Constructor for loading old V1 structures
+var
+  tempnode: TDOMNode;
   elements: TDOMNode;
   element, tempelement: TDOMNode;
   i: integer;
@@ -1962,138 +2133,131 @@ var tempnode: TDOMNode;
 
   se: TStructelement;
 begin
-  currentoffset:=0;
+  currentoffset := 0;
 
-  self.name:='';
-  structelementlist:=tlist.Create;
-  autoCreateStructsize:=4096; //default autocreate size
+  self.Name := '';
+  structelementlist := TList.Create;
+  autoCreateStructsize := 4096; //default autocreate size
   setupDefaultSettings;
 
   beginupdate;
   try
-    if structure.NodeName='Structure' then
+    if structure.NodeName = 'Structure' then
     begin
-      tempnode:=structure.FindNode('Name');
-      if tempnode<>nil then
-        self.name:=tempnode.TextContent;
+      tempnode := structure.FindNode('Name');
+      if tempnode <> nil then
+        self.Name := tempnode.TextContent;
 
-      elements:=structure.FindNode('Elements');
-      for i:=0 to elements.childnodes.count-1 do
+      elements := structure.FindNode('Elements');
+      for i := 0 to elements.childnodes.Count - 1 do
       begin
-        element:=elements.ChildNodes[i];
+        element := elements.ChildNodes[i];
 
-        childstruct:='';
-        findoffset:=true;
-        tempnode:=element.FindNode('Offset');
-        if tempnode<>nil then
+        childstruct := '';
+        findoffset := True;
+        tempnode := element.FindNode('Offset');
+        if tempnode <> nil then
         begin
           try
-            offset:=strtoint(tempnode.textcontent);
-            findoffset:=false; //the offset was fetched properly, no need to calculate it
+            offset := StrToInt(tempnode.textcontent);
+            findoffset := False;
+            //the offset was fetched properly, no need to calculate it
           except
 
           end;
         end;
 
         if findoffset then //it couldn't be read out
-          offset:=currentoffset;  //calculated offset
+          offset := currentoffset;  //calculated offset
 
 
-        tempnode:=element.FindNode('Description');
-        if tempnode<>nil then
-          description:=tempnode.TextContent;
+        tempnode := element.FindNode('Description');
+        if tempnode <> nil then
+          description := tempnode.TextContent;
 
         {
         tempnode:=element.FindNode('PointerTo');
         tempnode:=element.FindNode('PointerToSize');   }
 
 
-        tempnode:=element.FindNode('Structurenr');
-        if tempnode<>nil then
+        tempnode := element.FindNode('Structurenr');
+        if tempnode <> nil then
         begin
-          displaymethod:=dtUnsignedInteger;
-          structurenr:=strtoint(tempnode.TextContent);
+          displaymethod := dtUnsignedInteger;
+          structurenr := StrToInt(tempnode.TextContent);
           case structurenr of
-            -1,-2,-3: //byte
+            -1, -2, -3: //byte
             begin
-              vartype:=vtByte;
-              bytesize:=1;
+              vartype := vtByte;
+              bytesize := 1;
 
-              if structurenr=-2 then
-                displaymethod:=dtSignedInteger
+              if structurenr = -2 then
+                displaymethod := dtSignedInteger
               else
-              if structurenr=-3 then
-                displaymethod:=dtHexadecimal;
+              if structurenr = -3 then
+                displaymethod := dtHexadecimal;
             end;
-
-            -4,-5,-6: //word
+            -4, -5, -6: //word
             begin
-              vartype:=vtWord;
-              bytesize:=2;
+              vartype := vtWord;
+              bytesize := 2;
 
-              if structurenr=-5 then
-                displaymethod:=dtSignedInteger
+              if structurenr = -5 then
+                displaymethod := dtSignedInteger
               else
-              if structurenr=-6 then
-                displaymethod:=dtHexadecimal;
+              if structurenr = -6 then
+                displaymethod := dtHexadecimal;
             end;
-
-            -7,-8,-9: //dword
+            -7, -8, -9: //dword
             begin
-              vartype:=vtDWord;
-              bytesize:=4;
+              vartype := vtDWord;
+              bytesize := 4;
 
-              if structurenr=-8 then
-                displaymethod:=dtSignedInteger
+              if structurenr = -8 then
+                displaymethod := dtSignedInteger
               else
-              if structurenr=-9 then
-                displaymethod:=dtHexadecimal;
+              if structurenr = -9 then
+                displaymethod := dtHexadecimal;
             end;
-
-            -10,-11: //qword
+            -10, -11: //qword
             begin
-              vartype:=vtQWord;
-              bytesize:=8;
+              vartype := vtQWord;
+              bytesize := 8;
 
-              if structurenr=-11 then
-                displaymethod:=dtHexadecimal;
+              if structurenr = -11 then
+                displaymethod := dtHexadecimal;
             end;
-
             -12: //single
             begin
-              vartype:=vtSingle;
-              bytesize:=4;
+              vartype := vtSingle;
+              bytesize := 4;
             end;
-
             -13: //double
             begin
-              vartype:=vtDouble;
-              bytesize:=8;
+              vartype := vtDouble;
+              bytesize := 8;
             end;
-
             -14: //string
             begin
-              vartype:=vtString;
+              vartype := vtString;
             end;
-
             -15: //unicode string
             begin
-              vartype:=vtUnicodeString;
+              vartype := vtUnicodeString;
             end;
           end;
         end;
 
-        tempnode:=element.FindNode('Bytesize');
-        if tempnode<>nil then
-          bytesize:=strtoint(tempnode.TextContent);
+        tempnode := element.FindNode('Bytesize');
+        if tempnode <> nil then
+          bytesize := StrToInt(tempnode.TextContent);
 
 
-        se:=addElement(description, offset, vartype,nil, bytesize, nil);
-        se.DisplayMethod:=displaymethod;
+        se := addElement(description, offset, vartype, nil, bytesize, nil);
+        se.DisplayMethod := displaymethod;
 
-        currentoffset:=offset+Bytesize;
+        currentoffset := offset + Bytesize;
       end;
-
 
     end; //structure.NodeName='Structure'
   finally
@@ -2102,11 +2266,11 @@ begin
 end;
 
 constructor TDissectedStruct.createFromXMLNode(structure: TDOMNode);
-//Create the structure with the given data and possible local structs as well
+  //Create the structure with the given data and possible local structs as well
 var
   elementnodes, elementnode: TDOMElement;
   childnode: TDOMElement;
-  i,j: integer;
+  i, j: integer;
   se: TStructelement;
 
   offset: integer;
@@ -2114,49 +2278,49 @@ var
   vartype: TVariableType;
   customtype: TCustomType;
   bytesize: integer;
-  displaymethod :TdisplayMethod;
-
+  displaymethod: TdisplayMethod;
 
   childstruct: TDissectedStruct;
   childname: string;
   ChildStructStartS: string;
   ChildStructStart: integer;
 begin
-  self.name:='';
-  structelementlist:=tlist.Create;
-  autoCreateStructsize:=4096; //default autocreate size
+  self.Name := '';
+  structelementlist := TList.Create;
+  autoCreateStructsize := 4096; //default autocreate size
   setupDefaultSettings;
 
   beginUpdate;
   try
-    if structure.NodeName='Structure' then
+    if structure.NodeName = 'Structure' then
     begin
-      self.name:=TDOMElement(structure).GetAttribute('Name');
+      self.Name := TDOMElement(structure).GetAttribute('Name');
 
-      fDoNotSaveLocal:=TDOMElement(structure).GetAttribute('DoNotSaveLocal')='1';
-      fAutoCreate:=TDOMElement(structure).GetAttribute('AutoCreate')='1';
-      fAutoCreateStructsize:=StrToIntDef(TDOMElement(structure).GetAttribute('AutoCreateStructsize'), 4096);
-      fAutoDestroy:=TDOMElement(structure).GetAttribute('AutoDestroy')='1';
-      fAutoFill:=TDOMElement(structure).GetAttribute('AutoFill')='1';
-      fDefaultHex:=TDOMElement(structure).GetAttribute('DefaultHex')='1';
-      fRLECompression:=TDOMElement(structure).GetAttribute('RLECompression')='1';
+      fDoNotSaveLocal := TDOMElement(structure).GetAttribute('DoNotSaveLocal') = '1';
+      fAutoCreate := TDOMElement(structure).GetAttribute('AutoCreate') = '1';
+      fAutoCreateStructsize :=
+        StrToIntDef(TDOMElement(structure).GetAttribute('AutoCreateStructsize'), 4096);
+      fAutoDestroy := TDOMElement(structure).GetAttribute('AutoDestroy') = '1';
+      fAutoFill := TDOMElement(structure).GetAttribute('AutoFill') = '1';
+      fDefaultHex := TDOMElement(structure).GetAttribute('DefaultHex') = '1';
+      fRLECompression := TDOMElement(structure).GetAttribute('RLECompression') = '1';
 
 
-      elementnodes:=TDOMElement(structure.FindNode('Elements'));
-      if elementnodes<>nil then
+      elementnodes := TDOMElement(structure.FindNode('Elements'));
+      if elementnodes <> nil then
       begin
-        for i:=0 to elementnodes.ChildNodes.Count-1 do
+        for i := 0 to elementnodes.ChildNodes.Count - 1 do
         begin
-          elementnode:=TDOMELement(elementnodes.ChildNodes[i]);
+          elementnode := TDOMELement(elementnodes.ChildNodes[i]);
 
-          if elementnode.Attributes.GetNamedItem('RLECount')=nil then
-            structelementlist.Add(TStructelement.createFromXMLElement(self,elementnode))
+          if elementnode.Attributes.GetNamedItem('RLECount') = nil then
+            structelementlist.Add(TStructelement.createFromXMLElement(self, elementnode))
           else
           begin
-            for j:=1 to strtoint(elementnode.GetAttribute('RLECount')) do
+            for j := 1 to StrToInt(elementnode.GetAttribute('RLECount')) do
             begin
-              se:=TStructelement.createFromXMLElement(self,TDOMELement(elementnode));
-              se.Offset:=se.Offset+se.fbytesize*(j-1);
+              se := TStructelement.createFromXMLElement(self, TDOMELement(elementnode));
+              se.Offset := se.Offset + se.fbytesize * (j - 1);
               structelementlist.Add(se);
             end;
           end;
@@ -2172,35 +2336,36 @@ begin
   end;
 end;
 
-constructor TDissectedStruct.create(name: string);
+constructor TDissectedStruct.Create(Name: string);
 begin
-  self.name:=name;
-  structelementlist:=tlist.Create;
+  self.Name := Name;
+  structelementlist := TList.Create;
 
-  autoCreateStructsize:=4096; //default autocreate size
+  autoCreateStructsize := 4096; //default autocreate size
   setupDefaultSettings;
 end;
 
-destructor TDissectedStruct.destroy;
-var i: integer;
+destructor TDissectedStruct.Destroy;
+var
+  i: integer;
 begin
   beginUpdate; //never endupdate
 
   DoDeleteStructNotification;
 
-  if structelementlist<>nil then
+  if structelementlist <> nil then
   begin
-    while structelementlist.Count>0 do
-      TStructelement(structelementlist.Items[0]).free;
+    while structelementlist.Count > 0 do
+      TStructelement(structelementlist.Items[0]).Free;
 
-    freeandnil(structelementlist);
+    FreeAndNil(structelementlist);
   end;
 
 
   removeFromGlobalStructList;
 
 
-  inherited destroy;
+  inherited Destroy;
 end;
 
 
@@ -2214,40 +2379,42 @@ end;
 procedure TStructColumn.popAddress;
 begin
   if canPopAddress then
-    Address:=ptruint(backlist.Pop);
+    Address := ptruint(backlist.Pop);
 end;
 
 function TStructColumn.canPopAddress: boolean;
 begin
-  result:=backlist.Count>0;
+  Result := backlist.Count > 0;
 end;
 
 procedure TStructColumn.setNewParent(group: TStructGroup);
-var i: integer;
-   oldparent: TStructGroup;
+var
+  i: integer;
+  oldparent: TStructGroup;
 begin
-  if group=parent then exit;
+  if group = parent then
+    exit;
 
-  oldparent:=parent;
-  i:=parent.fcolumns.IndexOf(self);
+  oldparent := parent;
+  i := parent.fcolumns.IndexOf(self);
 
   parent.fcolumns.Remove(self);
 
-  if i<parent.fcolumns.Count then
+  if i < parent.fcolumns.Count then
     TStructColumn(parent.fcolumns[i]).setAnchorsForPos(i);
 
-  if parent.fcolumns.Count=0 then //group has 0 entries , destroy the group
+  if parent.fcolumns.Count = 0 then //group has 0 entries , destroy the group
     parent.Free;
 
 
 
-  parent:=group;
-  i:=parent.fcolumns.Add(self);
+  parent := group;
+  i := parent.fcolumns.Add(self);
 
-  edtAddress.parent:=group.box;
-  focusedShape.parent:=group.box;
-  if lblname<>nil then
-    lblName.parent:=group.box;
+  edtAddress.parent := group.box;
+  focusedShape.parent := group.box;
+  if lblname <> nil then
+    lblName.parent := group.box;
 
   setAnchorsForPos(i);
 
@@ -2256,13 +2423,13 @@ begin
   group.setPositions; //update the gui
 end;
 
-procedure TStructColumn.DeleteClick(sender: TObject);
+procedure TStructColumn.DeleteClick(Sender: TObject);
 begin
-  if parent.parent.columnCount>1 then //leave one intact
-    free;
+  if parent.parent.columnCount > 1 then //leave one intact
+    Free;
 end;
 
-procedure TStructColumn.ChangeGroupClick(sender: tobject);
+procedure TStructColumn.ChangeGroupClick(Sender: TObject);
 var
   grouplist: TStringList;
   l: TfrmSelectionList;
@@ -2272,11 +2439,11 @@ var
   newname: string;
 begin
   //input a window to choose which group
-  grouplist:=TStringList.create;
-  for i:=0 to parent.parent.groupcount-1 do
+  grouplist := TStringList.Create;
+  for i := 0 to parent.parent.groupcount - 1 do
     grouplist.AddObject(parent.parent.group[i].groupname, parent.parent.group[i]);
 
-  grouplist.AddObject(rsSF2NewGroup,nil);
+  grouplist.AddObject(rsSF2NewGroup, nil);
 
   l := TfrmSelectionList.Create(parent.parent, grouplist);
   l.Caption := rsSF2GroupPicker;
@@ -2286,75 +2453,76 @@ begin
   if (l.showmodal = mrOk) and (l.ItemIndex <> -1) then
   begin
     //apply change
-    if grouplist.Objects[l.itemindex]=nil then //new group
+    if grouplist.Objects[l.ItemIndex] = nil then //new group
     begin
-      newname:=rsSF2Group2+inttostr(parent.parent.groupcount+1);
-      if inputquery(rsSF2NewGroup2,rsSF2GiveTheNewName, newname) then
-        g:=TStructGroup.create(parent.parent, newname)
+      newname := rsSF2Group2 + IntToStr(parent.parent.groupcount + 1);
+      if inputquery(rsSF2NewGroup2, rsSF2GiveTheNewName, newname) then
+        g := TStructGroup.Create(parent.parent, newname)
       else
         exit; //no new group, no change
     end
     else
-      g:=TStructGroup(grouplist.Objects[l.itemindex]);
+      g := TStructGroup(grouplist.Objects[l.ItemIndex]);
 
     setNewParent(g);
   end;
-  freeandnil(l);
-  freeandnil(grouplist);
-
-
-
-
+  FreeAndNil(l);
+  FreeAndNil(grouplist);
 
 end;
 
 function TStructColumn.getGlobalIndex: integer;
-var i: integer;
+var
+  i: integer;
 begin
   //can be optimized
-  result:=-1;
-  for i:=0 to parent.parent.columnCount-1 do
-    if parent.parent.columns[i]=self then
+  Result := -1;
+  for i := 0 to parent.parent.columnCount - 1 do
+    if parent.parent.columns[i] = self then
     begin
-      result:=i;
+      Result := i;
       exit;
     end;
 end;
 
 function TStructColumn.isXInColumn(x: integer): boolean;
-var i: integer;
+var
+  i: integer;
   hsection: Theadersection;
 begin
   //check if this x position is in the current columns
-  i:=getGlobalIndex;
-  hsection:=parent.parent.HeaderControl1.Sections[i+1];
-  result:=InRange(x, hsection.left, hsection.Right);
+  i := getGlobalIndex;
+  hsection := parent.parent.HeaderControl1.Sections[i + 1];
+  Result := InRange(x, hsection.left, hsection.Right);
 end;
 
 procedure TStructColumn.focus;
 begin
-  focused:=true;
+  focused := True;
 end;
 
-procedure TStructColumn.edtAddressEnter(sender: tobject);
+procedure TStructColumn.edtAddressEnter(Sender: TObject);
 begin
   focus;
 end;
 
-procedure TStructColumn.edtaddressMousedown(Sender: TObject; Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+procedure TStructColumn.edtaddressMousedown(Sender: TObject;
+  Button: TMouseButton; Shift: TShiftState; X, Y: integer);
 begin
   focus;
 end;
 
-function TStructColumn.getFocused:boolean;
+function TStructColumn.getFocused: boolean;
 begin
-  result:=fFocused;
+  Result := fFocused;
 end;
 
 procedure TStructColumn.setFocused(state: boolean);
-var i,x: integer;
+var
+  i, x: integer;
 begin
-  if fFocused=state then exit;
+  if fFocused = state then
+    exit;
 
   //sets this column as the focused column
   //(there can be only one focused column)
@@ -2362,21 +2530,24 @@ begin
 
   if state then //set all others to false
   begin
-    for i:=0 to parent.parent.columncount-1 do
-      if parent.parent.columns[i]<>self then
+    for i := 0 to parent.parent.columncount - 1 do
+      if parent.parent.columns[i] <> self then
       begin
-        parent.parent.columns[i].focused:=false;
+        parent.parent.columns[i].focused := False;
       end
       else
       begin
         if state and parent.parent.pnlGroups.HorzScrollBar.IsScrollBarVisible then
         begin
 
-          x:=parent.parent.columns[i].EditLeft+parent.parent.columns[i].parent.GroupBox.left;
+          x := parent.parent.columns[i].EditLeft +
+            parent.parent.columns[i].parent.GroupBox.left;
           //if not visible, then make it visible
-          if not InRange(x+parent.parent.columns[i].EditWidth div 2, parent.parent.pnlGroups.HorzScrollBar.Position,  parent.parent.pnlGroups.ClientWidth) then
+          if not InRange(x + parent.parent.columns[i].EditWidth div
+            2, parent.parent.pnlGroups.HorzScrollBar.Position,
+            parent.parent.pnlGroups.ClientWidth) then
           begin
-            parent.parent.pnlGroups.HorzScrollBar.Position:=x-5;
+            parent.parent.pnlGroups.HorzScrollBar.Position := x - 5;
           end;
 
         end;
@@ -2384,111 +2555,115 @@ begin
   end;
 
   //make focus visible
-  focusedShape.visible:=state;
-  fFocused:=state;
-
+  focusedShape.Visible := state;
+  fFocused := state;
 
 end;
 
 procedure TStructColumn.clearSavedState;
 begin
 
-  if fsavedstate<>nil then
+  if fsavedstate <> nil then
   begin
     VirtualFreeEx(processhandle, fsavedstate, 0, MEM_RELEASE);
-    fsavedstatesize:=0;
-    fsavedstate:=nil;
+    fsavedstatesize := 0;
+    fsavedstate := nil;
   end;
 
-  miToggleLock.Checked:=false;
-  mitoggleLock.caption:=rsLock;
+  miToggleLock.Checked := False;
+  mitoggleLock.Caption := rsLock;
 
 end;
 
 function TStructColumn.getAddress: ptruint;
 begin
-  result:=faddress;
+  Result := faddress;
 end;
 
 procedure TStructColumn.setAddress(address: ptruint);
 begin
   clearSavedState;
-  faddress:=address;
+  faddress := address;
 
-  edtAddress.Text:=IntToHex(faddress,8);
+  edtAddress.Text := IntToHex(faddress, 8);
 end;
 
 function TStructColumn.getAddressText: string;
 begin
-  result:=edtAddress.Text;
+  Result := edtAddress.Text;
 end;
 
 procedure TStructColumn.setAddressText(address: string);
 begin
   clearSavedState;
-  edtAddress.Text:=address;
+  edtAddress.Text := address;
   edtAddressChange(nil);
 end;
 
 function TStructColumn.getName: string;
 begin
-  if lblname<>nil then
-    result:=lblName.Caption
+  if lblname <> nil then
+    Result := lblName.Caption
   else
-    result:='';
+    Result := '';
 end;
 
-function TStructColumn.LockAddress(shownaddress: ptruint; memoryblock: pointer; size: integer): boolean;
+function TStructColumn.LockAddress(shownaddress: ptruint; memoryblock: pointer;
+  size: integer): boolean;
 var
   x: ptruint;
 begin
-  result:=false;
+  Result := False;
 
-  address:=shownaddress;
+  address := shownaddress;
 
-  fsavedstatesize:=size;
-  fsavedstate:=VirtualAllocEx(processhandle, nil, fsavedstatesize+1, MEM_COMMIT or MEM_RESERVE, PAGE_READWRITE);
-  if fsavedstate<>nil then
+  fsavedstatesize := size;
+  fsavedstate := VirtualAllocEx(processhandle, nil, fsavedstatesize +
+    1, MEM_COMMIT or MEM_RESERVE, PAGE_READWRITE);
+  if fsavedstate <> nil then
   begin
     //copy the original bytes to the copy
-    x:=0;
-    if WriteProcessMemory(processhandle, pointer(fsavedstate), memoryblock, fsavedstatesize, x) then
-      result:=true
+    x := 0;
+    if WriteProcessMemory(processhandle, pointer(fsavedstate), memoryblock,
+      fsavedstatesize, x) then
+      Result := True
     else
     begin
-      if x=0 then
-        VirtualFreeEx(processhandle, fsavedstate, 0, MEM_RELEASE)   //copy failed for some unknown reason, free the allocated buffer
+      if x = 0 then
+        VirtualFreeEx(processhandle, fsavedstate, 0, MEM_RELEASE)
+      //copy failed for some unknown reason, free the allocated buffer
       else
       begin
-        result:=true;
-        fsavedstatesize:=x;
+        Result := True;
+        fsavedstatesize := x;
       end;
     end;
   end;
 
 
 
-  miToggleLock.Checked:=result;
-  miToggleLock.Caption:=format(rsSF2ShadowcopyAt, [inttohex(qword(fsavedstate),8)]);
+  miToggleLock.Checked := Result;
+  miToggleLock.Caption := format(rsSF2ShadowcopyAt, [inttohex(qword(fsavedstate), 8)]);
 end;
 
 function TStructColumn.saveState: boolean;
-var buf: pointer;
+var
+  buf: pointer;
   size: integer;
   x: ptruint;
 begin
   clearSavedState;
-  result:=false;
+  Result := False;
 
-  if parent.parent.MainStruct<>nil then
-    size:=max(8192, parent.parent.MainStruct.getStructureSize)
+  if parent.parent.MainStruct <> nil then
+    size := max(8192, parent.parent.MainStruct.getStructureSize)
   else
-    size:=8192;
+    size := 8192;
 
   getmem(buf, size);
   try
     if readprocessmemory(processhandle, pointer(faddress), buf, size, x) then
-      result:=LockAddress(faddress, buf, x);
+      Result := LockAddress(faddress, buf, x);
   finally
     FreeMemAndNil(buf);
   end;
@@ -2496,53 +2671,54 @@ end;
 
 function TStructColumn.getSavedState: ptruint;
 begin
-  result:=ptruint(fsavedstate);
+  Result := ptruint(fsavedstate);
 end;
 
 function TStructColumn.getSavedStateSize: integer;
 begin
-  if fsavedstate<>nil then
-    result:=fsavedstatesize
+  if fsavedstate <> nil then
+    Result := fsavedstatesize
   else
-    result:=0;
+    Result := 0;
 end;
 
 function TStructColumn.getEditWidth: integer;
 begin
-  if edtAddress<>nil then
-    result:=edtAddress.Width
+  if edtAddress <> nil then
+    Result := edtAddress.Width
   else
-    result:=0;
+    Result := 0;
 end;
 
 function TStructColumn.getEditLeft: integer;
 begin
-  if edtAddress<>nil then
-    result:=edtAddress.left
+  if edtAddress <> nil then
+    Result := edtAddress.left
   else
-    result:=0;
+    Result := 0;
 end;
 
-procedure TStructColumn.edtAddressChange(sender: TObject);  //todo: use an addressedit box instead
+procedure TStructColumn.edtAddressChange(Sender: TObject);
+//todo: use an addressedit box instead
 var
   invalidaddress: boolean;
   a: ptruint;
 begin
   //get the string in the editbox and parse it. On error, indicate with red text
-  a:=symhandler.getAddressFromName(edtAddress.Text, false, invalidaddress);
+  a := symhandler.getAddressFromName(edtAddress.Text, False, invalidaddress);
 
   if invalidaddress then
-    edtAddress.Font.Color:=clred
+    edtAddress.Font.Color := clred
   else
   begin
-    faddress:=a;
-    edtAddress.Font.Color:=clWindowText;
+    faddress := a;
+    edtAddress.Font.Color := clWindowText;
   end;
 
   parent.parent.tvStructureView.Refresh;
 end;
 
-procedure TStructColumn.ToggleLockClick(sender: TObject);
+procedure TStructColumn.ToggleLockClick(Sender: TObject);
 begin
   //togglelock is not set to autocheck, so if it's not checked, it needs to be checked
 
@@ -2554,78 +2730,79 @@ begin
   parent.parent.tvStructureView.Refresh;
 end;
 
-procedure TStructColumn.CutClick(sender: TObject);
+procedure TStructColumn.CutClick(Sender: TObject);
 begin
   edtAddress.CutToClipboard;
 end;
 
-procedure TStructColumn.CopyClick(sender: TObject);
+procedure TStructColumn.CopyClick(Sender: TObject);
 begin
   edtAddress.CopyToClipboard;
 end;
 
-procedure TStructColumn.PasteClick(sender: TObject);
+procedure TStructColumn.PasteClick(Sender: TObject);
 begin
   edtAddress.PasteFromClipboard;
 end;
 
-procedure TStructColumn.SpiderClick(sender: TObject);
+procedure TStructColumn.SpiderClick(Sender: TObject);
 //Opens the structure spider on the current address
-var f: Tfrmstringpointerscan;
+var
+  f: Tfrmstringpointerscan;
   ss: ptruint;
 begin
-  f:=Tfrmstringpointerscan.create(application);
+  f := Tfrmstringpointerscan.Create(application);
 
-  f.rbDatascan.Checked:=true;
-  f.edtBase.text:=edtAddress.Text;
-  ss:=ptruint(getSavedState);
+  f.rbDatascan.Checked := True;
+  f.edtBase.Text := edtAddress.Text;
+  ss := ptruint(getSavedState);
 
-  f.cbHasShadow.checked:=ss<>0;
+  f.cbHasShadow.Checked := ss <> 0;
 
-  if ss<>0 then
+  if ss <> 0 then
   begin
-    f.edtShadowAddress.Text:=inttohex(ss,8);
-    f.edtShadowSize.text:=inttostr(getSavedStateSize);
+    f.edtShadowAddress.Text := inttohex(ss, 8);
+    f.edtShadowSize.Text := IntToStr(getSavedStateSize);
   end;
 
 
-  f.show;
+  f.Show;
 end;
 
-procedure TStructColumn.SetCaptionClick(sender: TObject);
+procedure TStructColumn.SetCaptionClick(Sender: TObject);
 var
   i: integer;
   newname: string;
 begin
-  parent.parent.AutoSize:=false;
+  parent.parent.AutoSize := False;
 
-  newname:=lblname.caption;
+  newname := lblname.Caption;
   if InputQuery(rsSF2NewColumnName, rsSF2WhatNameShouldThisColumnHave, newname) then
-    lblname.caption:=newname;
+    lblname.Caption := newname;
 
-  lblname.visible:=lblname.caption<>'';
+  lblname.Visible := lblname.Caption <> '';
 
-  if lblname.Width+4>edtAddress.Width then
+  if lblname.Width + 4 > edtAddress.Width then
   begin
-    edtAddress.Width:=lblname.width+4;
-    focusedShape.Width:=edtAddress.width+2*(focusedshape.Pen.Width);
+    edtAddress.Width := lblname.Width + 4;
+    focusedShape.Width := edtAddress.Width + 2 * (focusedshape.Pen.Width);
   end;
 
   //update the header text as well
-  for i:=0 to parent.parent.columnCount-1 do
-    if parent.parent.columns[i]=self then
+  for i := 0 to parent.parent.columnCount - 1 do
+    if parent.parent.columns[i] = self then
     begin
-      parent.parent.HeaderControl1.Sections[i+1].Text:=newname;
+      parent.parent.HeaderControl1.Sections[i + 1].Text := newname;
       break;
     end;
 
 end;
 
-procedure TStructColumn.MenuPopup(sender: TObject);
+procedure TStructColumn.MenuPopup(Sender: TObject);
 begin
-  miCut.enabled:=edtAddress.SelLength>0;
-  miCopy.enabled:=edtAddress.SelLength>0;
-  miPaste.enabled:=Clipboard.HasFormat(CF_TEXT);
+  miCut.Enabled := edtAddress.SelLength > 0;
+  miCopy.Enabled := edtAddress.SelLength > 0;
+  miPaste.Enabled := Clipboard.HasFormat(CF_TEXT);
 end;
 
 procedure TStructColumn.SetProperEditboxPosition;
@@ -2635,308 +2812,314 @@ end;
 
 procedure TStructColumn.setSavedState(p: ptruint);
 begin
-  fsavedstate:=pointer(p);
+  fsavedstate := pointer(p);
 end;
 
 procedure TStructColumn.setAnchorsForPos(i: integer);
 begin
-  if i=0 then
+  if i = 0 then
   begin
-    edtAddress.AnchorSideTop.control:=parent.box;
-    edtAddress.AnchorSideTop.side:=asrTop;
-    edtAddress.BorderSpacing.Top:=4;
+    edtAddress.AnchorSideTop.control := parent.box;
+    edtAddress.AnchorSideTop.side := asrTop;
+    edtAddress.BorderSpacing.Top := 4;
 
-    edtAddress.AnchorSideLeft.control:=parent.box;
-    edtAddress.AnchorSideLeft.side:=asrLeft;
-    edtAddress.BorderSpacing.Left:=4;
+    edtAddress.AnchorSideLeft.control := parent.box;
+    edtAddress.AnchorSideLeft.side := asrLeft;
+    edtAddress.BorderSpacing.Left := 4;
   end
   else
   begin
-    edtAddress.AnchorSideTop.control:=parent.columns[i-1].edtAddress;
-    edtAddress.AnchorSideTop.side:=asrTop;
-    edtAddress.BorderSpacing.Top:=0;
+    edtAddress.AnchorSideTop.control := parent.columns[i - 1].edtAddress;
+    edtAddress.AnchorSideTop.side := asrTop;
+    edtAddress.BorderSpacing.Top := 0;
 
-    edtAddress.AnchorSideLeft.control:=parent.columns[i-1].edtAddress;
-    edtAddress.AnchorSideLeft.side:=asrRight;
-    edtAddress.BorderSpacing.Left:=4;
+    edtAddress.AnchorSideLeft.control := parent.columns[i - 1].edtAddress;
+    edtAddress.AnchorSideLeft.side := asrRight;
+    edtAddress.BorderSpacing.Left := 4;
   end;
 
 
 
-  if focusedShape<>nil then
+  if focusedShape <> nil then
   begin
-    focusedShape.AnchorSideLeft.Control:=edtAddress;
-    focusedShape.AnchorSideLeft.Side:=asrCenter;
-    focusedShape.AnchorSideTop.Control:=edtAddress;
-    focusedShape.AnchorSideTop.Side:=asrCenter;
+    focusedShape.AnchorSideLeft.Control := edtAddress;
+    focusedShape.AnchorSideLeft.Side := asrCenter;
+    focusedShape.AnchorSideTop.Control := edtAddress;
+    focusedShape.AnchorSideTop.Side := asrCenter;
   end;
 
-  if lblname<>nil then
+  if lblname <> nil then
   begin
-    lblname.AnchorSideTop.Control:=edtAddress;
-    lblname.AnchorSideTop.Side:=asrBottom;
-    lblname.AnchorSideLeft.control:=edtAddress;
-    lblname.AnchorSideLeft.side:=asrCenter;
+    lblname.AnchorSideTop.Control := edtAddress;
+    lblname.AnchorSideTop.Side := asrBottom;
+    lblname.AnchorSideLeft.control := edtAddress;
+    lblname.AnchorSideLeft.side := asrCenter;
   end;
-
 
 end;
 
-constructor TStructColumn.create(parent: TStructGroup);
-var hsection: THeaderSection;
+constructor TStructColumn.Create(parent: TStructGroup);
+var
+  hsection: THeaderSection;
   s: TMenuItem;
   i: integer;
   marginsize: integer;
 
   fsmultiplication: single;
 begin
-  if parent=nil then raise exception.create(rsSF2TStructColumnCreateError);
-  self.parent:=parent;
+  if parent = nil then
+    raise Exception.Create(rsSF2TStructColumnCreateError);
+  self.parent := parent;
 
-  columneditpopupmenu:=TPopupMenu.Create(parent.parent);
+  columneditpopupmenu := TPopupMenu.Create(parent.parent);
 
-  miToggleLock:=TMenuItem.create(columneditpopupmenu);
-  miToggleLock.caption:=rsLock;
-  miToggleLock.OnClick:=ToggleLockClick;
+  miToggleLock := TMenuItem.Create(columneditpopupmenu);
+  miToggleLock.Caption := rsLock;
+  miToggleLock.OnClick := ToggleLockClick;
   columneditpopupmenu.Items.Add(miToggleLock);
 
-  miChangeGroup:=TMenuItem.Create(columneditpopupmenu);
-  miChangeGroup.Caption:=rsChangeGroup2;
-  miChangeGroup.OnClick:=ChangeGroupClick;
+  miChangeGroup := TMenuItem.Create(columneditpopupmenu);
+  miChangeGroup.Caption := rsChangeGroup2;
+  miChangeGroup.OnClick := ChangeGroupClick;
   columneditpopupmenu.Items.Add(miChangeGroup);
 
-  miDelete:=TMenuItem.create(columneditpopupmenu);
-  miDelete.caption:=rsDeleteAddress;
-  miDelete.OnClick:=DeleteClick;
+  miDelete := TMenuItem.Create(columneditpopupmenu);
+  miDelete.Caption := rsDeleteAddress;
+  miDelete.OnClick := DeleteClick;
   columneditpopupmenu.Items.Add(miDelete);
 
   columneditpopupmenu.Items.AddSeparator;
 
-  miCut:=TMenuItem.create(columneditpopupmenu);
-  miCut.OnClick:=CutClick;
-  miCut.caption:=rsCut;
-  miCut.ShortCut:=TextToShortCut('Ctrl+X');
+  miCut := TMenuItem.Create(columneditpopupmenu);
+  miCut.OnClick := CutClick;
+  miCut.Caption := rsCut;
+  miCut.ShortCut := TextToShortCut('Ctrl+X');
   columneditpopupmenu.Items.Add(miCut);
 
-  miCopy:=TMenuItem.create(columneditpopupmenu);
-  miCopy.OnClick:=Copyclick;
-  miCopy.caption:=rsCopy;
-  miCopy.ShortCut:=TextToShortCut('Ctrl+C');
+  miCopy := TMenuItem.Create(columneditpopupmenu);
+  miCopy.OnClick := Copyclick;
+  miCopy.Caption := rsCopy;
+  miCopy.ShortCut := TextToShortCut('Ctrl+C');
   columneditpopupmenu.Items.Add(miCopy);
 
-  miPaste:=TMenuItem.create(columneditpopupmenu);
-  mipaste.OnClick:=PasteClick;
-  mipaste.caption:=rsPaste;
-  miPaste.ShortCut:=TextToShortCut('Ctrl+V');
+  miPaste := TMenuItem.Create(columneditpopupmenu);
+  mipaste.OnClick := PasteClick;
+  mipaste.Caption := rsPaste;
+  miPaste.ShortCut := TextToShortCut('Ctrl+V');
   columneditpopupmenu.Items.Add(miPaste);
 
 
-  miSpider:=TMenuItem.create(columneditpopupmenu);
-  miSpider.OnClick:=SpiderClick;
-  miSpider.caption:=rsSpider;
-  miSpider.ShortCut:=TextToShortCut('Ctrl+Alt+S');
+  miSpider := TMenuItem.Create(columneditpopupmenu);
+  miSpider.OnClick := SpiderClick;
+  miSpider.Caption := rsSpider;
+  miSpider.ShortCut := TextToShortCut('Ctrl+Alt+S');
   columneditpopupmenu.Items.Add(miSpider);
 
 
-  s:=TMenuItem.create(columneditpopupmenu);
-  s.caption:='-';
+  s := TMenuItem.Create(columneditpopupmenu);
+  s.Caption := '-';
   columneditpopupmenu.Items.Add(s);
 
-  miSetCaption:=TMenuItem.create(columneditpopupmenu);
-  miSetCaption.OnClick:=SetCaptionClick;
-  miSetCaption.caption:=rsSF2SetNameRename;
-  miSetCaption.ShortCut:=TextToShortCut('Ctrl+R');
+  miSetCaption := TMenuItem.Create(columneditpopupmenu);
+  miSetCaption.OnClick := SetCaptionClick;
+  miSetCaption.Caption := rsSF2SetNameRename;
+  miSetCaption.ShortCut := TextToShortCut('Ctrl+R');
   columneditpopupmenu.Items.Add(miSetCaption);
 
 
 
-  columneditpopupmenu.OnPopup:=MenuPopup;
+  columneditpopupmenu.OnPopup := MenuPopup;
 
 
 
 
-  i:=parent.fcolumns.add(self);
+  i := parent.fcolumns.add(self);
 
-  focusedShape:=TShape.Create(parent.parent);
-  focusedShape.Shape:=stRectangle;  //stRoundRect;
-  focusedShape.visible:=false;
-  focusedShape.parent:=parent.box;
-
-
-  edtAddress:=TEdit.Create(parent.parent);
-  edtAddress.Tag:=ptruint(self);
-  edtAddress.OnChange:=edtAddressChange;
-  edtAddress.PopupMenu:=columneditpopupmenu;
-  edtAddress.OnEnter:=edtAddressEnter;
-  edtAddress.Parent:=parent.box;
-  edtAddress.OnMouseDown:=edtaddressMousedown;
-
- // setAnchorsForPos(i);
-  edtAddress.BorderSpacing.Bottom:=3;
-  edtAddress.BorderSpacing.Right:=4;
+  focusedShape := TShape.Create(parent.parent);
+  focusedShape.Shape := stRectangle;  //stRoundRect;
+  focusedShape.Visible := False;
+  focusedShape.parent := parent.box;
 
 
-  if WindowsVersion>=wvVista then
+  edtAddress := TEdit.Create(parent.parent);
+  edtAddress.Tag := ptruint(self);
+  edtAddress.OnChange := edtAddressChange;
+  edtAddress.PopupMenu := columneditpopupmenu;
+  edtAddress.OnEnter := edtAddressEnter;
+  edtAddress.Parent := parent.box;
+  edtAddress.OnMouseDown := edtaddressMousedown;
+
+  // setAnchorsForPos(i);
+  edtAddress.BorderSpacing.Bottom := 3;
+  edtAddress.BorderSpacing.Right := 4;
+
+
+  if WindowsVersion >= wvVista then
   begin
-    marginsize:=sendmessage(edtAddress.Handle, EM_GETMARGINS, 0,0);
-    marginsize:=(marginsize shr 16)+(marginsize and $ffff);
+    marginsize := sendmessage(edtAddress.Handle, EM_GETMARGINS, 0, 0);
+    marginsize := (marginsize shr 16) + (marginsize and $ffff);
   end
   else
-    marginsize:=8;
+    marginsize := 8;
 
-  edtAddress.ClientWidth:=parent.parent.Canvas.TextWidth('DDDDDDDDFFFF')+marginsize;
-  edtAddress.Constraints.MinWidth:=edtAddress.Width;
+  edtAddress.ClientWidth := parent.parent.Canvas.TextWidth('DDDDDDDDFFFF') + marginsize;
+  edtAddress.Constraints.MinWidth := edtAddress.Width;
 
-  focusedShape.Width:=edtAddress.width+2*(focusedshape.Pen.Width);
-  focusedShape.Height:=edtAddress.Height+2*(focusedshape.Pen.Width);
+  focusedShape.Width := edtAddress.Width + 2 * (focusedshape.Pen.Width);
+  focusedShape.Height := edtAddress.Height + 2 * (focusedshape.Pen.Width);
 
 
 
-  hsection:=parent.parent.headercontrol1.Sections.Add;
-  hsection.Text:=rsAddressValue;
-  hsection.Width:=parent.parent.headercontrol1.Sections[parent.parent.headercontrol1.Sections.Count-2].width;
-  hsection.MinWidth:=20;
+  hsection := parent.parent.headercontrol1.Sections.Add;
+  hsection.Text := rsAddressValue;
+  hsection.Width := parent.parent.headercontrol1.Sections[
+    parent.parent.headercontrol1.Sections.Count - 2].Width;
+  hsection.MinWidth := 20;
 
-  lblName:=tlabel.create(parent.parent);
-  lblName.AutoSize:=true;
-  lblName.parent:=edtAddress.Parent;
-  lblName.Alignment:=taCenter;
-  lblName.visible:=false;
+  lblName := tlabel.Create(parent.parent);
+  lblName.AutoSize := True;
+  lblName.parent := edtAddress.Parent;
+  lblName.Alignment := taCenter;
+  lblName.Visible := False;
 
   setAnchorsForPos(i);
 
   parent.setPositions;
-  Address:=MemoryBrowser.hexview.address;
+  Address := MemoryBrowser.hexview.address;
 
-  backlist:=TStack.Create;
+  backlist := TStack.Create;
 
 end;
 
-destructor TStructColumn.destroy;
-var i: integer;
+destructor TStructColumn.Destroy;
+var
+  i: integer;
 begin
-  for i:=0 to parent.columnCount-2 do
-    if parent.columns[i]=self then
+  for i := 0 to parent.columnCount - 2 do
+    if parent.columns[i] = self then
     begin
-      parent.columns[i+1].edtAddress.BorderSpacing:=edtaddress.BorderSpacing;
-      parent.columns[i+1].edtAddress.AnchorSideTop:=edtAddress.AnchorSideTop;
-      parent.columns[i+1].edtAddress.AnchorSideLeft:=edtAddress.AnchorSideLeft;
+      parent.columns[i + 1].edtAddress.BorderSpacing := edtaddress.BorderSpacing;
+      parent.columns[i + 1].edtAddress.AnchorSideTop := edtAddress.AnchorSideTop;
+      parent.columns[i + 1].edtAddress.AnchorSideLeft := edtAddress.AnchorSideLeft;
       break;
     end;
 
   parent.fcolumns.remove(self);
-  parent.parent.headercontrol1.Sections.Delete(parent.parent.HeaderControl1.Sections.Count-1);
+  parent.parent.headercontrol1.Sections.Delete(
+    parent.parent.HeaderControl1.Sections.Count - 1);
 
   clearSavedState;
 
 
 
-  if edtAddress<>nil then
-    freeandnil(edtAddress);
+  if edtAddress <> nil then
+    FreeAndNil(edtAddress);
 
-  if focusedShape<>nil then
-    freeandnil(focusedShape);
+  if focusedShape <> nil then
+    FreeAndNil(focusedShape);
 
-  if lblname<>nil then
-    freeandnil(lblname);
+  if lblname <> nil then
+    FreeAndNil(lblname);
 
   //parent.setPositions;
 
-  if parent.fcolumns.Count=0 then
+  if parent.fcolumns.Count = 0 then
   begin
     //free the parent group unless it's already deleting itself
     //if it was, it already has removed itself from the form's grouplist
-    if parent.parent.fgroups.IndexOf(parent)<>-1 then  //damn!
-      freeandnil(parent);
+    if parent.parent.fgroups.IndexOf(parent) <> -1 then  //damn!
+      FreeAndNil(parent);
   end;
 
 
-  if backlist<>nil then
-    freeandnil(backlist);
+  if backlist <> nil then
+    FreeAndNil(backlist);
 
-  if (self.parent<>nil) and (self.parent.parent<>nil) then
+  if (self.parent <> nil) and (self.parent.parent <> nil) then
     self.parent.parent.FixPositions;
 end;
 
 { Tstructgroup }
-procedure TStructGroup.addString(s:string);
+procedure TStructGroup.addString(s: string);
 begin
   if isempty then
   begin
-    fcurrentString:=s;
-    isempty:=false;
+    fcurrentString := s;
+    isempty := False;
   end
   else
-    if fcurrentString<>s then
-      fMatches:=false;
+  if fcurrentString <> s then
+    fMatches := False;
 end;
 
-procedure TStructGroup.clear;
+procedure TStructGroup.Clear;
 begin
-  fMatches:=true;
-  isempty:=true;
+  fMatches := True;
+  isempty := True;
 end;
 
 procedure TStructGroup.setGroupName(newname: string);
 begin
-  groupbox.Caption:=newname;
-  fgroupname:=newname;
+  groupbox.Caption := newname;
+  fgroupname := newname;
 end;
 
-procedure TStructGroup.RenameClick(sender: tobject);
-var newname: string;
+procedure TStructGroup.RenameClick(Sender: TObject);
+var
+  newname: string;
 begin
-  newname:=groupname;
+  newname := groupname;
   if inputquery(rsSF2RenameGroup, rsSF2GiveTheNewNameForTheGroup, newname) then
-    groupname:=newname;
+    groupname := newname;
 end;
 
-procedure TStructGroup.DeleteClick(sender: tobject);
+procedure TStructGroup.DeleteClick(Sender: TObject);
 begin
   //delete he current group if it's not the last one
-  if parent.groupcount>1 then
-    free;
+  if parent.groupcount > 1 then
+    Free;
 end;
 
-procedure TStructGroup.groupboxresize(sender: TObject);
+procedure TStructGroup.groupboxresize(Sender: TObject);
 var
   i: integer;
   preferedheight: integer;
 begin
-  groupbox.OnResize:=nil;
-  preferedheight:=10;
-  for i:=0 to parent.groupcount-1 do
-    preferedheight:=max(parent.group[i].GroupBox.Height+2, preferedheight);
+  groupbox.OnResize := nil;
+  preferedheight := 10;
+  for i := 0 to parent.groupcount - 1 do
+    preferedheight := max(parent.group[i].GroupBox.Height + 2, preferedheight);
 
-  parent.pnlGroups.ClientHeight:=preferedheight;
+  parent.pnlGroups.ClientHeight := preferedheight;
 
-  groupbox.OnResize:=groupboxresize;
+  groupbox.OnResize := groupboxresize;
 end;
 
 function TStructGroup.getColumnCount: integer;
 begin
-  result:=fcolumns.count;
+  Result := fcolumns.Count;
 end;
 
 function TStructGroup.getColumn(i: integer): TStructColumn;
 begin
-  result:=fcolumns[i];
+  Result := fcolumns[i];
 end;
 
 function TStructGroup.getParent: TfrmStructures2;
 begin
-  result:=parent;
+  Result := parent;
 end;
 
 function TStructGroup.AColumnHasSetCaption: boolean;
-var i: integer;
+var
+  i: integer;
 begin
-  result:=false;
-  for i:=0 to columnCount-1 do
+  Result := False;
+  for i := 0 to columnCount - 1 do
   begin
-    if columns[i].lblName.caption<>'' then
+    if columns[i].lblName.Caption <> '' then
     begin
-      result:=true;
+      Result := True;
       exit;
     end;
   end;
@@ -2948,111 +3131,115 @@ begin
   parent.FixPositions;
 end;
 
-constructor TStructGroup.create(parent: TfrmStructures2; GroupName: string);
-var i: integer;
+constructor TStructGroup.Create(parent: TfrmStructures2; GroupName: string);
+var
+  i: integer;
 begin
-  self.parent:=parent;
-  i:=parent.fgroups.Add(self);
+  self.parent := parent;
+  i := parent.fgroups.Add(self);
 
-  fGroupName:=groupname;
+  fGroupName := groupname;
 
-  fcolumns:=tlist.create;
+  fcolumns := TList.Create;
 
-  grouppopup:=Tpopupmenu.create(parent);
-  miRename:=TmenuItem.create(grouppopup);
-  miRename.caption:=rsSF2Rename;
-  miRename.OnClick:=RenameClick;
+  grouppopup := Tpopupmenu.Create(parent);
+  miRename := TmenuItem.Create(grouppopup);
+  miRename.Caption := rsSF2Rename;
+  miRename.OnClick := RenameClick;
   grouppopup.items.Add(miRename);
 
-  miDelete:=TMenuItem.create(grouppopup);
-  miDelete.caption:=rsSF2DeleteGroup;
-  miDelete.OnClick:=DeleteClick;
+  miDelete := TMenuItem.Create(grouppopup);
+  miDelete.Caption := rsSF2DeleteGroup;
+  miDelete.OnClick := DeleteClick;
   grouppopup.items.Add(miDelete);
 
   //create the groupbox
-  GroupBox:=TGroupBox.Create(parent);
-  GroupBox.Caption:=groupname;
-  GroupBox.height:=parent.pnlGroups.ClientHeight;
-  groupbox.parent:=parent.pnlGroups;
-  groupbox.AutoSize:=true;
+  GroupBox := TGroupBox.Create(parent);
+  GroupBox.Caption := groupname;
+  GroupBox.Height := parent.pnlGroups.ClientHeight;
+  groupbox.parent := parent.pnlGroups;
+  groupbox.AutoSize := True;
 
-  groupbox.OnResize:=groupboxresize;
+  groupbox.OnResize := groupboxresize;
 
-  groupbox.popupmenu:=grouppopup;
+  groupbox.popupmenu := grouppopup;
 
-  if i=0 then
+  if i = 0 then
   begin
-    groupbox.AnchorSideTop.Control:=parent.pnlGroups;
-    groupbox.AnchorSideTop.Side:=asrTop;
+    groupbox.AnchorSideTop.Control := parent.pnlGroups;
+    groupbox.AnchorSideTop.Side := asrTop;
 
-    groupbox.AnchorSideLeft.Control:=parent.pnlGroups;
-    groupbox.AnchorSideLeft.Side:=asrLeft;
+    groupbox.AnchorSideLeft.Control := parent.pnlGroups;
+    groupbox.AnchorSideLeft.Side := asrLeft;
   end
   else
   begin
-    groupbox.AnchorSideTop.Control:=parent.group[i-1].GroupBox;
-    groupbox.AnchorSideTop.Side:=asrTop;
+    groupbox.AnchorSideTop.Control := parent.group[i - 1].GroupBox;
+    groupbox.AnchorSideTop.Side := asrTop;
 
-    groupbox.AnchorSideLeft.Control:=parent.group[i-1].GroupBox;
-    groupbox.AnchorSideLeft.Side:=asrRight;
-    groupbox.BorderSpacing.Left:=8;
+    groupbox.AnchorSideLeft.Control := parent.group[i - 1].GroupBox;
+    groupbox.AnchorSideLeft.Side := asrRight;
+    groupbox.BorderSpacing.Left := 8;
   end;
 
 end;
 
-destructor TStructGroup.destroy;
-var i: integer;
+destructor TStructGroup.Destroy;
+var
+  i: integer;
   g: tgroupbox;
 begin
   //delete all the columns first
-  i:=parent.fgroups.IndexOf(self);
-  if i<parent.fgroups.count-1 then
+  i := parent.fgroups.IndexOf(self);
+  if i < parent.fgroups.Count - 1 then
   begin
     //has stuff right of it
-    g:=TStructGroup(parent.fgroups[i+1]).GroupBox;
+    g := TStructGroup(parent.fgroups[i + 1]).GroupBox;
 
-    g.AnchorSideTop:=groupbox.AnchorSideTop;
-    g.AnchorSideLeft:=groupbox.AnchorSideLeft;
-    g.BorderSpacing.Left:=groupbox.BorderSpacing.Left;
+    g.AnchorSideTop := groupbox.AnchorSideTop;
+    g.AnchorSideLeft := groupbox.AnchorSideLeft;
+    g.BorderSpacing.Left := groupbox.BorderSpacing.Left;
   end;
 
   parent.fgroups.Remove(self);
 
-  while fcolumns.count>0 do
-    TStructColumn(fcolumns[0]).free;
+  while fcolumns.Count > 0 do
+    TStructColumn(fcolumns[0]).Free;
 
   fcolumns.Clear;
 
-  if groupbox<>nil then
-    freeandnil(groupbox);
+  if groupbox <> nil then
+    FreeAndNil(groupbox);
 
-  if grouppopup<>nil then
-    freeandnil(grouppopup);
+  if grouppopup <> nil then
+    FreeAndNil(grouppopup);
 
-  if fcolumns<>nil then
-    freeandnil(fcolumns);
+  if fcolumns <> nil then
+    FreeAndNil(fcolumns);
 
-  inherited destroy;
+  inherited Destroy;
 end;
 
 { TfrmStructures2 }
 
-procedure TfrmStructures2.TreeViewVScroll(sender: TObject);
+procedure TfrmStructures2.TreeViewVScroll(Sender: TObject);
 begin
   RefreshVisibleNodes;
 end;
 
-procedure TfrmStructures2.TreeViewHScroll(sender: TObject; scrolledleft, maxscrolledleft: integer);
+procedure TfrmStructures2.TreeViewHScroll(Sender: TObject;
+  scrolledleft, maxscrolledleft: integer);
 begin
   //The problem with this solution is that there is a limit the value can be negative
-  HeaderControl1.Left:=-scrolledleft;
-  HeaderControl1.Width:=tvStructureView.clientwidth  +maxscrolledleft+100;
+  HeaderControl1.Left := -scrolledleft;
+  HeaderControl1.Width := tvStructureView.clientwidth + maxscrolledleft + 100;
 
 end;
 
 
 procedure TfrmStructures2.FormDestroy(Sender: TObject);
-var showaddress: integer;
+var
+  showaddress: integer;
   descriptionsize: integer;
   autoguess: integer;
   defaultstructsize: integer;
@@ -3061,67 +3248,72 @@ begin
   frmStructures2.Remove(self);
 
   //save the settings
-  if miShowAddresses.checked then showaddress:=1 else showaddress:=0;
-  if miAutoCreate.checked then autoguess:=1 else autoguess:=0;
+  if miShowAddresses.Checked then
+    showaddress := 1
+  else
+    showaddress := 0;
+  if miAutoCreate.Checked then
+    autoguess := 1
+  else
+    autoguess := 0;
 
-  descriptionsize:=HeaderControl1.Sections[0].Width;
+  descriptionsize := HeaderControl1.Sections[0].Width;
 
-  setlength(x,3);
-  x[0]:=showaddress;
-  x[1]:=autoguess;
-  x[2]:=descriptionsize;
+  setlength(x, 3);
+  x[0] := showaddress;
+  x[1] := autoguess;
+  x[2] := descriptionsize;
   SaveFormPosition(self, x);
 
-  if frmStructuresNewStructure<>nil then
-    freeandnil(frmStructuresNewStructure);
+  if frmStructuresNewStructure <> nil then
+    FreeAndNil(frmStructuresNewStructure);
 end;
 
 procedure TfrmStructures2.FormCreate(Sender: TObject);
-var x: array of integer;
+var
+  x: array of integer;
 begin
   //set default colors
 
 
 
-  if frmStructuresConfig=nil then
-    frmStructuresConfig:=TfrmStructuresConfig.Create(application);
+  if frmStructuresConfig = nil then
+    frmStructuresConfig := TfrmStructuresConfig.Create(application);
 
-  tvStructureView.Top:=headercontrol1.top+headercontrol1.height;
-  tvStructureView.left:=0;
-  tvStructureView.width:=clientwidth;
-  tvStructureView.height:=clientheight-tvStructureView.Top;
+  tvStructureView.Top := headercontrol1.top + headercontrol1.Height;
+  tvStructureView.left := 0;
+  tvStructureView.Width := clientwidth;
+  tvStructureView.Height := clientheight - tvStructureView.Top;
 
-  tvStructureView.onHScroll:=TreeViewHScroll;
-  tvStructureView.onVScroll:=TreeViewVScroll;
+  tvStructureView.onHScroll := TreeViewHScroll;
+  tvStructureView.onVScroll := TreeViewVScroll;
 
 
   frmStructures2.Add(self);
 
   RefreshStructureList; //get the current structure list
 
-  fgroups:=tlist.create;
+  fgroups := TList.Create;
 
-  setlength(x,3);
+  setlength(x, 3);
   if LoadFormPosition(self, x) then
   begin
-    if length(x)>0 then
+    if length(x) > 0 then
     begin
-      miShowAddresses.checked:=x[0]=1;
-      miAutoCreate.checked:=x[1]=1;
-      HeaderControl1.Sections[0].Width:=x[2];
+      miShowAddresses.Checked := x[0] = 1;
+      miAutoCreate.Checked := x[1] = 1;
+      HeaderControl1.Sections[0].Width := x[2];
     end;
   end;
 
 
   setupColors; //load colors and default struct options
 
-
 end;
 
-procedure TfrmStructures2.FormClose(Sender: TObject;
-  var CloseAction: TCloseAction);
+procedure TfrmStructures2.FormClose(Sender: TObject; var CloseAction: TCloseAction);
 begin
-  CloseAction:=cafree;
+  CloseAction := cafree;
 end;
 
 
@@ -3129,20 +3321,22 @@ end;
 
 procedure TfrmStructures2.FormShow(Sender: TObject);
 begin
-  HeaderControl1.Height:=canvas.TextHeight('XgjQh'+HeaderControl1.Sections[0].Text)+4;
-  if (initialaddress<>0) and (columnCount=0) then  //add the initial address, else it looks so sad...
+  HeaderControl1.Height := canvas.TextHeight('XgjQh' +
+    HeaderControl1.Sections[0].Text) + 4;
+  if (initialaddress <> 0) and (columnCount = 0) then
+    //add the initial address, else it looks so sad...
   begin
     addColumn;
     columns[0].setAddress(initialaddress);
-    columns[0].setFocused(true);
+    columns[0].setFocused(True);
     columns[0].edtAddress.SetFocus;
   end;
 
-  tvStructureView.Font.Height:=GetFontData(font.handle).Height;
-  if tvStructureView.Font.Height>-15 then
-    tvStructureView.Font.Height:=-15;
+  tvStructureView.Font.Height := GetFontData(font.handle).Height;
+  if tvStructureView.Font.Height > -15 then
+    tvStructureView.Font.Height := -15;
 
-  if (frmStructuresConfig<>nil) and (frmStructuresConfig.customfont) then
+  if (frmStructuresConfig <> nil) and (frmStructuresConfig.customfont) then
     tvStructureView.font.Assign(frmStructuresConfig.GroupBox1.Font);
 end;
 
@@ -3153,24 +3347,25 @@ begin
   SetupFirstNodeLength;
   tvStructureView.ReAlign;
 
-  HeaderControl.Left:=-tvStructureView.scrolledleft;
-//  self.FixPositions;
+  HeaderControl.Left := -tvStructureView.scrolledleft;
+  //  self.FixPositions;
 end;
 
 procedure TfrmStructures2.HeaderControl1SectionTrack(
-  HeaderControl: TCustomHeaderControl; Section: THeaderSection; Width: Integer;
-  State: TSectionTrackState);
-var x: integer;
-    s: string;
+  HeaderControl: TCustomHeaderControl;
+  Section: THeaderSection; Width: integer; State: TSectionTrackState);
+var
+  x: integer;
+  s: string;
 
 begin
-  if gettickcount>lastresizecheck+50 then
+  if gettickcount > lastresizecheck + 50 then
   begin
-    lastresizecheck:=GetTickCount;
+    lastresizecheck := GetTickCount;
     SetupFirstNodeLength;
     tvStructureView.ReAlign;
 
-    HeaderControl.Left:=-tvStructureView.scrolledleft;
+    HeaderControl.Left := -tvStructureView.scrolledleft;
   end;
 
   tvStructureView.Repaint;
@@ -3193,145 +3388,154 @@ var
   parentelement: TStructelement;
   n: TStructelement;
 begin
-  baseaddress:=column.Address;
-  setlength(offsetlist,0);
+  baseaddress := column.Address;
+  setlength(offsetlist, 0);
 
-  if (node=nil) or (node.level=0) then exit; //first entry in the mainstruct
+  if (node = nil) or (node.level = 0) then
+    exit; //first entry in the mainstruct
 
-  setlength(offsetlist, node.Level-1);
-  lastoffsetentry:=node.level-2;
+  setlength(offsetlist, node.Level - 1);
+  lastoffsetentry := node.level - 2;
 
 
-  i:=0;
-  while node.level>1 do
+  i := 0;
+  while node.level > 1 do
   begin
-    prevnode:=node.parent;
+    prevnode := node.parent;
 
-    parentelement:=getStructElementFromNode(node.parent);
-    if parentelement<>nil then
-      displacement:=parentelement.ChildStructStart
+    parentelement := getStructElementFromNode(node.parent);
+    if parentelement <> nil then
+      displacement := parentelement.ChildStructStart
     else
-      displacement:=0;
+      displacement := 0;
 
-    n:=getStructElementFromNode(node);
-    if n=nil then
+    n := getStructElementFromNode(node);
+    if n = nil then
     begin
-      baseaddress:=0;
-      setlength(offsetlist,0);
+      baseaddress := 0;
+      setlength(offsetlist, 0);
       exit;
     end;
 
-    offsetlist[i]:=n.Offset-displacement;
-    inc(i);
+    offsetlist[i] := n.Offset - displacement;
+    Inc(i);
 
-    node:=prevnode;
+    node := prevnode;
   end;
 
   //now at node.level=1
   //add the starting offset
-  inc(baseaddress, getStructElementFromNode(node).Offset);
+  Inc(baseaddress, getStructElementFromNode(node).Offset);
 end;
 
 
 
-function getPointerAddressOverride(c: TStructColumn; address: ptruint; const offsets: array of integer; var hasError: boolean): ptruint;
-//special version of the normal getPointerAddress with support for locked addresses
-var realaddress, realaddress2: PtrUInt;
-    count: ptruint;
-    check: boolean;
-    i: integer;
+function getPointerAddressOverride(c: TStructColumn; address: ptruint;
+  const offsets: array of integer; var hasError: boolean): ptruint;
+  //special version of the normal getPointerAddress with support for locked addresses
+var
+  realaddress, realaddress2: PtrUInt;
+  Count: ptruint;
+  check: boolean;
+  i: integer;
 
-    savedstate: ptruint;
+  savedstate: ptruint;
 begin
-  savedstate:=ptruint(c.getSavedState);
-  realaddress2:=address;
+  savedstate := ptruint(c.getSavedState);
+  realaddress2 := address;
 
 
-  for i:=length(offsets)-1 downto 0 do
+  for i := length(offsets) - 1 downto 0 do
   begin
-    realaddress:=0;
-    if (savedstate<>0) and (InRangeX(realaddress2, c.Address, c.address+ c.getSavedStateSize)) then
-       realaddress2:=realaddress2+(savedstate-c.address);
+    realaddress := 0;
+    if (savedstate <> 0) and (InRangeX(realaddress2, c.Address, c.address +
+      c.getSavedStateSize)) then
+      realaddress2 := realaddress2 + (savedstate - c.address);
 
 
-    check:=readprocessmemory(processhandle,pointer(realaddress2),@realaddress,processhandler.pointersize,count);
-    if check and (count=processhandler.pointersize) then
-      realaddress2:=realaddress+offsets[i]
+    check := readprocessmemory(processhandle, pointer(realaddress2),
+      @realaddress, processhandler.pointersize, Count);
+    if check and (Count = processhandler.pointersize) then
+      realaddress2 := realaddress + offsets[i]
     else
     begin
-      hasError:=true;
-      result:=0;
+      hasError := True;
+      Result := 0;
 
       exit;
     end;
   end;
 
-  result:=realAddress2;
+  Result := realAddress2;
 
 
-  hasError:=false;
+  hasError := False;
 end;
 
-function TfrmStructures2.getAddressFromNode(node: TTreenode; column: TStructColumn; var hasError: boolean): ptruint;
-//Find out the address of this node
+function TfrmStructures2.getAddressFromNode(node: TTreenode;
+  column: TStructColumn; var hasError: boolean): ptruint;
+  //Find out the address of this node
 var
   baseaddress: ptruint;
   offsets: array of integer;
 begin
-  getPointerFromNode(node,column, baseaddress, offsets);
-  result:=getPointerAddressOverride(column, baseaddress,  offsets, hasError);
+  getPointerFromNode(node, column, baseaddress, offsets);
+  Result := getPointerAddressOverride(column, baseaddress, offsets, hasError);
 end;
 
 
-procedure TfrmStructures2.setCurrentNodeStringsInColumns(node: TTreenode; element: TStructElement; highlighted: boolean=false);
+procedure TfrmStructures2.setCurrentNodeStringsInColumns(node: TTreenode;
+  element: TStructElement; highlighted: boolean = False);
 {
 This method will get the address and value of the current node and store them temporarily in the column for the renderer to fetch
 }
 var
-    i: integer;
-    error: boolean;
-    address, displayaddress: ptruint;
+  i: integer;
+  error: boolean;
+  address, displayaddress: ptruint;
 
-    groupvalue: string;
-    allmatch: boolean;
-    allsame: boolean;
+  groupvalue: string;
+  allmatch: boolean;
+  allsame: boolean;
 
-    c: TStructColumn;
-    savedstate: ptruint;
-    everythinghex: boolean;
+  c: TStructColumn;
+  savedstate: ptruint;
+  everythinghex: boolean;
 
 begin
-  if element<>nil then
+  if element <> nil then
   begin
-    for i:=0 to groupcount-1 do
-      group[i].clear;
+    for i := 0 to groupcount - 1 do
+      group[i].Clear;
 
-    everythinghex:=miEverythingHex.checked;
+    everythinghex := miEverythingHex.Checked;
 
-    for i:=0 to columnCount-1 do
+    for i := 0 to columnCount - 1 do
     begin
-      c:=columns[i];
+      c := columns[i];
 
-      displayaddress:=getAddressFromNode(node, columns[i], error);  //get the address to show the user
+      displayaddress := getAddressFromNode(node, columns[i], error);
+      //get the address to show the user
 
-      savedstate:=ptruint(c.getSavedState);
-      address:=displayaddress;
+      savedstate := ptruint(c.getSavedState);
+      address := displayaddress;
 
-      if (savedstate<>0) and (InRangeX(address, c.Address, c.address+ c.getSavedStateSize)) then
-        address:=address+(savedstate-c.address);
+      if (savedstate <> 0) and (InRangeX(address, c.Address,
+        c.address + c.getSavedStateSize)) then
+        address := address + (savedstate - c.address);
 
 
 
 
       if not error then
       begin
-        c.currentNodeAddress:=inttohex(displayaddress,1)+' : ';
-        c.currentNodeValue:=element.getValue(address, false, everythinghex);
+        c.currentNodeAddress := inttohex(displayaddress, 1) + ' : ';
+        c.currentNodeValue := element.getValue(address, False, everythinghex);
       end
       else
       begin
-        c.currentNodeAddress:='??? : ';
-        c.currentNodeValue:='???';
+        c.currentNodeAddress := '??? : ';
+        c.currentNodeValue := '???';
       end;
 
       //add this string for comparison
@@ -3339,65 +3543,66 @@ begin
     end;
 
     //now find out which groups have matching sets
-    allmatch:=true;
-    allsame:=true;
+    allmatch := True;
+    allsame := True;
 
-    groupvalue:='';
-    for i:=0 to groupcount-1 do
+    groupvalue := '';
+    for i := 0 to groupcount - 1 do
     begin
-      if group[i].Matches=false then
+      if group[i].Matches = False then
       begin
-        allmatch:=false;
-        allsame:=false;
+        allmatch := False;
+        allsame := False;
         break;
       end;
 
-      if i=0 then
-        groupvalue:=group[0].currentString
+      if i = 0 then
+        groupvalue := group[0].currentString
       else
       begin
-        if groupvalue<>group[i].currentString then
-          allsame:=false;
+        if groupvalue <> group[i].currentString then
+          allsame := False;
       end;
     end;
 
 
-    for i:=0 to columncount-1 do
+    for i := 0 to columncount - 1 do
     begin
-      c:=columns[i];
+      c := columns[i];
 
       if c.parent.Matches then
       begin
         if not highlighted then
-          c.currentNodeColor:=fMatchColor //default match color
+          c.currentNodeColor := fMatchColor //default match color
         else
-          c.currentNodeColor:=fMatchColorHighlighted;
+          c.currentNodeColor := fMatchColorHighlighted;
 
 
-        if (groupcount>1) and allmatch then //if all the groups have columns that match, and more than 1 group, then
+        if (groupcount > 1) and allmatch then
+          //if all the groups have columns that match, and more than 1 group, then
         begin
           if allsame then //if all the groups have the same value then
           begin
             if not highlighted then
-              c.currentNodeColor:=fAllMatchColorSame
+              c.currentNodeColor := fAllMatchColorSame
             else
-              c.currentNodeColor:=fAllMatchColorSameHighlighted;
+              c.currentNodeColor := fAllMatchColorSameHighlighted;
           end
           else
           begin
             if not highlighted then
-              c.currentNodeColor:=fAllMatchColorDiff
+              c.currentNodeColor := fAllMatchColorDiff
             else
-              c.currentNodeColor:=fAllMatchColorDiffHighlighted;
+              c.currentNodeColor := fAllMatchColorDiffHighlighted;
           end;
         end;
       end
       else
       begin
         if not highlighted then
-          c.currentNodeColor:=fNoMatchColor
+          c.currentNodeColor := fNoMatchColor
         else
-          c.currentNodeColor:=fNoMatchColorHighlighted;
+          c.currentNodeColor := fNoMatchColorHighlighted;
       end;
     end;
 
@@ -3405,48 +3610,48 @@ begin
   else
   begin
     //invalid struct
-    for i:=0 to columnCount-1 do
+    for i := 0 to columnCount - 1 do
     begin
-      c:=columns[i];
+      c := columns[i];
       if not highlighted then
-        c.currentNodeColor:=tvStructureView.BackgroundColor
+        c.currentNodeColor := tvStructureView.BackgroundColor
       else
-        c.currentNodeColor:=tvStructureView.SelectionColor;
+        c.currentNodeColor := tvStructureView.SelectionColor;
 
-      c.currentNodeValue:='';
-      c.currentNodeAddress:='';
+      c.currentNodeValue := '';
+      c.currentNodeAddress := '';
     end;
   end;
 end;
 
 procedure TfrmStructures2.setupNodeWithElement(node: TTreenode; element: TStructElement);
 begin
-  tvStructureView.OnCollapsing:=nil;
-  tvStructureView.OnCollapsed:=nil;
+  tvStructureView.OnCollapsing := nil;
+  tvStructureView.OnCollapsed := nil;
 
   try
     if (element.isPointer) then
     begin
-      node.Data:=element.ChildStruct;
-      if node.data=nil then
+      node.Data := element.ChildStruct;
+      if node.Data = nil then
         node.DeleteChildren;
 
-      node.HasChildren:=true;
+      node.HasChildren := True;
     end
     else
     begin
       //an update caused this node to lose it's pointerstate. If it had children, it doesn't anymore
-      node.data:=nil;
+      node.Data := nil;
       node.DeleteChildren;
-      node.haschildren:=false;
+      node.haschildren := False;
     end;
 
 
 
 
   finally
-    tvStructureView.OnCollapsing:=tvStructureViewCollapsing;
-    tvStructureView.OnCollapsed:=tvStructureViewCollapsed;
+    tvStructureView.OnCollapsing := tvStructureViewCollapsing;
+    tvStructureView.OnCollapsed := tvStructureViewCollapsed;
   end;
 end;
 
@@ -3458,93 +3663,95 @@ var
   i: integer;
   startindex: integer;
 begin
-  tvStructureView.OnExpanded:=nil;
-  tvStructureView.OnExpanding:=nil;
-  tvStructureView.OnCollapsed:=nil;
-  tvStructureView.OnCollapsing:=nil;
+  tvStructureView.OnExpanded := nil;
+  tvStructureView.OnExpanding := nil;
+  tvStructureView.OnCollapsed := nil;
+  tvStructureView.OnCollapsing := nil;
 
   tvStructureView.BeginUpdate;
   if currentnode.haschildren then
     currentnode.DeleteChildren;
 
-  struct:=TDissectedStruct(currentnode.data);
+  struct := TDissectedStruct(currentnode.Data);
 
 
 
-  if struct<>nil then
+  if struct <> nil then
   begin
     //get the start index of this structure
-    startindex:=0;
-    se:=getStructElementFromNode(currentnode);
-    if (se<>nil) and (se.ChildStructStart<>0) then
-      startindex:=struct.getIndexOfOffset(se.ChildStructStart);
+    startindex := 0;
+    se := getStructElementFromNode(currentnode);
+    if (se <> nil) and (se.ChildStructStart <> 0) then
+      startindex := struct.getIndexOfOffset(se.ChildStructStart);
 
-    for i:=startindex to struct.count-1 do
+    for i := startindex to struct.Count - 1 do
     begin
-      newnode:=tvStructureView.Items.AddChild(currentnode,'');
+      newnode := tvStructureView.Items.AddChild(currentnode, '');
       setupNodeWithElement(newnode, struct[i]);
     end;
 
     if currentnode.haschildren then
-      currentnode.Expand(false);
+      currentnode.Expand(False);
   end;
 
   tvStructureView.EndUpdate;
 
-  tvStructureView.OnExpanded:=tvStructureViewExpanded;
-  tvStructureView.OnExpanding:=tvStructureViewExpanding;
-  tvStructureView.OnCollapsed:=tvStructureViewCollapsed;
-  tvStructureView.OnCollapsing:=tvStructureViewCollapsing;
+  tvStructureView.OnExpanded := tvStructureViewExpanded;
+  tvStructureView.OnExpanding := tvStructureViewExpanding;
+  tvStructureView.OnCollapsed := tvStructureViewCollapsed;
+  tvStructureView.OnCollapsing := tvStructureViewCollapsing;
 end;
 
 
 procedure TfrmStructures2.tvStructureViewCollapsed(Sender: TObject; Node: TTreeNode);
-var struct, childstruct: TDissectedStruct;
+var
+  struct, childstruct: TDissectedStruct;
 begin
   tvStructureView.BeginUpdate;
   try
     if node.HasChildren then
     begin
-      tvStructureView.OnCollapsing:=nil;
-      tvStructureView.OnCollapsed:=nil;
+      tvStructureView.OnCollapsing := nil;
+      tvStructureView.OnCollapsed := nil;
 
       node.DeleteChildren; //delete the children when collapsed
 
-      tvStructureView.OnCollapsing:=tvStructureViewCollapsing;
-      tvStructureView.OnCollapsed:=tvStructureViewCollapsed;
+      tvStructureView.OnCollapsing := tvStructureViewCollapsing;
+      tvStructureView.OnCollapsed := tvStructureViewCollapsed;
 
     end;
 
-    if node.parent<>nil then //almost always, and then it IS a child
+    if node.parent <> nil then //almost always, and then it IS a child
     begin
       //get the structure this node belongs to
 
-      struct:=getStructFromNode(node);
+      struct := getStructFromNode(node);
 
-      if (struct=nil) or (struct.structelementlist=nil) then exit; //this whole structure is destroyed
+      if (struct = nil) or (struct.structelementlist = nil) then
+        exit; //this whole structure is destroyed
 
       //now get the element this node represents and check if it is a pointer
-      if node.Index>=struct.count then
+      if node.Index >= struct.Count then
       begin
         outputdebugstring('Error at tvStructureViewCollapsed. node.Index>=struct.count');
         exit;
       end;
-      node.HasChildren:=struct[node.Index].isPointer;
+      node.HasChildren := struct[node.Index].isPointer;
 
-      if miAutoDestroyLocal.checked then //delete autocreated local structs when closed
+      if miAutoDestroyLocal.Checked then //delete autocreated local structs when closed
       begin
-        childstruct:=TDissectedStruct(node.data);
-        if childstruct<>nil then
+        childstruct := TDissectedStruct(node.Data);
+        if childstruct <> nil then
         begin
           if not childstruct.isInGlobalStructList then
           begin
             //delete this local struct
-            freeandnil(childstruct);
+            FreeAndNil(childstruct);
 
             {$ifdef DEBUG}
-            assert(node.data=nil);
+            assert(node.Data = nil);
             {$endif}
-            node.data:=nil;   //not necessary
+            node.Data := nil;   //not necessary
           end;
         end;
 
@@ -3552,10 +3759,10 @@ begin
 
     end
     else //root node (mainstruct)
-    if node.data<>nil then //weird if not...
+    if node.Data <> nil then //weird if not...
     begin
-      node.HasChildren:=true;
-      node.Expand(false); //causes the expand the fill in the nodes
+      node.HasChildren := True;
+      node.Expand(False); //causes the expand the fill in the nodes
     end;
 
 
@@ -3565,23 +3772,22 @@ begin
 end;
 
 procedure TfrmStructures2.tvStructureViewCollapsing(Sender: TObject;
-  Node: TTreeNode; var AllowCollapse: Boolean);
+  Node: TTreeNode; var AllowCollapse: boolean);
 begin
-  AllowCollapse:=node.level>0;
-
+  AllowCollapse := node.level > 0;
 
 end;
 
-procedure TfrmStructures2.tvStructureViewExpanded(Sender: TObject;
-  Node: TTreeNode);
+procedure TfrmStructures2.tvStructureViewExpanded(Sender: TObject; Node: TTreeNode);
 begin
-  if node.data<>nil then
-    FillTreenodeWithStructData(node)
+  if node.Data <> nil then
+    FillTreenodeWithStructData(node);
 end;
 
 procedure TfrmStructures2.tvStructureViewExpanding(Sender: TObject;
-  Node: TTreeNode; var AllowExpansion: Boolean);
-var n: TStructelement;
+  Node: TTreeNode; var AllowExpansion: boolean);
+var
+  n: TStructelement;
   error: boolean;
 
   address, address2: ptruint;
@@ -3591,29 +3797,30 @@ var n: TStructelement;
   savedstate: PtrUInt;
   structName: string;
 begin
-  AllowExpansion:=true;
-  n:=getStructElementFromNode(node);
+  AllowExpansion := True;
+  n := getStructElementFromNode(node);
 
 
-  if (n<>nil) and (n.ExpandChangesAddress) then
+  if (n <> nil) and (n.ExpandChangesAddress) then
   begin
     //change address and the structure if needed
-    AllowExpansion:=false;
+    AllowExpansion := False;
 
-    c:=getFocusedColumn;
-    address:=getAddressFromNode(node, c, error);
+    c := getFocusedColumn;
+    address := getAddressFromNode(node, c, error);
     if not error then
     begin
       //dereference the pointer and fill it in if possible
-      address2:=0;
-      if ReadProcessMemory(processhandle, pointer(address), @address2, processhandler.pointersize, x) then
+      address2 := 0;
+      if ReadProcessMemory(processhandle, pointer(address), @address2,
+        processhandler.pointersize, x) then
       begin
         if ReadProcessMemory(processhandle, pointer(address2), @address2, 1, x) then
         begin
-          c:=getFocusedColumn;
+          c := getFocusedColumn;
           c.pushAddress;
-          c.Address:=address2-n.ChildStructStart;
-          mainStruct:=n.ChildStruct;
+          c.Address := address2 - n.ChildStructStart;
+          mainStruct := n.ChildStruct;
         end;
       end;
     end;
@@ -3622,96 +3829,101 @@ begin
   end;
 
 
-  if (n<>nil) and (n.isPointer) and (n.ChildStruct=nil) then
+  if (n <> nil) and (n.isPointer) and (n.ChildStruct = nil) then
   begin
     if miAutoCreate.Checked then
     begin
 
       //create a structure
-      c:=getFocusedColumn;
-      if c=nil then
-        c:=columns[0];
+      c := getFocusedColumn;
+      if c = nil then
+        c := columns[0];
 
-      address:=getAddressFromNode(node, c, error);
+      address := getAddressFromNode(node, c, error);
 
-      savedstate:=ptruint(c.getSavedState);
-      if (savedstate<>0) and (InRangeX(address, c.Address, c.address+ c.getSavedStateSize)) then
-        address:=address+(savedstate-c.address);
+      savedstate := ptruint(c.getSavedState);
+      if (savedstate <> 0) and (InRangeX(address, c.Address,
+        c.address + c.getSavedStateSize)) then
+        address := address + (savedstate - c.address);
 
       if not error then
       begin
         //dereference the pointer and fill it in if possible
 
-        if ReadProcessMemory(processhandle, pointer(address), @address, processhandler.pointersize, x) then
+        if ReadProcessMemory(processhandle, pointer(address), @address,
+          processhandler.pointersize, x) then
         begin
           //adjust the address again if it's inside the savedstate
-          if (savedstate<>0) and (InRangeX(address, c.Address, c.address+ c.getSavedStateSize)) then
-            address:=address+(savedstate-c.address);
+          if (savedstate <> 0) and
+            (InRangeX(address, c.Address, c.address + c.getSavedStateSize)) then
+            address := address + (savedstate - c.address);
 
           //check if the address pointed to is readable
           if ReadProcessMemory(processhandle, pointer(address), @temp, 1, x) then
           begin
-            structName:=lookupStructureName(address, rsSF2AutocreatedFrom+inttohex(address,8));
-            n.AutoCreateChildStruct(structName, address)
+            structName := lookupStructureName(address,
+              rsSF2AutocreatedFrom + inttohex(address, 8));
+            n.AutoCreateChildStruct(structName, address);
           end
           else
-            error:=true;
+            error := True;
         end
         else
-          error:=true;
+          error := True;
       end;
 
-      AllowExpansion:=not error;
+      AllowExpansion := not error;
     end
     else
-      AllowExpansion:=false;
+      AllowExpansion := False;
 
   end;
 end;
 
 function TfrmStructures2.getMainStruct: TDissectedStruct;
 begin
-  result:=mainStruct;
+  Result := mainStruct;
 end;
 
-function TfrmStructures2.getHorizontalScrollbarString: String; //returns a string out of spaces that fills up the length of all the columns combined
+function TfrmStructures2.getHorizontalScrollbarString: string;
+  //returns a string out of spaces that fills up the length of all the columns combined
 var
   i: integer;
   s: THeaderSection;
   totalwidth: integer;
   currentwidth: integer;
 begin
-  currentwidth:=0;
-  result:='';
-  s:=HeaderControl1.Sections[HeaderControl1.Sections.Count-1];
-  totalwidth:=s.Left+s.Width;
+  currentwidth := 0;
+  Result := '';
+  s := HeaderControl1.Sections[HeaderControl1.Sections.Count - 1];
+  totalwidth := s.Left + s.Width;
 
-  while currentwidth<totalwidth do
+  while currentwidth < totalwidth do
   begin
-    result:=result+'    ';
-    currentwidth:=tvStructureView.Canvas.GetTextWidth(result);
+    Result := Result + '    ';
+    currentwidth := tvStructureView.Canvas.GetTextWidth(Result);
   end;
-
 
 end;
 
 procedure TfrmStructures2.SetupFirstNodeLength;
 begin
-  if tvStructureView.items.count>0 then
-    tvStructureView.Items[0].Text:=getHorizontalScrollbarString;
+  if tvStructureView.items.Count > 0 then
+    tvStructureView.Items[0].Text := getHorizontalScrollbarString;
 end;
 
 procedure TfrmStructures2.InitializeFirstNode;
 //Clear the screen and setup the first node
-var tn: TTreenode;
+var
+  tn: TTreenode;
 begin
   tvStructureView.Items.Clear;
-  if mainStruct<>nil then
+  if mainStruct <> nil then
   begin
-    tn:=tvStructureView.Items.Add(nil, '');
-    tn.Data:=mainStruct;
-    tn.HasChildren:=true;
-    tn.Expand(false);
+    tn := tvStructureView.Items.Add(nil, '');
+    tn.Data := mainStruct;
+    tn.HasChildren := True;
+    tn.Expand(False);
 
     SetupFirstNodeLength;
 
@@ -3724,92 +3936,96 @@ begin
 end;
 
 
-procedure TfrmStructures2.onAddedToStructList(sender: TDissectedStruct);
+procedure TfrmStructures2.onAddedToStructList(Sender: TDissectedStruct);
 begin
   RefreshStructureList;
 end;
 
-procedure TfrmStructures2.onRemovedFromStructList(sender: TDissectedStruct);
+procedure TfrmStructures2.onRemovedFromStructList(Sender: TDissectedStruct);
 begin
   RefreshStructureList;
 end;
 
-procedure TfrmStructures2.onStructureDelete(sender: TDissectedStruct);
-var n: TTreenode;
+procedure TfrmStructures2.onStructureDelete(Sender: TDissectedStruct);
+var
+  n: TTreenode;
 begin
-  if sender=mainStruct then
+  if Sender = mainStruct then
   begin
-    mainstruct:=nil;
+    mainstruct := nil;
     tvStructureView.Items.Clear;
   end
   else
   begin
-    tvStructureView.OnCollapsing:=nil;
-    tvStructureView.OnCollapsed:=nil;
+    tvStructureView.OnCollapsing := nil;
+    tvStructureView.OnCollapsed := nil;
 
     try
-      n:=tvStructureView.Items.GetFirstNode;
+      n := tvStructureView.Items.GetFirstNode;
 
-      while n<>nil do
+      while n <> nil do
       begin
-        if n.data=sender then
+        if n.Data = Sender then
         begin
-          n.data:=nil;
-          n.Collapse(true);
+          n.Data := nil;
+          n.Collapse(True);
           n.DeleteChildren;
         end;
-        n:=n.GetNext;
+        n := n.GetNext;
       end;
 
     finally
-      tvStructureView.OnCollapsing:=tvStructureViewCollapsing;
-      tvStructureView.OnCollapsed:=tvStructureViewCollapsed;
+      tvStructureView.OnCollapsing := tvStructureViewCollapsing;
+      tvStructureView.OnCollapsed := tvStructureViewCollapsed;
     end;
   end;
 end;
 
-procedure TfrmStructures2.onStructOptionsChange(sender: TDissectedStruct);
+procedure TfrmStructures2.onStructOptionsChange(Sender: TDissectedStruct);
 begin
-  if mainStruct=sender then
+  if mainStruct = Sender then
     UpdateCurrentStructOptions;
 end;
 
-procedure TfrmStructures2.onFullStructChange(sender: TDissectedStruct);
-var currentNode: TTreenode;
-    nextnode: TTreenode;
+procedure TfrmStructures2.onFullStructChange(Sender: TDissectedStruct);
+var
+  currentNode: TTreenode;
+  nextnode: TTreenode;
 begin
   //update the childnode of the treenode with this struct to represent the new state
-  if mainStruct<>nil then
+  if mainStruct <> nil then
   begin
 
-    currentNode:=tvStructureView.Items.GetFirstNode;
-    if currentnode=nil then
+    currentNode := tvStructureView.Items.GetFirstNode;
+    if currentnode = nil then
     begin
       InitializeFirstNode;
-      currentNode:=tvStructureView.Items.GetFirstNode;
+      currentNode := tvStructureView.Items.GetFirstNode;
     end;
 
-    while currentnode<>nil do
+    while currentnode <> nil do
     begin
       //go through all entries
 
       //check if currentnode.data is of the type that needs to be updated
-      if (currentnode.Data=sender) and (currentnode.Expanded or (currentNode.level=0)) then  //node is of the updated type and currently has children , or it's the root node
+      if (currentnode.Data = Sender) and (currentnode.Expanded or
+        (currentNode.level = 0)) then
+        //node is of the updated type and currently has children , or it's the root node
         FillTreeNodeWithStructData(currentnode);
 
 
       //nothing else to be done, get the next one
-      nextnode:=currentnode.GetFirstChild;
-      if nextnode=nil then
-        nextnode:=currentnode.GetNextSibling;
-      if nextnode=nil then
+      nextnode := currentnode.GetFirstChild;
+      if nextnode = nil then
+        nextnode := currentnode.GetNextSibling;
+      if nextnode = nil then
       begin
         //up one level
-        nextnode:=currentnode.Parent;
-        if nextnode<>nil then
-          nextnode:=nextnode.GetNextSibling;
+        nextnode := currentnode.Parent;
+        if nextnode <> nil then
+          nextnode := nextnode.GetNextSibling;
       end;
-      currentnode:=nextnode;
+      currentnode := nextnode;
     end;
 
   end;
@@ -3821,34 +4037,36 @@ begin
   RefreshStructureList;
 end;
 
-procedure TfrmStructures2.onElementChange(struct:TDissectedStruct; element: TStructelement);
-var i: integer;
-    n: Ttreenode;
+procedure TfrmStructures2.onElementChange(struct: TDissectedStruct;
+  element: TStructelement);
+var
+  i: integer;
+  n: Ttreenode;
 begin
   //find the treenodes that belong to this specific element and change them accordingly
-  i:=0;
-  n:=tvStructureView.Items.GetFirstNode;
-  while n<>nil do
+  i := 0;
+  n := tvStructureView.Items.GetFirstNode;
+  while n <> nil do
   begin
-    if n.data=struct then
+    if n.Data = struct then
     begin
       if n.expanded then
       begin
-        if n.Count>=element.index then
+        if n.Count >= element.index then
           setupNodeWithElement(n[element.index], element)
         else
         begin
-          tvStructureView.OnCollapsing:=nil;
-          tvStructureView.OnCollapsed:=nil;
+          tvStructureView.OnCollapsing := nil;
+          tvStructureView.OnCollapsed := nil;
 
           n.DeleteChildren;
 
-          tvStructureView.OnCollapsing:=tvStructureViewCollapsing;
-          tvStructureView.OnCollapsed:=tvStructureViewCollapsed;
+          tvStructureView.OnCollapsing := tvStructureViewCollapsing;
+          tvStructureView.OnCollapsed := tvStructureViewCollapsed;
         end;
       end;
     end;
-    n:=n.GetNext;
+    n := n.GetNext;
   end;
 
 {  while i<tvStructureView.Items.Count do
@@ -3866,12 +4084,11 @@ begin
     inc(i);
   end;   }
 
-
-
 end;
 
 
-function TfrmStructures2.DefineNewStructureDialog(recommendedSize: integer=4096): TDissectedStruct;
+function TfrmStructures2.DefineNewStructureDialog(recommendedSize: integer = 4096):
+TDissectedStruct;
 var
   addressdata: TAddressData;
   hasAddressData: boolean;
@@ -3880,30 +4097,31 @@ var
   UsedOverride: boolean;
   a: ptruint;
 
-  structName: String;
-  guessFieldTypes, useAutoTypes: Boolean;
-  guessSize: Integer;
-  found: Boolean;
-  pos: Integer;
+  structName: string;
+  guessFieldTypes, useAutoTypes: boolean;
+  guessSize: integer;
+  found: boolean;
+  pos: integer;
 begin
-  result:=nil;
+  Result := nil;
   if columnCount > 0 then
   begin
     // try to determine structure name using extensions
-    hasAddressData:=symhandler.GetLayoutFromAddress(TStructColumn(columns[0]).getAddress, addressdata);
+    hasAddressData := symhandler.GetLayoutFromAddress(
+      TStructColumn(columns[0]).getAddress, addressdata);
 
     if hasAddressData then
-      structName:=addressdata.classname
+      structName := addressdata.ClassName
     else
     begin
       // try to determine structure name if there are LUA callbacks
-      structName:=rsUnnamedStructure;
+      structName := rsUnnamedStructure;
 
-      for i:=0 to length(StructureNameLookups)-1 do
+      for i := 0 to length(StructureNameLookups) - 1 do
       begin
         if assigned(StructureNameLookups[i]) then
         begin
-          a:=TStructColumn(columns[0]).getAddress;
+          a := TStructColumn(columns[0]).getAddress;
           if StructureNameLookups[i](a, structname) then
           begin
             TStructColumn(columns[0]).setAddress(a);
@@ -3915,56 +4133,67 @@ begin
 
     // check for existing structure with the same name
     repeat
-    begin
-      found := false;
-      for i:=0 to DissectedStructs.Count-1 do
       begin
-        if TDissectedStruct(dissectedstructs[i]).name=structName then
+        found := False;
+        for i := 0 to DissectedStructs.Count - 1 do
         begin
-          found := true;
-          break;
+          if TDissectedStruct(dissectedstructs[i]).Name = structName then
+          begin
+            found := True;
+            break;
+          end;
         end;
-      end;
 
-      // if we found it, find numbers at the end and increment, then try again
-      if found then
-      begin
-        pos := Length(structName);
-        repeat
-          if not (structName[pos] in ['0'..'9']) then break;
-          pos := pos - 1;
-        until pos < 1;
-
-        if (pos < 1) or (pos = Length(structName)) then
+        // if we found it, find numbers at the end and increment, then try again
+        if found then
         begin
-          // if pos < 1 or pos = length, then all digits or no digits so we will add " 2"
-          // i.e. "Player" becomes "Player 2", "23456" becomes "23456 2"
-          structName := Concat(structName, ' 2');
-        end else begin
-          // it ends in digits, so we take that number and add 1 to it
-          structName := Concat(Copy(structName, 1, pos), IntToStr(StrToInt(Copy(structName, pos + 1, Length(structName) - pos)) + 1));
+          pos := Length(structName);
+          repeat
+            if not (structName[pos] in ['0'..'9']) then
+              break;
+            pos := pos - 1;
+          until pos < 1;
+
+          if (pos < 1) or (pos = Length(structName)) then
+          begin
+            // if pos < 1 or pos = length, then all digits or no digits so we will add " 2"
+            // i.e. "Player" becomes "Player 2", "23456" becomes "23456 2"
+            structName := Concat(structName, ' 2');
+          end
+          else
+          begin
+            // it ends in digits, so we take that number and add 1 to it
+            structName := Concat(Copy(structName, 1, pos),
+              IntToStr(StrToInt(Copy(structName, pos + 1, Length(structName) -
+              pos)) + 1));
+          end;
         end;
-      end;
-    end until not found;
+      end
+    until not found;
 
     // if the name is the same as an existing structure, then make sure
     // the user wants to create a duplicate
-    if structName<>rsUnnamedStructure then
+    if structName <> rsUnnamedStructure then
     begin
-      for i:=0 to DissectedStructs.Count-1 do
-        if TDissectedStruct(dissectedstructs[i]).name=structname then
+      for i := 0 to DissectedStructs.Count - 1 do
+        if TDissectedStruct(dissectedstructs[i]).Name = structname then
         begin
-          if messagedlg(format(rsStructAlreadyExists,[structname]), mtWarning, [mbyes, mbno], 0)<>mryes then exit else break;
+          if messagedlg(format(rsStructAlreadyExists, [structname]),
+            mtWarning, [mbYes, mbNo], 0) <> mrYes then
+            exit
+          else
+            break;
         end;
     end;
 
 
     // show form to allow name to be entered and options selected
-    if frmStructuresNewStructure=nil then
-      frmStructuresNewStructure:=TfrmStructuresNewStructure.Create(self);
+    if frmStructuresNewStructure = nil then
+      frmStructuresNewStructure := TfrmStructuresNewStructure.Create(self);
 
     frmStructuresNewStructure.setStructName(structName);
-    if frmStructuresNewStructure.ShowModal <> mrOk then exit;
+    if frmStructuresNewStructure.ShowModal <> mrOk then
+      exit;
     structName := frmStructuresNewStructure.structName;
     guessFieldTypes := frmStructuresNewStructure.guessFieldTypes;
     useAutoTypes := frmStructuresNewStructure.useAutoTypes;
@@ -3972,18 +4201,22 @@ begin
 
     // if the name is the same as an existing structure, then make sure
     // the user wants to create a duplicate
-    if structName<>rsUnnamedStructure then
+    if structName <> rsUnnamedStructure then
     begin
-      for i:=0 to DissectedStructs.Count-1 do
-        if TDissectedStruct(dissectedstructs[i]).name=structname then
+      for i := 0 to DissectedStructs.Count - 1 do
+        if TDissectedStruct(dissectedstructs[i]).Name = structname then
         begin
-          if messagedlg(format(rsStructAlreadyExists,[structname]), mtWarning, [mbyes, mbno], 0)<>mryes then exit else break;
+          if messagedlg(format(rsStructAlreadyExists, [structname]),
+            mtWarning, [mbYes, mbNo], 0) <> mrYes then
+            exit
+          else
+            break;
         end;
     end;
 
-    mainStruct:=nil;
-    tvStructureView.items.clear;
-    mainStruct:=TDissectedStruct.create(structName);
+    mainStruct := nil;
+    tvStructureView.items.Clear;
+    mainStruct := TDissectedStruct.Create(structName);
 
     if guessFieldTypes then
     begin
@@ -3996,16 +4229,17 @@ begin
       else
       begin
         // use LUA callbacks to try and define structure elements
-        UsedOverride:=false;
+        UsedOverride := False;
 
         // wrap in if to only try if useAutoTypes is specified in the future possibly
-        for i:=0 to length(StructureDissectOverrides)-1 do
+        for i := 0 to length(StructureDissectOverrides) - 1 do
         begin
           if assigned(StructureDissectOverrides[i]) then
           begin
-            a:=TStructColumn(columns[0]).getAddress;
-            UsedOverride:=StructureDissectOverrides[i](mainStruct, a);
-            if UsedOverride then break;
+            a := TStructColumn(columns[0]).getAddress;
+            UsedOverride := StructureDissectOverrides[i](mainStruct, a);
+            if UsedOverride then
+              break;
           end;
         end;
 
@@ -4013,10 +4247,13 @@ begin
         // none of the LUA callbacks handled it, so guess the elements
         if not UsedOverride then
         begin
-          if TStructColumn(columns[0]).getSavedState=0 then
-            mainStruct.autoGuessStruct(TStructColumn(columns[0]).getAddress, 0, guessSize)
+          if TStructColumn(columns[0]).getSavedState = 0 then
+            mainStruct.autoGuessStruct(TStructColumn(columns[0]).getAddress,
+              0, guessSize)
           else
-            mainStruct.autoGuessStruct(ptruint(TStructColumn(columns[0]).getSavedState), 0, min(guessSize, TStructColumn(columns[0]).getSavedStateSize)); //fill base don the saved state
+            mainStruct.autoGuessStruct(ptruint(TStructColumn(columns[0]).getSavedState),
+              0, min(guessSize, TStructColumn(columns[0]).getSavedStateSize));
+          //fill base don the saved state
         end;
       end;
     end;
@@ -4024,12 +4261,13 @@ begin
     mainStruct.addToGlobalStructList;
     UpdateCurrentStructOptions;
 
-    result:=mainStruct;
+    Result := mainStruct;
   end;
 end;
 
 // deprecated, menu now calls DefineNewStructureDialog()
-function TfrmStructures2.DefineNewStructure(recommendedSize: integer=4096): TDissectedStruct;
+function TfrmStructures2.DefineNewStructure(recommendedSize: integer = 4096):
+TDissectedStruct;
 var
   structName: string;
   autoFillIn: integer;
@@ -4043,24 +4281,24 @@ var
   UsedOverride: boolean;
   a: ptruint;
 begin
-  result:=nil;
-  if columnCount>0 then
+  Result := nil;
+  if columnCount > 0 then
   begin
-    hasAddressData:=symhandler.GetLayoutFromAddress(TStructColumn(columns[0]).getAddress, addressdata);
+    hasAddressData := symhandler.GetLayoutFromAddress(
+      TStructColumn(columns[0]).getAddress, addressdata);
 
     if hasAddressData then
-      structname:=addressdata.classname
+      structname := addressdata.ClassName
     else
     begin
 
+      structname := rsUnnamedStructure;
 
-      structname:=rsUnnamedStructure;
-
-      for i:=0 to length(StructureNameLookups)-1 do
+      for i := 0 to length(StructureNameLookups) - 1 do
       begin
         if assigned(StructureNameLookups[i]) then
         begin
-          a:=TStructColumn(columns[0]).getAddress;
+          a := TStructColumn(columns[0]).getAddress;
           if StructureNameLookups[i](a, structname) then
           begin
             TStructColumn(columns[0]).setAddress(a);
@@ -4071,29 +4309,36 @@ begin
     end;
 
     //get the name
-    if not inputquery(rsStructureDefine, rsGiveTheNameForThisStructure, structName) then exit;
+    if not inputquery(rsStructureDefine, rsGiveTheNameForThisStructure, structName) then
+      exit;
 
-    if structname<>rsUnnamedStructure then
+    if structname <> rsUnnamedStructure then
     begin
-      for i:=0 to DissectedStructs.Count-1 do
-        if TDissectedStruct(dissectedstructs[i]).name=structname then
+      for i := 0 to DissectedStructs.Count - 1 do
+        if TDissectedStruct(dissectedstructs[i]).Name = structname then
         begin
-          if messagedlg(format(rsStructAlreadyExists,[structname]), mtWarning, [mbyes, mbno], 0)<>mryes then exit else break;
+          if messagedlg(format(rsStructAlreadyExists, [structname]),
+            mtWarning, [mbYes, mbNo], 0) <> mrYes then
+            exit
+          else
+            break;
         end;
     end;
 
 
     //ask if it should be filled in automatically
-    autoFillIn:=messagedlg(rsDoYouWantCheatEngineToTryAndFillInTheMostBasicType, mtconfirmation, [mbyes, mbno, mbcancel], 0);
-    if autoFillIn=mrcancel then exit;
+    autoFillIn := messagedlg(rsDoYouWantCheatEngineToTryAndFillInTheMostBasicType,
+      mtConfirmation, [mbYes, mbNo, mbCancel], 0);
+    if autoFillIn = mrCancel then
+      exit;
 
-    mainStruct:=nil;
-    tvStructureView.items.clear;
+    mainStruct := nil;
+    tvStructureView.items.Clear;
 
 
-    mainStruct:=TDissectedStruct.create(structname);
+    mainStruct := TDissectedStruct.Create(structname);
 
-    if autofillin=mryes then
+    if autofillin = mrYes then
     begin
       if hasAddressData then
       begin
@@ -4102,27 +4347,33 @@ begin
       end
       else
       begin
-        UsedOverride:=false;
-        for i:=0 to length(StructureDissectOverrides)-1 do
+        UsedOverride := False;
+        for i := 0 to length(StructureDissectOverrides) - 1 do
         begin
           if assigned(StructureDissectOverrides[i]) then
           begin
-            a:=TStructColumn(columns[0]).getAddress;
-            UsedOverride:=StructureDissectOverrides[i](mainStruct, a);
-            if UsedOverride then break;
+            a := TStructColumn(columns[0]).getAddress;
+            UsedOverride := StructureDissectOverrides[i](mainStruct, a);
+            if UsedOverride then
+              break;
           end;
         end;
 
         if not UsedOverride then
         begin
-          sstructsize:=inttostr(recommendedSize);
-          if not inputquery(rsStructureDefine, rsPleaseGiveAStartingSizeOfTheStructYouCanChangeThis, Sstructsize) then exit;
-          structsize:=strtoint(sstructsize);
+          sstructsize := IntToStr(recommendedSize);
+          if not inputquery(rsStructureDefine,
+            rsPleaseGiveAStartingSizeOfTheStructYouCanChangeThis, Sstructsize) then
+            exit;
+          structsize := StrToInt(sstructsize);
 
-          if TStructColumn(columns[0]).getSavedState=0 then
-            mainStruct.autoGuessStruct(TStructColumn(columns[0]).getAddress, 0, structsize )
+          if TStructColumn(columns[0]).getSavedState = 0 then
+            mainStruct.autoGuessStruct(TStructColumn(columns[0]).getAddress,
+              0, structsize)
           else
-            mainStruct.autoGuessStruct(ptruint(TStructColumn(columns[0]).getSavedState), 0, min(structsize, TStructColumn(columns[0]).getSavedStateSize)); //fill base don the saved state
+            mainStruct.autoGuessStruct(ptruint(TStructColumn(columns[0]).getSavedState),
+              0, min(structsize, TStructColumn(columns[0]).getSavedStateSize));
+          //fill base don the saved state
         end;
       end;
     end;
@@ -4130,7 +4381,7 @@ begin
     mainStruct.addToGlobalStructList;
     UpdateCurrentStructOptions;
 
-    result:=mainStruct;
+    Result := mainStruct;
 
   end;
 
@@ -4143,7 +4394,8 @@ end;
 
 
 function TfrmStructures2.getStructElementFromNode(node: TTreenode): TStructelement;
-var i: integer;
+var
+  i: integer;
   s: TDissectedStruct;
   nodestruct: TDissectedStruct;
 
@@ -4151,46 +4403,48 @@ var i: integer;
   n: TTreenode;
 begin
   //find the structure this node belongs
-  result:=nil;
+  Result := nil;
 
-  if (node<>nil) and (node.level>0) then
+  if (node <> nil) and (node.level > 0) then
   begin
-    pse:=getStructElementFromNode(node.parent);
-    nodestruct:=TDissectedStruct(node.parent.data);
+    pse := getStructElementFromNode(node.parent);
+    nodestruct := TDissectedStruct(node.parent.Data);
 
-    if nodestruct=nil then exit;
+    if nodestruct = nil then
+      exit;
 
-    if pse<>nil then
-      i:=nodestruct.getIndexOfOffset(pse.ChildStructStart)
+    if pse <> nil then
+      i := nodestruct.getIndexOfOffset(pse.ChildStructStart)
     else
-      i:=0;
+      i := 0;
 
-    if node.index+i>=nodestruct.count then
+    if node.index + i >= nodestruct.Count then
       exit(nil);
 
-    result:=nodestruct[node.index+i];
+    Result := nodestruct[node.index + i];
   end;
 end;
 
 function TfrmStructures2.getStructFromNode(node: TTreenode): TDissectedStruct;
 begin
-  result:=mainStruct;
+  Result := mainStruct;
 
-  if node<>nil then
+  if node <> nil then
   begin
-    node:=node.parent;
+    node := node.parent;
 
-    if node<>nil then
-      result:=TDissectedStruct(node.data);
+    if node <> nil then
+      Result := TDissectedStruct(node.Data);
   end;
 end;
 
 function TfrmStructures2.getChildStructFromNode(node: TTreenode): TDissectedStruct;
 begin
-  result:=nil;
-  if node=nil then exit;
+  Result := nil;
+  if node = nil then
+    exit;
 
-  result:=TDissectedStruct(node.data);
+  Result := TDissectedStruct(node.Data);
 end;
 
 procedure TfrmStructures2.changeNodes;
@@ -4200,106 +4454,113 @@ var
   i: integer;
   ei: TfrmStructures2ElementInfo;
 begin
-  n:=tvStructureView.GetLastMultiSelected;
-  if n=nil then exit;
+  n := tvStructureView.GetLastMultiSelected;
+  if n = nil then
+    exit;
 
-  structElement:=getStructElementFromNode(n);
-  if structElement=nil then exit;
+  structElement := getStructElementFromNode(n);
+  if structElement = nil then
+    exit;
 
-  ei:=tfrmstructures2ElementInfo.create(self);
+  ei := tfrmstructures2ElementInfo.Create(self);
 
   with ei do
   begin
-    description:=structelement.name;
-    offset:=structelement.offset;
-    vartype:=structelement.vartype;
-    customtype:=structelement.CustomType;
-    backgroundcolor:=structelement.BackgroundColor;
+    description := structelement.Name;
+    offset := structelement.offset;
+    vartype := structelement.vartype;
+    customtype := structelement.CustomType;
+    backgroundcolor := structelement.BackgroundColor;
 
-    bytesize:=structelement.bytesize;
-    childstruct:=structelement.childstruct;
-    hexadecimal:=structelement.displayMethod=dtHexadecimal;
-    signed:=structelement.displaymethod=dtSignedInteger;
+    bytesize := structelement.bytesize;
+    childstruct := structelement.childstruct;
+    hexadecimal := structelement.displayMethod = dtHexadecimal;
+    signed := structelement.displaymethod = dtSignedInteger;
 
-    ExpandChangesAddress:=structelement.ExpandChangesAddress;
-
-
-    if tvStructureView.SelectionCount>1 then
-      edtOffset.Enabled:=false;
+    ExpandChangesAddress := structelement.ExpandChangesAddress;
 
 
-    childstructstart:=structelement.ChildStructStart;
+    if tvStructureView.SelectionCount > 1 then
+      edtOffset.Enabled := False;
+
+
+    childstructstart := structelement.ChildStructStart;
 
     //fill in basic info
 
-    ChangedDescription:=false;
-    ChangedOffset:=false;
-    ChangedHexadecimal:=false;
-    ChangedSigned:=false;
-    ChangedVartype:=false;
-    ChangedByteSize:=false;
-    ChangedBackgroundColor:=false;
-    ChangedChildStruct:=false;
-    ChangedchildStructStart:=false;
+    ChangedDescription := False;
+    ChangedOffset := False;
+    ChangedHexadecimal := False;
+    ChangedSigned := False;
+    ChangedVartype := False;
+    ChangedByteSize := False;
+    ChangedBackgroundColor := False;
+    ChangedChildStruct := False;
+    ChangedchildStructStart := False;
 
 
 
-    if showmodal=mrok then
+    if showmodal = mrOk then
     begin
-      for i:=0 to tvStructureView.SelectionCount-1 do
+      for i := 0 to tvStructureView.SelectionCount - 1 do
       begin
-        tvStructureView.Selections[i].Collapse(true); //close the selections (destroys autocreated structure nodes if destroy is enabled)
+        tvStructureView.Selections[i].Collapse(True);
+        //close the selections (destroys autocreated structure nodes if destroy is enabled)
 
-        structElement:=getStructElementFromNode(tvStructureView.Selections[i]);
-        if structelement=nil then continue;
+        structElement := getStructElementFromNode(tvStructureView.Selections[i]);
+        if structelement = nil then
+          continue;
 
 
         structElement.parent.beginUpdate;
         try
-          structelement.ExpandChangesAddress:=ExpandChangesAddress;
+          structelement.ExpandChangesAddress := ExpandChangesAddress;
 
           if changedDescription then
-            structElement.name:=description;
+            structElement.Name := description;
 
-          if tvStructureView.SelectionCount=1 then //only update the offset if only one entry is selected (e.g the user might be so stupid to select a level 1 and a level 3 of a completely different structure....)
-            structElement.offset:=offset;
+          if tvStructureView.SelectionCount = 1 then
+            //only update the offset if only one entry is selected (e.g the user might be so stupid to select a level 1 and a level 3 of a completely different structure....)
+            structElement.offset := offset;
 
           if changedVartype then
           begin
-            structElement.vartype:=vartype;
-            structElement.CustomType:=customtype;
+            structElement.vartype := vartype;
+            structElement.CustomType := customtype;
           end;
 
           if changedBytesize then
-            structElement.bytesize:=bytesize;
+            structElement.bytesize := bytesize;
 
           if changedBackgroundColor then
-            structElement.BackgroundColor:=backgroundColor;
+            structElement.BackgroundColor := backgroundColor;
 
           if changedChildstruct then
-            structElement.childstruct:=childstruct;
+            structElement.childstruct := childstruct;
 
           if changedhexadecimal or changedsigned then
           begin
             if hexadecimal then
-              structelement.displayMethod:=dtHexadecimal
+              structelement.displayMethod := dtHexadecimal
             else
             if signed then
-              structelement.displayMethod:=dtSignedInteger
+              structelement.displayMethod := dtSignedInteger
             else
-              structelement.displayMethod:=dtUnsignedInteger;
+              structelement.displayMethod := dtUnsignedInteger;
           end;
 
           if changedChildStructStart then
-            structelement.ChildStructStart:=childstructstart;
+            structelement.ChildStructStart := childstructstart;
 
-          if (structelement.VarType<>vtPointer) and (miAutoDestroyLocal.checked=false) then
+          if (structelement.VarType <> vtPointer) and
+            (miAutoDestroyLocal.Checked = False) then
           begin
-            if (structelement.ChildStruct<>nil) and (not structelement.ChildStruct.isInGlobalStructList) then
-              structelement.ChildStruct.free;
+            if (structelement.ChildStruct <> nil) and
+              (not structelement.ChildStruct.isInGlobalStructList) then
+              structelement.ChildStruct.Free;
 
-            structelement.ChildStruct:=nil;
-            structelement.ChildStructStart:=0;
+            structelement.ChildStruct := nil;
+            structelement.ChildStructStart := 0;
           end;
 
 
@@ -4311,92 +4572,95 @@ begin
       end;
     end;
 
-
   end;
 
-  freeandnil(ei);
+  FreeAndNil(ei);
 end;
 
-procedure TfrmStructures2.addFromNode(n: TTreenode; asChild: boolean=false);
+procedure TfrmStructures2.addFromNode(n: TTreenode; asChild: boolean = False);
 var
   struct: TDissectedStruct;
   structElement: TStructElement;
 begin
   if asChild then
-    struct:=getChildStructFromNode(n)
+    struct := getChildStructFromNode(n)
   else
-    struct:=getStructFromNode(n);  //find out what node this belongs to. (n can be nil, as that will return the mainstruct)
+    struct := getStructFromNode(n);
+  //find out what node this belongs to. (n can be nil, as that will return the mainstruct)
 
-  if struct<>nil then
+  if struct <> nil then
   begin
-    with tfrmstructures2ElementInfo.create(self) do
+    with tfrmstructures2ElementInfo.Create(self) do
     begin
       //fill in some basic info
-      structElement:=getStructElementFromNode(n);
+      structElement := getStructElementFromNode(n);
 
 
 
-      if structElement<>nil then
+      if structElement <> nil then
       begin
         //set the default variabes to the type of the currently selected item
-        vartype:=structElement.VarType;
-        customtype:=structElement.CustomType;
-        bytesize:=structElement.Bytesize;
-        signed:=structElement.DisplayMethod=dtSignedInteger;
+        vartype := structElement.VarType;
+        customtype := structElement.CustomType;
+        bytesize := structElement.Bytesize;
+        signed := structElement.DisplayMethod = dtSignedInteger;
 
 
-        if struct.DefaultHex and (vartype in [vtByte..vtQword, vtByteArray]) then   //if defaulthex is set and the previous item was an integer type then use the defaulthex's state
-          hexadecimal:=struct.DefaultHex
+        if struct.DefaultHex and (vartype in [vtByte..vtQword, vtByteArray]) then
+          //if defaulthex is set and the previous item was an integer type then use the defaulthex's state
+          hexadecimal := struct.DefaultHex
         else
-          hexadecimal:=structElement.DisplayMethod=dtHexadecimal
+          hexadecimal := structElement.DisplayMethod = dtHexadecimal;
 
       end
       else
       begin
-        vartype:=vtDword;
-        hexadecimal:=struct.DefaultHex;
+        vartype := vtDword;
+        hexadecimal := struct.DefaultHex;
       end;
 
       if asChild then
-        structElement:=nil //adding as child from a rootnode
+        structElement := nil //adding as child from a rootnode
       else
-        structElement:=getStructElementFromNode(n); //can return nil if no node was selected, or the mainnode was selected
+        structElement := getStructElementFromNode(n);
+      //can return nil if no node was selected, or the mainnode was selected
 
-      if structelement=nil then
-        offset:=struct.getStructureSize
+      if structelement = nil then
+        offset := struct.getStructureSize
       else         //clicked on a node, find the offset and add it after that
-        offset:=structElement.Offset+structElement.Bytesize;
+        offset := structElement.Offset + structElement.Bytesize;
 
       //show the form to make modification
-      if showmodal=mrok then
+      if showmodal = mrOk then
       begin
-        structElement:=struct.addElement(description, offset, vartype, customtype, bytesize, childstruct);
+        structElement := struct.addElement(description, offset, vartype,
+          customtype, bytesize, childstruct);
         if hexadecimal then
-          structelement.DisplayMethod:=dtHexadecimal
+          structelement.DisplayMethod := dtHexadecimal
         else
         if signed then
-          structElement.DisplayMethod:=dtSignedInteger
+          structElement.DisplayMethod := dtSignedInteger
         else
-          structElement.DisplayMethod:=dtUnsignedInteger; //default, but set anyhow
+          structElement.DisplayMethod := dtUnsignedInteger; //default, but set anyhow
 
         //set the selection to this entry
         if not asChild then
         begin
-          if (n=nil) or (n.level=0) then
-            n:=tvStructureView.Items.GetFirstNode
+          if (n = nil) or (n.level = 0) then
+            n := tvStructureView.Items.GetFirstNode
           else
-            n:=n.parent;
+            n := n.parent;
         end;
 
-        structElement.BackgroundColor:=backgroundColor;
-        structElement.ExpandChangesAddress:=ExpandChangesAddress;
+        structElement.BackgroundColor := backgroundColor;
+        structElement.ExpandChangesAddress := ExpandChangesAddress;
 
 
-        if structElement.index<n.Count then
+        if structElement.index < n.Count then
           tvStructureView.Items.SelectOnlyThis(n.Items[structElement.Index]);
       end;
 
-      free;
+      Free;
     end;
   end;
 
@@ -4410,7 +4674,7 @@ end;
 
 procedure TfrmStructures2.miAddChildElementClick(Sender: TObject);
 begin
-  addFromNode(tvStructureView.GetLastMultiSelected, true);
+  addFromNode(tvStructureView.GetLastMultiSelected, True);
 end;
 
 
@@ -4427,31 +4691,33 @@ begin
 end;
 
 procedure TfrmStructures2.miUpdateOffsetsClick(Sender: TObject);
-var offsetstring: string;
+var
+  offsetstring: string;
   struct: TDissectedStruct;
   element: TStructelement;
   i: integer;
   offset: integer;
 begin
   //get the structure and the element to start from
-  struct:=getStructFromNode(tvStructureView.GetLastMultiSelected);
-  if struct<>nil then
+  struct := getStructFromNode(tvStructureView.GetLastMultiSelected);
+  if struct <> nil then
   begin
-    element:=getStructElementFromNode(tvStructureView.GetLastMultiSelected);
-    if (element=nil) and (struct.count>0) then
-      element:=struct[0];
+    element := getStructElementFromNode(tvStructureView.GetLastMultiSelected);
+    if (element = nil) and (struct.Count > 0) then
+      element := struct[0];
 
-    if element<>nil then
+    if element <> nil then
     begin
-      offsetstring:='0';
-      if InputQuery(rsDissectData, rsHowManyBytesDoYouWantToShiftThisAndFollowingOffset, offsetstring) then
+      offsetstring := '0';
+      if InputQuery(rsDissectData, rsHowManyBytesDoYouWantToShiftThisAndFollowingOffset,
+        offsetstring) then
       begin
 
-        offset:=StrToInt(offsetstring);
+        offset := StrToInt(offsetstring);
 
         struct.beginUpdate; //prevents sorting
-        for i:=element.index to struct.count-1 do
-          struct[i].Offset:=struct[i].offset+offset;
+        for i := element.index to struct.Count - 1 do
+          struct[i].Offset := struct[i].offset + offset;
 
         struct.endUpdate;//resort and update
       end;
@@ -4461,33 +4727,34 @@ begin
 end;
 
 procedure TfrmStructures2.Open1Click(Sender: TObject);
-var doc: TXMLDocument;
+var
+  doc: TXMLDocument;
   structnode: TDOMNode;
   s: TDissectedStruct;
   i: integer;
 begin
   if Opendialog1.Execute then
   begin
-    mainstruct:=nil;
-    tvStructureView.items.clear;
+    mainstruct := nil;
+    tvStructureView.items.Clear;
 
     ReadXMLFile(doc, Opendialog1.FileName);
 
-    if doc<>nil then
+    if doc <> nil then
     begin
-      structnode:=doc.FindNode('Structures');
+      structnode := doc.FindNode('Structures');
 
-      for i:=0 to structnode.ChildNodes.Count-1 do
+      for i := 0 to structnode.ChildNodes.Count - 1 do
       begin
-        s:=TDissectedStruct.createFromXMLNode(structnode.ChildNodes[i]);
+        s := TDissectedStruct.createFromXMLNode(structnode.ChildNodes[i]);
 
-        if s<>nil then
+        if s <> nil then
         begin
           s.addToGlobalStructList;
 
-          if mainstruct=nil then
+          if mainstruct = nil then
           begin
-            mainstruct:=s;
+            mainstruct := s;
 
             onFullStructChange(mainstruct);
             RefreshStructureList;
@@ -4496,9 +4763,8 @@ begin
         end;
       end;
 
-      for i:=0 to DissectedStructs.count-1 do
+      for i := 0 to DissectedStructs.Count - 1 do
         TDissectedStruct(DissectedStructs[i]).fillDelayLoadedChildstructs;
-
 
     end;
 
@@ -4507,15 +4773,18 @@ begin
 end;
 
 procedure TfrmStructures2.Save1Click(Sender: TObject);
-var doc: TXMLDocument;
+var
+  doc: TXMLDocument;
   structnode: TDOMNode;
 begin
-  if mainstruct=nil then exit;
+  if mainstruct = nil then
+    exit;
 
   if Savedialog1.Execute then
   begin
-    doc:=TXMLDocument.Create;
-    structnode:=TDOMElement(doc.AppendChild(TDOMNode(doc.CreateElement('Structures'))));
+    doc := TXMLDocument.Create;
+    structnode := TDOMElement(doc.AppendChild(
+      TDOMNode(doc.CreateElement('Structures'))));
 
     mainstruct.WriteToXMLNode(structnode);
     WriteXML(structnode, savedialog1.filename);
@@ -4527,19 +4796,20 @@ end;
 procedure TfrmStructures2.Structures1Click(Sender: TObject);
 begin
   //check if miDefineNewStructureFromDebugData should be visible
-  miDefineNewStructureFromDebugData.visible:=symhandler.hasDefinedStructures;
-  miDefineNewStructureFromDebugData.enabled:=miDefineNewStructureFromDebugData.visible;
-  miSeperatorStructCommandsAndList.visible:=DissectedStructs.count>0;
+  miDefineNewStructureFromDebugData.Visible := symhandler.hasDefinedStructures;
+  miDefineNewStructureFromDebugData.Enabled := miDefineNewStructureFromDebugData.Visible;
+  miSeperatorStructCommandsAndList.Visible := DissectedStructs.Count > 0;
 end;
 
 procedure TfrmStructures2.tmFixGuiTimer(Sender: TObject);
 begin
-  tmFixgui.enabled:=false;
+  tmFixgui.Enabled := False;
   FixPositions;
 end;
 
 procedure TfrmStructures2.pmStructureViewPopup(Sender: TObject);
-var childstruct: TDissectedStruct;
+var
+  childstruct: TDissectedStruct;
   ownerstruct: TDissectedStruct;
   structelement: TStructelement;
   c: TStructColumn;
@@ -4551,101 +4821,159 @@ var childstruct: TDissectedStruct;
 begin
 
   try
-    selected:=tvStructureView.GetLastMultiSelected;
+    selected := tvStructureView.GetLastMultiSelected;
 
-    ownerstruct:=getStructFromNode(selected);
-    childstruct:=getChildStructFromNode(selected);
-    structelement:=getStructElementFromNode(selected);
+    ownerstruct := getStructFromNode(selected);
+    childstruct := getChildStructFromNode(selected);
+    structelement := getStructElementFromNode(selected);
 
-    miFullUpgrade.visible:=((childstruct=nil) and (structelement<>nil) and (structelement.isPointer)) or ((childstruct<>nil) and (not childstruct.isInGlobalStructList));
-    if miFullUpgrade.visible then
+    miFullUpgrade.Visible := ((childstruct = nil) and (structelement <> nil) and
+      (structelement.isPointer)) or ((childstruct <> nil) and
+      (not childstruct.isInGlobalStructList));
+    if miFullUpgrade.Visible then
     begin
-      if (childstruct=nil) then
-        miFullUpgrade.caption:=rsDefinePointer
+      if (childstruct = nil) then
+        miFullUpgrade.Caption := rsDefinePointer
       else
-        miFullUpgrade.caption:=rsUpgradePointer;
+        miFullUpgrade.Caption := rsUpgradePointer;
 
     end;
 
-    miOpenInNewWindow.visible:=((not miFullUpgrade.visible) and (childstruct<>nil)) or (tvStructureView.SelectionCount>1);
+    miOpenInNewWindow.Visible :=
+      ((not miFullUpgrade.Visible) and (childstruct <> nil)) or
+      (tvStructureView.SelectionCount > 1);
 
-    miAddElement.visible:=(ownerstruct<>nil) or (childstruct<>nil);
-    miAddChildElement.visible:=(childstruct<>nil);
-    miDeleteElement.visible:=selected<>nil;
-    miChangeElement.visible:=structElement<>nil;
+    miAddElement.Visible := (ownerstruct <> nil) or (childstruct <> nil);
+    miAddChildElement.Visible := (childstruct <> nil);
+    miDeleteElement.Visible := selected <> nil;
+    miChangeElement.Visible := structElement <> nil;
 
-    miBrowseAddress.Visible:=selected<>nil;
-    miBrowsePointer.visible:=(structelement<>nil) and (structelement.isPointer);
+    miBrowseAddress.Visible := selected <> nil;
+    miBrowsePointer.Visible := (structelement <> nil) and (structelement.isPointer);
 
-    miChangeValue.Visible:=structelement<>nil;
-    miUpdateOffsets.visible:=structelement<>nil;
-    miAddToAddresslist.Visible:=structelement<>nil;
+    miChangeValue.Visible := structelement <> nil;
+    miChangeAllValuesInRow.Visible := structelement <> nil;
+    miUpdateOffsets.Visible := structelement <> nil;
+    miAddToAddressList.Visible := structelement <> nil;
+    miAddAllInRowToAddressList.Visible := structelement <> nil;
 
-    miRecalculateAddress.Visible:=(structelement<>nil) and (selected.Level=1);
+    miFindOutWhatAccessesThisAddress.Visible := structelement <> nil; 
+    miFindOutWhatWritesThisAddress.Visible := structelement <> nil;
 
-    n2.visible:=ownerstruct<>nil;
+    miRecalculateAddress.Visible := (structelement <> nil) and (selected.Level = 1);
 
-    N3.visible:=miRecalculateAddress.visible or miUpdateOffsets.visible;
+    N2.Visible := ownerstruct <> nil;
 
-    micopy.Visible:=structelement<>nil;
-    s:=copy(trim(clipboard.astext),1,9);
+    N3.Visible := miRecalculateAddress.Visible or miUpdateOffsets.Visible;
 
-    mipaste.Visible:=(ownerstruct<>nil) and (s='<Elements'); //  structelement<>nil;
-    n4.visible:=n3.visible and (miCopy.visible or mipaste.visible);
+    micopy.Visible := structelement <> nil;
+    s := copy(trim(clipboard.astext), 1, 9);
 
-    c:=getFocusedColumn;
-    n5.Visible:=(c<>nil) and c.canPopAddress;
-    miBack.visible:=n5.Visible;
+    mipaste.Visible := (ownerstruct <> nil) and (s = '<Elements');
+    //  structelement<>nil;
+    n4.Visible := n3.Visible and (miCopy.Visible or mipaste.Visible);
+
+    c := getFocusedColumn;
+    n5.Visible := (c <> nil) and c.canPopAddress;
+    miBack.Visible := n5.Visible;
 
     // change type menu and display types
-    miChangeType.visible:=structElement<>nil;
-    if (miChangeType.visible) then
+    miChangeType.Visible := structElement <> nil;
+
+    if (miChangeType.Visible) then
     begin
-      hasError := true; // default to not show
-      if (selected<>nil) and (c<>nil)then address := getAddressFromNode(selected, c, hasError);
+      hasError := True; // default to not show
+
+      if (selected <> nil) and (c <> nil) then
+        address := getAddressFromNode(selected, c, hasError);
 
       if hasError then
       begin
         // just display types if we don't have a valid address
         //using the dotnet types for translation, it's ok
-        miChangeTypeByte.Caption:=rsDNTByte;
-        miChangeType2Byte.Caption:=rsDNT2Byte;
-        miChangeType4Byte.Caption:=rsDNT4Byte;
-        miChangeTypeByteHex.Caption:=rsDNTByte+' '+rsHex;
-        miChangeType2ByteHex.Caption:=rsDNT2Byte+' '+rsHex;
-        miChangeType4ByteHex.Caption:=rsDNT4Byte+' '+rsHex;
-        miChangeType8ByteHex.Caption:=rsDNT8Byte+' '+rsHex;
-        miChangeTypeFloat.Caption:=rsDNTFloat;
-        miChangeTypeDouble.Caption:=rsDNTDouble;
-        miChangeTypeString.Caption:=rsDNTString;
-        miChangeTypeUnicode.Caption:=rsUnicodeString;
-        miChangeTypeArrayOfByte.Caption:=rsArrayOfByte;
-        miChangeTypePointer.Caption:=rsPointer;
-      end else begin
+        miChangeTypeByte.Caption := rsDNTByte;
+        miChangeType2Byte.Caption := rsDNT2Byte;
+        miChangeType4Byte.Caption := rsDNT4Byte;
+        miChangeType8Byte.Caption := rsDNT8Byte;
+
+        miChangeTypeByteHex.Caption := rsDNTByte + ' ' + rsHex;
+        miChangeType2ByteHex.Caption := rsDNT2Byte + ' ' + rsHex;
+        miChangeType4ByteHex.Caption := rsDNT4Byte + ' ' + rsHex;
+        miChangeType8ByteHex.Caption := rsDNT8Byte + ' ' + rsHex;
+
+        miChangeTypeFloat.Caption := rsDNTFloat;
+        miChangeTypeDouble.Caption := rsDNTDouble;
+
+        miChangeTypeString.Caption := rsDNTString;
+        miChangeTypeUnicode.Caption := rsUnicodeString;
+
+        miChangeTypeArrayOfByte.Caption := rsArrayOfByte;
+        miChangeTypePointer.Caption := rsPointer;
+
+      end
+      else
+      begin
+
         // booleans are hex override, signed
-        miChangeTypeByte.Caption:=Format(rsDNTByte+': %s', [readAndParseAddress(address, vtByte, nil, false, true, 1)]);
-        miChangeType2Byte.Caption:=Format(rsDNT2Byte+': %s', [readAndParseAddress(address, vtWord, nil, false, true, 2)]);
-        miChangeType4Byte.Caption:=Format(rsDNT4Byte+': %s', [readAndParseAddress(address, vtDword, nil, false, true, 4)]);
-        miChangeTypeByteHex.Caption:=Format(rsDNTByte+' '+rsHex+': %s', [readAndParseAddress(address, vtByte, nil, true, false, 1)]);
-        miChangeType2ByteHex.Caption:=Format(rsDNT2Byte+' '+rsHex+': %s', [readAndParseAddress(address, vtWord, nil, true, false, 2)]);
-        miChangeType4ByteHex.Caption:=Format(rsDNT4Byte+' '+rsHex+': %s', [readAndParseAddress(address, vtDword, nil, true, false, 4)]);
-        miChangeType8ByteHex.Caption:=Format(rsDNT8Byte+' '+rsHex+': %s', [readAndParseAddress(address, vtQWord, nil, true, false, 8)]);
-        miChangeTypeFloat.Caption:=Format(rsDNTFloat+': %s', [readAndParseAddress(address, vtSingle, nil, false, true, 4)]);
-        miChangeTypeDouble.Caption:=Format(rsDNTDouble+': %s', [readAndParseAddress(address, vtDouble, nil, false, true, 8)]);
-        miChangeTypeString.Caption:=Format(rsDNTString+': %s', [readAndParseAddress(address, vtString, nil, false, false, 32)]);
-        miChangeTypeUnicode.Caption:=Format(rsUnicodeString+': %s', [readAndParseAddress(address, vtUnicodeString, nil, false, true, 32)]);
-        miChangeTypeArrayOfByte.Caption:=Format(rsArrayOfByte+': %s', [readAndParseAddress(address, vtByteArray, nil, true, false, 16)]);
+        miChangeTypeByte.Caption :=
+          Format(rsDNTByte + ': %s',
+          [readAndParseAddress(address, vtByte, nil, False, True, 1)]);
+        miChangeType2Byte.Caption :=
+          Format(rsDNT2Byte + ': %s',
+          [readAndParseAddress(address, vtWord, nil, False, True, 2)]);
+        miChangeType4Byte.Caption :=
+          Format(rsDNT4Byte + ': %s',
+          [readAndParseAddress(address, vtDword, nil, False, True, 4)]);
+        miChangeType8Byte.Caption :=
+          Format(rsDNT8Byte + ': %s',
+          [readAndParseAddress(address, vtQWord, nil, False, True, 8)]);
+
+        miChangeTypeByteHex.Caption :=
+          Format(rsDNTByte + ' ' + rsHex + ': %s',
+          [readAndParseAddress(address, vtByte, nil, True, False, 1)]);
+        miChangeType2ByteHex.Caption :=
+          Format(rsDNT2Byte + ' ' + rsHex + ': %s',
+          [readAndParseAddress(address, vtWord, nil, True, False, 2)]);
+        miChangeType4ByteHex.Caption :=
+          Format(rsDNT4Byte + ' ' + rsHex + ': %s',
+          [readAndParseAddress(address, vtDword, nil, True, False, 4)]);
+        miChangeType8ByteHex.Caption :=
+          Format(rsDNT8Byte + ' ' + rsHex + ': %s',
+          [readAndParseAddress(address, vtQWord, nil, True, False, 8)]);
+
+        miChangeTypeFloat.Caption :=
+          Format(rsDNTFloat + ': %s',
+          [readAndParseAddress(address, vtSingle, nil, False, True, 4)]);
+        miChangeTypeDouble.Caption :=
+          Format(rsDNTDouble + ': %s',
+          [readAndParseAddress(address, vtDouble, nil, False, True, 8)]);
+
+        miChangeTypeString.Caption :=
+          Format(rsDNTString + ': %s',
+          [readAndParseAddress(address, vtString, nil, False, False, 32)]);
+        miChangeTypeUnicode.Caption :=
+          Format(rsUnicodeString + ': %s',
+          [readAndParseAddress(address, vtUnicodeString, nil, False, True, 32)]);
+
+        miChangeTypeArrayOfByte.Caption :=
+          Format(rsArrayOfByte + ': %s',
+          [readAndParseAddress(address, vtByteArray, nil, True, False, 16)]);
+
         if processhandler.pointersize = 4 then
-          miChangeTypePointer.Caption:=Format(rsPointer+': P->%s', [readAndParseAddress(address, vtDWord, nil, true, false, 4)])
+          miChangeTypePointer.Caption :=
+            Format(rsPointer + ': P->%s',
+            [readAndParseAddress(address, vtDWord, nil, True, False, 4)])
         else
-          miChangeTypePointer.Caption:=Format(rsPointer+': P->%s', [readAndParseAddress(address, vtQWord, nil, true, false, 8)]);
+          miChangeTypePointer.Caption :=
+            Format(rsPointer + ': P->%s',
+            [readAndParseAddress(address, vtQWord, nil, True, False, 8)]);
       end;
     end;
 
 
   except
-    on e: exception do
-      outputdebugstring('TfrmStructures2.pmStructureViewPopup:'+e.message);
+    on e: Exception do
+      outputdebugstring('TfrmStructures2.pmStructureViewPopup:' + e.message);
   end;
 end;
 
@@ -4658,23 +4986,34 @@ var
   i: integer;
   n: TTreenode;
 begin
-  if tvStructureView.SelectionCount=0 then exit;
+  if tvStructureView.SelectionCount = 0 then
+    exit;
 
- // element := getStructElementFromNode(tvStructureView.Selected);
- // if (element = nil) then exit;
+  // element := getStructElementFromNode(tvStructureView.Selected);
+  // if (element = nil) then exit;
 
-  if (Sender = miChangeTypeByte) or (Sender = miChangeTypeByteHex) then vt := vtByte
-  else if (Sender = miChangeType2Byte) or (Sender = miChangeType2ByteHex) then vt := vtWord
-  else if (Sender = miChangeType4Byte) or (Sender = miChangeType4ByteHex) then vt := vtDWord
-  else if (Sender = miChangeType8ByteHex) then vt := vtQWord
-  else if (Sender = miChangeTypeFloat) then vt := vtSingle
-  else if (Sender = miChangeTypeDouble) then vt := vtDouble
-  else if (Sender = miChangeTypeString) then vt := vtString
-  else if (Sender = miChangeTypeUnicode) then vt := vtUnicodeString
-  else if (Sender = miChangeTypeArrayOfByte) then vt := vtByteArray
-  else if (Sender = miChangeTypePointer) then vt := vtPointer
+  if (Sender = miChangeTypeByte) or (Sender = miChangeTypeByteHex) then
+    vt := vtByte
+  else if (Sender = miChangeType2Byte) or (Sender = miChangeType2ByteHex) then
+    vt := vtWord
+  else if (Sender = miChangeType4Byte) or (Sender = miChangeType4ByteHex) then
+    vt := vtDWord
+  else if (Sender = miChangeType8Byte) or (Sender = miChangeType8ByteHex) then
+    vt := vtQWord
+  else if (Sender = miChangeTypeFloat) then
+    vt := vtSingle
+  else if (Sender = miChangeTypeDouble) then
+    vt := vtDouble
+  else if (Sender = miChangeTypeString) then
+    vt := vtString
+  else if (Sender = miChangeTypeUnicode) then
+    vt := vtUnicodeString
+  else if (Sender = miChangeTypeArrayOfByte) then
+    vt := vtByteArray
+  else if (Sender = miChangeTypePointer) then
+    vt := vtPointer
   else
-    vt:=vtByte;
+    vt := vtByte;
 
 
   case vt of
@@ -4689,21 +5028,27 @@ begin
     vtString: size := 32;
     vtUnicodeString: size := 32;
     else
-      size:=1;
+      size := 1;
   end;
 
   displayMethod := dtHexadecimal;
 
   // only decimal and float types are signed, and are not hex
   if (Sender = miChangeTypeByte) or (Sender = miChangeType2Byte) or
-     (Sender = miChangeType4Byte) or (Sender = miChangeTypeFloat) or
-     (Sender = miChangeTypeDouble) then displayMethod := dtSignedInteger;
+    (Sender = miChangeType4Byte) or (Sender = miChangeType8Byte) or
+    (Sender = miChangeTypeFloat) or (Sender = miChangeTypeDouble) then
+    displayMethod := dtSignedInteger;
 
-  for i:=0 to tvStructureView.SelectionCount-1 do
+  // Pointer, String, Unicode String cannot be Hexadeciaml or Signed
+  if (Sender = miChangeTypePointer) or (Sender = miChangeTypeString) or
+    (Sender = miChangeTypeUnicode) then
+    displayMethod := dtUnsignedInteger;
+
+  for i := 0 to tvStructureView.SelectionCount - 1 do
   begin
-    n:=tvStructureView.Selections[i];
+    n := tvStructureView.Selections[i];
     element := getStructElementFromNode(n);
-    if element<>nil then
+    if element <> nil then
     begin
       element.setVartype(vt);
       element.setDisplayMethod(displayMethod);
@@ -4717,51 +5062,52 @@ var
   f: TfrmRearrangeStructureList;
   i: integer;
 begin
-  f:=tfrmRearrangeStructureList.create(self);
+  f := tfrmRearrangeStructureList.Create(self);
   f.ShowModal;
-  f.free;
+  f.Free;
 end;
 
 procedure TfrmStructures2.miViewClick(Sender: TObject);
 begin
-  if (groupcount>=2) and (group[0].columnCount>=1) and (group[1].columnCount>=1) then
+  if (groupcount >= 2) and (group[0].columnCount >= 1) and
+    (group[1].columnCount >= 1) then
   begin
-    miSeperatorCommonalityScanner.visible:=true;
-    miCommonalityScan.visible:=true;
+    miSeperatorCommonalityScanner.Visible := True;
+    miCommonalityScan.Visible := True;
   end;
 end;
 
 procedure TfrmStructures2.miCommonalityScanClick(Sender: TObject);
 var
   f: tfrmStructureCompare;
-  i,j: integer;
+  i, j: integer;
   shadow: ptruint;
   shadowsize: integer;
 begin
-  if groupcount>=2 then
+  if groupcount >= 2 then
   begin
-    if (group[0].columnCount<2) or (group[1].columnCount<2) then
-      messagedlg(rsWarnAboutLessThan2Addresses, mtWarning, [mbok], 0);
+    if (group[0].columnCount < 2) or (group[1].columnCount < 2) then
+      messagedlg(rsWarnAboutLessThan2Addresses, mtWarning, [mbOK], 0);
 
-    if frmStructureCompare<>nil then
-      f:=TfrmStructureCompare.Create(application)
+    if frmStructureCompare <> nil then
+      f := TfrmStructureCompare.Create(application)
     else
     begin
-      frmStructureCompare:=tfrmStructureCompare.Create(application);
-      f:=frmStructureCompare;
+      frmStructureCompare := tfrmStructureCompare.Create(application);
+      f := frmStructureCompare;
     end;
 
-    for i:=0 to 1 do
+    for i := 0 to 1 do
     begin
-      for j:=0 to group[i].columnCount-1 do
+      for j := 0 to group[i].columnCount - 1 do
       begin
-        shadow:=group[i].columns[j].getSavedState;
-        shadowsize:=group[i].columns[j].getSavedStateSize;
-        f.AddAddress(group[i].columns[j].Address,shadow, shadowsize, i);
+        shadow := group[i].columns[j].getSavedState;
+        shadowsize := group[i].columns[j].getSavedStateSize;
+        f.AddAddress(group[i].columns[j].Address, shadow, shadowsize, i);
       end;
     end;
 
-    f.show;
+    f.Show;
   end;
 
 end;
@@ -4770,26 +5116,26 @@ end;
 
 procedure TfrmStructures2.miNewWindowClick(Sender: TObject);
 begin
-  with tfrmstructures2.create(application) do
+  with tfrmstructures2.Create(application) do
   begin
-    initialaddress:=MemoryBrowser.hexview.address; //self.getFocusedColumn.Address;
-    show;
+    initialaddress := MemoryBrowser.hexview.address; //self.getFocusedColumn.Address;
+    Show;
   end;
 end;
 
 procedure TfrmStructures2.miUpdateIntervalClick(Sender: TObject);
-var interval: string;
+var
+  interval: string;
 begin
-  interval:=inttostr(updatetimer.interval);
-  if InputQuery(rsUpdateInterval, rsNewInterval+':', interval) then
+  interval := IntToStr(updatetimer.interval);
+  if InputQuery(rsUpdateInterval, rsNewInterval + ':', interval) then
   begin
     try
-      updatetimer.interval:=strtoint(interval);
+      updatetimer.interval := StrToInt(interval);
     except
     end;
 
-    miUpdateInterval.caption:=rsUpdateInterval+': '+inttostr(
-      updatetimer.interval);
+    miUpdateInterval.Caption := rsUpdateInterval + ': ' + IntToStr(updatetimer.interval);
   end;
 end;
 
@@ -4800,13 +5146,15 @@ end;
 
 
 procedure TfrmStructures2.Renamestructure1Click(Sender: TObject);
-var newname: string;
+var
+  newname: string;
 begin
-  if mainstruct<>nil then
+  if mainstruct <> nil then
   begin
-    newname:=mainStruct.name;
-    if InputQuery(rsSF2GiveTheNewNameForThisStructure, rsSF2StructureRename, newname) then
-      mainStruct.name:=newname;
+    newname := mainStruct.Name;
+    if InputQuery(rsSF2GiveTheNewNameForThisStructure, rsSF2StructureRename,
+      newname) then
+      mainStruct.Name := newname;
   end;
 end;
 
@@ -4814,23 +5162,23 @@ end;
 
 
 procedure TfrmStructures2.tvStructureViewMouseDown(Sender: TObject;
-  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
-var i: integer;
+  Button: TMouseButton; Shift: TShiftState; X, Y: integer);
+var
+  i: integer;
   c: TStructColumn;
   n: TTreenode;
 begin
 
-  c:=getColumnAtXPos(x+tvStructureView.ScrolledLeft);
-  if c<>nil then
+  c := getColumnAtXPos(x + tvStructureView.ScrolledLeft);
+  if c <> nil then
     c.focus;
 
-  if (button=mbRight) then //lazarus 32774: If rightclickselect is on it does not deselect other lines
+  if (button = mbRight) then
+    //lazarus 32774: If rightclickselect is on it does not deselect other lines
   begin
-    n:=tvStructureView.GetNodeAt(x,y);
-    if n<>nil then
+    n := tvStructureView.GetNodeAt(x, y);
+    if n <> nil then
     begin
-
-
 
       if (not n.Selected) and (not n.MultiSelected) then
       begin
@@ -4838,39 +5186,41 @@ begin
         if not ((ssShift in Shift) or (ssCtrl in Shift)) then
           tvStructureView.Items.SelectOnlyThis(n)
         else
-          n.Selected:=true;
+          n.Selected := True;
       end;
-
 
     end;
   end;
 end;
 
 function TfrmStructures2.getFocusedColumn: TStructColumn;
-var i: integer;
+var
+  i: integer;
 begin
-  if columncount=0 then exit(nil); //rare/impossible
+  if columncount = 0 then
+    exit(nil); //rare/impossible
 
-  for i:=0 to columnCount-1 do
+  for i := 0 to columnCount - 1 do
     if columns[i].Focused then
     begin
-      result:=columns[i];
+      Result := columns[i];
       exit;
     end;
 
-  result:=columns[0]; //nothing found, so give the first column
+  Result := columns[0]; //nothing found, so give the first column
 end;
 
 
 function TfrmStructures2.getColumnAtXPos(x: integer): TStructColumn;
-var i: integer;
+var
+  i: integer;
 begin
   //find which header is clicked. This coincides with the form's structure list
-  result:=nil;
-  for i:=1 to HeaderControl1.Sections.count-1 do
+  Result := nil;
+  for i := 1 to HeaderControl1.Sections.Count - 1 do
     if inrange(x, HeaderControl1.Sections[i].Left, HeaderControl1.Sections[i].Right) then
     begin
-      result:=columns[i-1];
+      Result := columns[i - 1];
       exit;
     end;
 end;
@@ -4883,31 +5233,33 @@ begin
   try
     RefreshVisibleNodes;
   except
-    on e:exception do
-      outputdebugstring('TfrmStructures2.updatetimerTimer:'+e.message);
+    on e: Exception do
+      outputdebugstring('TfrmStructures2.updatetimerTimer:' + e.message);
   end;
 end;
 
 procedure TfrmStructures2.miRecalculateAddressClick(Sender: TObject);
-var s: string;
+var
+  s: string;
   n: TTreenode;
   e: boolean;
   a: string;
   oldaddress, newaddress: ptruint;
   offset: ptruint;
 begin
-  n:=tvStructureView.GetLastMultiSelected;
-  if (n<>nil) and (n.level=1) then //recalculate can only be done on the main structure
+  n := tvStructureView.GetLastMultiSelected;
+  if (n <> nil) and (n.level = 1) then
+    //recalculate can only be done on the main structure
   begin
-    oldaddress:=getAddressFromNode(n, getFocusedColumn, e);
+    oldaddress := getAddressFromNode(n, getFocusedColumn, e);
     if not e then
     begin
-      a:=inttohex(memorybrowser.hexview.address,8);
+      a := inttohex(memorybrowser.hexview.address, 8);
       if inputquery(rsRecalculateBaseOfStructure, rsGiveTheAddressOfThisElement, a) then
       begin
-        newaddress:=StrToQWordEx('$'+a);
-        offset:=newaddress-oldaddress;
-        getFocusedColumn.Address:=getFocusedColumn.Address+offset;
+        newaddress := StrToQWordEx('$' + a);
+        offset := newaddress - oldaddress;
+        getFocusedColumn.Address := getFocusedColumn.Address + offset;
       end;
 
     end;
@@ -4922,7 +5274,8 @@ end;
 
 
 procedure TfrmStructures2.miDeleteElementClick(Sender: TObject);
-var elementlist: Tlist;
+var
+  elementlist: TList;
   e: TStructelement;
 
   struct: TDissectedStruct;
@@ -4934,70 +5287,73 @@ begin
  { if tvStructureView.Selected<>nil then
     originalindex:=tvStructureView.Selected.AbsoluteIndex
   else    }
-    originalindex:=-1;
+  originalindex := -1;
 
 
   //fill the nodelist with all the selected entries that match the requirement: Same siblings only
-  struct:=nil;
-  elementlist:=tlist.create;
+  struct := nil;
+  elementlist := TList.Create;
   try
-    for i:=0 to tvStructureView.SelectionCount-1 do
+    for i := 0 to tvStructureView.SelectionCount - 1 do
     begin
-      if originalindex=-1 then
-        originalindex:=tvStructureView.Selections[i].AbsoluteIndex;
+      if originalindex = -1 then
+        originalindex := tvStructureView.Selections[i].AbsoluteIndex;
 
-      originalindex:=min(tvStructureView.Selections[i].AbsoluteIndex, originalindex);
+      originalindex := min(tvStructureView.Selections[i].AbsoluteIndex, originalindex);
 
-      e:=getStructElementFromNode(tvStructureView.Selections[i]);
-      if (e<>nil) and ((struct=nil) or (e.parent=struct))  then //the element can be null if it's the origin
+      e := getStructElementFromNode(tvStructureView.Selections[i]);
+      if (e <> nil) and ((struct = nil) or (e.parent = struct)) then
+        //the element can be null if it's the origin
       begin
-        if struct=nil then
-          struct:=e.parent;
+        if struct = nil then
+          struct := e.parent;
 
         elementlist.add(e);
       end;
     end;
 
     //now delete the entries in the list (if there are any)
-    if struct<>nil then
+    if struct <> nil then
     begin
       struct.beginUpdate;
       try
-        for i:=0 to elementlist.count-1 do
+        for i := 0 to elementlist.Count - 1 do
           struct.removeElement(TStructelement(elementlist[i]));
 
       finally
         struct.endUpdate;
 
-        if (not struct.isInGlobalStructList) and (struct.count=0) then
-          struct.free;
+        if (not struct.isInGlobalStructList) and (struct.Count = 0) then
+          struct.Free;
       end;
     end;
 
   finally
-    elementlist.free;
+    elementlist.Free;
   end;
 
   //restore the selection pos
-  if originalindex>=0 then
+  if originalindex >= 0 then
   begin
-    tvStructureView.Items.SelectOnlyThis(tvStructureView.Items[min(tvStructureView.items.count-1, originalindex)]);
+    tvStructureView.Items.SelectOnlyThis(
+      tvStructureView.Items[min(tvStructureView.items.Count - 1, originalindex)]);
   end;
 
 end;
 
 function TfrmStructures2.addColumn: TStructColumn;
-var c: TStructColumn;
+var
+  c: TStructColumn;
 begin
-  result:=nil;
-  if groupcount=0 then
-    TStructGroup.create(self,rsSF2Group1);
+  Result := nil;
+  if groupcount = 0 then
+    TStructGroup.Create(self, rsSF2Group1);
 
-  c:=getFocusedColumn;
-  if c=nil then
-    result:=TStructColumn.create(group[0])
+  c := getFocusedColumn;
+  if c = nil then
+    Result := TStructColumn.Create(group[0])
   else
-    result:=TStructColumn.create(c.parent);
+    Result := TStructColumn.Create(c.parent);
 
   SetupFirstNodeLength;
   RefreshVisibleNodes;
@@ -5005,7 +5361,7 @@ end;
 
 procedure TfrmStructures2.removeColumn(columnid: integer);
 begin
-  columns[columnid].free;
+  columns[columnid].Free;
   SetupFirstNodeLength;
   RefreshVisibleNodes;
 end;
@@ -5016,13 +5372,14 @@ begin
 end;
 
 procedure TfrmStructures2.FindDialog1Find(Sender: TObject);
-var i: integer;
+var
+  i: integer;
   n: ttreenode;
 begin
-  i:=searchString(FindDialog1.FindText, finddialog1.Options);
-  if i<>-1 then
+  i := searchString(FindDialog1.FindText, finddialog1.Options);
+  if i <> -1 then
   begin
-    n:=tvStructureView.Items[i];
+    n := tvStructureView.Items[i];
     tvStructureView.Items.SelectOnlyThis(n);
     n.MakeVisible;
   end;
@@ -5030,145 +5387,146 @@ end;
 
 
 
-function TfrmStructures2.searchString(search: string; findoptions: TFindOptions): integer;
+function TfrmStructures2.searchString(search: string;
+  findoptions: TFindOptions): integer;
 {
 Searches the current list for the specified value
 }
-var i,j: integer;
+var
+  i, j: integer;
   se: TStructelement;
   c: TStructColumn;
-  s,s2: string;
+  s, s2: string;
   node: TTreenode;
   cc: integer;
 
   casesensitive: boolean;
 begin
-  result:=-1;
+  Result := -1;
 
-  casesensitive:=frMatchCase in findoptions;
+  casesensitive := frMatchCase in findoptions;
 
   if not casesensitive then
-    search:=uppercase(search);
+    search := uppercase(search);
 
-  if tvStructureView.GetLastMultiSelected<>nil then
-    i:=tvStructureView.GetLastMultiSelected.AbsoluteIndex
+  if tvStructureView.GetLastMultiSelected <> nil then
+    i := tvStructureView.GetLastMultiSelected.AbsoluteIndex
   else
-    i:=-1;
+    i := -1;
 
   if frDown in findoptions then
-    i:=i+1
+    i := i + 1
   else
-    i:=i-1;
+    i := i - 1;
 
 
-  while (i>0) and (i<tvStructureView.Items.Count) do
+  while (i > 0) and (i < tvStructureView.Items.Count) do
   begin
-    node:=tvStructureView.Items[i];
-    se:=getStructElementFromNode(node);
+    node := tvStructureView.Items[i];
+    se := getStructElementFromNode(node);
 
-    if se<>nil then
+    if se <> nil then
     begin
 
-      s:=se.Name;
+      s := se.Name;
 
 
 
-      setCurrentNodeStringsInColumns(node,se);
+      setCurrentNodeStringsInColumns(node, se);
 
       //column now contains the strings
-      cc:=columnCount;
-      for j:=0 to columnCount-1 do
+      cc := columnCount;
+      for j := 0 to columnCount - 1 do
       begin
-        c:=columns[j];
-        s:=s+c.currentNodeValue;
+        c := columns[j];
+        s := s + c.currentNodeValue;
       end;
 
       if not casesensitive then
-        s:=uppercase(s);
+        s := uppercase(s);
 
-      if pos(search,s)>0 then //fouind a match
+      if pos(search, s) > 0 then //fouind a match
       begin
-        result:=i;
+        Result := i;
         exit;
       end;
     end;
 
 
     if frDown in findoptions then
-      i:=i+1
+      i := i + 1
     else
-      i:=i-1;
+      i := i - 1;
 
   end;
 
   beep;
 
-
-
 end;
 
 
-procedure TfrmStructures2.getValues(f: Tstrings);
-var i,j: integer;
+procedure TfrmStructures2.getValues(f: TStrings);
+var
+  i, j: integer;
   se: TStructelement;
   c: TStructColumn;
-  s,s2: string;
+  s, s2: string;
   node: TTreenode;
   cc: integer;
 begin
-  f.clear;
+  f.Clear;
 
-  s:='Offset-Description';
-  s:=padright(s,25);
-  for j:=0 to columncount-1 do
+  s := 'Offset-Description';
+  s := padright(s, 25);
+  for j := 0 to columncount - 1 do
   begin
-    if miShowAddresses.checked then
-      s:=s+PadRight(columns[j].Name,30)
+    if miShowAddresses.Checked then
+      s := s + PadRight(columns[j].Name, 30)
     else
-      s:=s+PadRight(columns[j].Name,20);
+      s := s + PadRight(columns[j].Name, 20);
   end;
 
   f.add(s);
 
 
-  for i:=1 to tvStructureView.Items.Count-1 do
+  for i := 1 to tvStructureView.Items.Count - 1 do
   begin
-    node:=tvStructureView.Items[i];
-    se:=getStructElementFromNode(node);
+    node := tvStructureView.Items[i];
+    se := getStructElementFromNode(node);
 
-    if se<>nil then
+    if se <> nil then
     begin
-      s:=getDisplayedDescription(se);
-      s:=PadRight(S, 25);
+      s := getDisplayedDescription(se);
+      s := PadRight(S, 25);
 
-      for j:=1 to node.level-1 do
-        s:=AddChar('-',S,length(s)+5);
+      for j := 1 to node.level - 1 do
+        s := AddChar('-', S, length(s) + 5);
 
-      setCurrentNodeStringsInColumns(node,se);
+      setCurrentNodeStringsInColumns(node, se);
 
       //column now contains the strings
-      cc:=columnCount;
-      for j:=0 to columnCount-1 do
+      cc := columnCount;
+      for j := 0 to columnCount - 1 do
       begin
-        c:=columns[j];
+        c := columns[j];
 
-        if miShowAddresses.checked then
+        if miShowAddresses.Checked then
         begin
-          s2:=PadRight(c.currentNodeAddress+c.currentNodeValue,30);
+          s2 := PadRight(c.currentNodeAddress + c.currentNodeValue, 30);
 
-          if j<cc-1 then //not the last column
-            setlength(s2,30); //cut of excess
+          if j < cc - 1 then //not the last column
+            setlength(s2, 30); //cut of excess
         end
         else
         begin
-          s2:=PadRight(c.currentNodeValue,20);
-          if j<cc-1 then
-            setlength(s2,20);
+          s2 := PadRight(c.currentNodeValue, 20);
+          if j < cc - 1 then
+            setlength(s2, 20);
         end;
 
 
 
-        s:=s+s2;
+        s := s + s2;
       end;
     end;
 
@@ -5181,26 +5539,27 @@ var
   f: TStringList;
 begin
 
-  if saveValues.execute then
+  if saveValues.Execute then
   begin
-    f:=tstringlist.create;
+    f := TStringList.Create;
     getValues(f);
     f.SaveToFile(saveValues.FileName);
-    f.free;
+    f.Free;
   end;
 end;
 
 procedure TfrmStructures2.MenuItem5Click(Sender: TObject);
-var s: string;
+var
+  s: string;
   g: Tstructgroup;
 begin
-  s:=rsSF2Group+inttostr(groupcount+1);
-  if InputQuery(rsSF2NameForThisGroup,rsFS2StructureDefine, s) then
+  s := rsSF2Group + IntToStr(groupcount + 1);
+  if InputQuery(rsSF2NameForThisGroup, rsFS2StructureDefine, s) then
   begin
-    g:=TStructGroup.create(self, s);
+    g := TStructGroup.Create(self, s);
 
     //add the first address as well
-    TStructColumn.create(g);
+    TStructColumn.Create(g);
   end;
 end;
 
@@ -5210,14 +5569,17 @@ begin
 end;
 
 procedure TfrmStructures2.miBackClick(Sender: TObject);
-var c: TStructColumn;
+var
+  c: TStructColumn;
 begin
-  c:=getFocusedColumn;
-  if c<>nil then c.popAddress;
+  c := getFocusedColumn;
+  if c <> nil then
+    c.popAddress;
 end;
 
 procedure TfrmStructures2.miDefineNewStructureFromDebugDataClick(Sender: TObject);
-var structlist, elementlist: Tstringlist;
+var
+  structlist, elementlist: TStringList;
   i: integer;
 
   s: TDBStructInfo;
@@ -5225,64 +5587,67 @@ var structlist, elementlist: Tstringlist;
   selected: string;
 
   struct: TDissectedStruct;
-  vtype:TVariableType;
+  vtype: TVariableType;
 begin
   //get the list of structures
-  structlist:=tstringlist.create;
-  elementlist:=tstringlist.create;
+  structlist := TStringList.Create;
+  elementlist := TStringList.Create;
   try
-    symhandler.getStructureList(structlist,100);
+    symhandler.getStructureList(structlist, 100);
 
-    if structlist.count>=100 then
+    if structlist.Count >= 100 then
     begin
       //show a dynamic list instead
       exit;
     end;
 
-    if structlist.count=0 then exit;
+    if structlist.Count = 0 then
+      exit;
 
-    i:=ShowSelectionList(self,'Structure list','Select a structure to load',structlist,selected);
-    if i=-1 then exit;
+    i := ShowSelectionList(self, 'Structure list', 'Select a structure to load',
+      structlist, selected);
+    if i = -1 then
+      exit;
 
-    s:=TDBStructInfo(structlist.objects[i]);
+    s := TDBStructInfo(structlist.objects[i]);
 
     symhandler.getStructureElements(s.callbackid, s.moduleid, s.typeid, elementlist);
 
-    if elementlist.count>0 then
+    if elementlist.Count > 0 then
     begin
-      struct:=TDissectedStruct.create(selected);
+      struct := TDissectedStruct.Create(selected);
 
 
       //convert the elements to structure types
-      for i:=0 to elementlist.count-1 do
+      for i := 0 to elementlist.Count - 1 do
       begin
-        e:=TDBElementInfo(elementlist.Objects[i]);
-        vtype:=e.vartype;
+        e := TDBElementInfo(elementlist.Objects[i]);
+        vtype := e.vartype;
 
-        struct.addElement(elementlist[i],e.offset, vtype);
+        struct.addElement(elementlist[i], e.offset, vtype);
 
       end;
 
       struct.addToGlobalStructList;
-      mainStruct:=struct;
+      mainStruct := struct;
       InitializeFirstNode;
       UpdateCurrentStructOptions;
     end;
     //showmessage('not yet implemented. come back later');
 
   finally
-    for i:=0 to structlist.count-1 do
-      if structlist.Objects[i]<>nil then
-         structlist.Objects[i].Free;
+    for i := 0 to structlist.Count - 1 do
+      if structlist.Objects[i] <> nil then
+        structlist.Objects[i].Free;
 
-    structlist.free;
+    structlist.Free;
 
-    if elementlist<>nil then
-      for i:=0 to elementlist.count-1 do
-        if elementlist.Objects[i]<>nil then
-           elementlist.Objects[i].Free;
+    if elementlist <> nil then
+      for i := 0 to elementlist.Count - 1 do
+        if elementlist.Objects[i] <> nil then
+          elementlist.Objects[i].Free;
 
-    elementlist.free;
+    elementlist.Free;
   end;
 end;
 
@@ -5295,16 +5660,19 @@ var
 begin
   tvStructureView.BeginUpdate;
   try
-    if mainstruct<>nil then
+    if mainstruct <> nil then
     begin
-      maxlevel:=frmStructuresConfig.maxautoexpandlevel+1;
-      i:=1;
-      while i<tvStructureView.Items.Count do
+      maxlevel := frmStructuresConfig.maxautoexpandlevel + 1;
+      i := 1;
+      while i < tvStructureView.Items.Count do
       begin
-        if tvStructureView.Items[i].HasChildren and (tvStructureView.Items[i].Level<maxlevel) and (all or (getStructElementFromNode(tvStructureView.Items[i]).ChildStruct<>nil)) then
-          tvStructureView.Items[i].Expand(false);
+        if tvStructureView.Items[i].HasChildren and
+          (tvStructureView.Items[i].Level < maxlevel) and
+          (all or (getStructElementFromNode(tvStructureView.Items[i]).ChildStruct <>
+          nil)) then
+          tvStructureView.Items[i].Expand(False);
 
-        inc(i);
+        Inc(i);
       end;
 
     end;
@@ -5315,26 +5683,27 @@ end;
 
 procedure TfrmStructures2.miExpandAllDefinedClick(Sender: TObject);
 begin
-  expandtree(false);
+  expandtree(False);
 end;
 
 procedure TfrmStructures2.miExpandAllClick(Sender: TObject);
 begin
-  expandtree(true);
+  expandtree(True);
 end;
 
 procedure TfrmStructures2.miClearClick(Sender: TObject);
 begin
-  if MessageDlg(rsSF2AreYouSureYouWantToDeleteAllTheDefinedStructures, mtWarning, [mbyes, mbno],0)=mryes then
+  if MessageDlg(rsSF2AreYouSureYouWantToDeleteAllTheDefinedStructures,
+    mtWarning, [mbYes, mbNo], 0) = mrYes then
   begin
-    if mainstruct<>nil then //this one first
+    if mainstruct <> nil then //this one first
     begin
-      mainstruct.free;
-      mainstruct:=nil;
+      mainstruct.Free;
+      mainstruct := nil;
     end;
 
-    while DissectedStructs.Count>0 do
-      TDissectedStruct(DissectedStructs[0]).free;
+    while DissectedStructs.Count > 0 do
+      TDissectedStruct(DissectedStructs[0]).Free;
   end;
 end;
 
@@ -5343,66 +5712,69 @@ var
   baseoffset: dword; //startoffset to start appending from  (currently selected+size)
   doc: TXMLDocument;
   elementnodes: TDOMElement;
-  i,j,k: integer;
+  i, j, k: integer;
   e: TStructelement;
   firstoffset: dword;
   ss: Tstringstream;
 
   struct: TDissectedStruct;
 
-  pathtobase: array of integer; //since the parent treenode might collapse if it's a pointer to itself...
+  pathtobase: array of integer;
+  //since the parent treenode might collapse if it's a pointer to itself...
   n: TTreenode;
   isroot: boolean;
 begin
-  isroot:=false;
-  if (mainstruct<>nil) and (tvStructureView.GetLastMultiSelected<>nil) then
+  isroot := False;
+  if (mainstruct <> nil) and (tvStructureView.GetLastMultiSelected <> nil) then
   begin
-    e:=getStructElementFromNode(tvStructureView.GetLastMultiSelected);
-    struct:=getStructFromNode(tvStructureView.GetLastMultiSelected);
+    e := getStructElementFromNode(tvStructureView.GetLastMultiSelected);
+    struct := getStructFromNode(tvStructureView.GetLastMultiSelected);
 
-    setlength(pathtobase,0);
-    n:=tvStructureView.GetLastMultiSelected.parent;
-    if n<>nil then
+    setlength(pathtobase, 0);
+    n := tvStructureView.GetLastMultiSelected.parent;
+    if n <> nil then
     begin
-      while n.parent<>nil do
+      while n.parent <> nil do
       begin
-        setlength(pathtobase, length(pathtobase)+1);
-        pathtobase[length(pathtobase)-1]:=n.Index;
-        n:=n.parent;
+        setlength(pathtobase, length(pathtobase) + 1);
+        pathtobase[length(pathtobase) - 1] := n.Index;
+        n := n.parent;
       end;
     end
     else
     begin
       //root
-      isroot:=true;
+      isroot := True;
     end;
 
 
 
-    if isroot or ((e<>nil) and (struct<>nil)) then
+    if isroot or ((e <> nil) and (struct <> nil)) then
     begin
       if isroot then
-        baseoffset:=0
+        baseoffset := 0
       else
-        baseoffset:=e.Offset+e.Bytesize;
+        baseoffset := e.Offset + e.Bytesize;
 
-      doc:=nil;
-      ss:=TStringStream.create(clipboard.AsText,TEncoding.Default, false);
+      doc := nil;
+      ss := TStringStream.Create(clipboard.AsText, TEncoding.Default, False);
       try
         try
           ReadXMLFile(doc, ss);
-          if doc<>nil then
+          if doc <> nil then
           begin
-            elementnodes:=TDOMElement(doc.FindNode('Elements'));
-            if elementnodes<>nil then
+            elementnodes := TDOMElement(doc.FindNode('Elements'));
+            if elementnodes <> nil then
             begin
               struct.beginUpdate;
-              for i:=0 to elementnodes.ChildNodes.Count-1 do
+              for i := 0 to elementnodes.ChildNodes.Count - 1 do
               begin
-                e:=TStructelement.createFromXMLElement(struct, TDOMElement(elementnodes.ChildNodes[i]));
-                if i=0 then firstoffset:=e.Offset;
+                e := TStructelement.createFromXMLElement(struct,
+                  TDOMElement(elementnodes.ChildNodes[i]));
+                if i = 0 then
+                  firstoffset := e.Offset;
 
-                e.offset:=baseoffset+(e.offset-firstoffset);
+                e.offset := baseoffset + (e.offset - firstoffset);
                 struct.structelementlist.Add(e);
               end;
               struct.sortElements;
@@ -5410,23 +5782,23 @@ begin
               struct.fillDelayLoadedChildstructs;
             end;
 
-            doc.free;
+            doc.Free;
           end;
 
           //select the last added element
-          i:=struct.getIndexOfOffset(e.offset);
-          n:=tvStructureView.Items.GetFirstNode;
+          i := struct.getIndexOfOffset(e.offset);
+          n := tvStructureView.Items.GetFirstNode;
 
           //open the path if it was closed
-          for j:=length(pathtobase)-1 downto 0 do
+          for j := length(pathtobase) - 1 downto 0 do
           begin
-            k:=pathtobase[j];
-            if k<n.Count then
+            k := pathtobase[j];
+            if k < n.Count then
             begin
               if n.Items[k].HasChildren then
               begin
-                n.Items[k].Expanded:=true;
-                n:=n.items[k];
+                n.Items[k].Expanded := True;
+                n := n.items[k];
               end
               else
                 exit; //give up
@@ -5437,13 +5809,11 @@ begin
         except
         end;
       finally
-        ss.free;
+        ss.Free;
       end;
 
     end;
   end;
-
-
 
 end;
 
@@ -5455,24 +5825,25 @@ var
   se: TStructelement;
   ms: TStringStream;
 begin
-  if mainstruct<>nil then
+  if mainstruct <> nil then
   begin
-    doc:=TXMLDocument.Create;
-    elementnodes:=TDOMElement(doc.AppendChild(TDOMNode(doc.CreateElement('Elements'))));
+    doc := TXMLDocument.Create;
+    elementnodes := TDOMElement(
+      doc.AppendChild(TDOMNode(doc.CreateElement('Elements'))));
 
-    for i:=0 to tvStructureView.SelectionCount-1 do
+    for i := 0 to tvStructureView.SelectionCount - 1 do
     begin
-      se:=getStructElementFromNode(tvStructureView.Selections[i]);
-      if se<>nil then
+      se := getStructElementFromNode(tvStructureView.Selections[i]);
+      if se <> nil then
         se.WriteToXMLNode(elementnodes);
     end;
 
 
-    ms:=TStringStream.create('',TEncoding.Default,false);
+    ms := TStringStream.Create('', TEncoding.Default, False);
     WriteXML(elementnodes, ms);
 
-    Clipboard.AsText:=ms.DataString;
-    ms.free;
+    Clipboard.AsText := ms.DataString;
+    ms.Free;
 
     doc.Free;
   end;
@@ -5486,10 +5857,11 @@ var
 begin
   if Savedialog1.Execute then
   begin
-    doc:=TXMLDocument.Create;
-    structnode:=TDOMElement(doc.AppendChild(TDOMNode(doc.CreateElement('Structures'))));
+    doc := TXMLDocument.Create;
+    structnode := TDOMElement(doc.AppendChild(
+      TDOMNode(doc.CreateElement('Structures'))));
 
-    for i:=0 to DissectedStructs.Count-1 do
+    for i := 0 to DissectedStructs.Count - 1 do
       TDissectedStruct(DissectedStructs[i]).WriteToXMLNode(structnode);
 
     WriteXML(structnode, savedialog1.filename);
@@ -5500,58 +5872,61 @@ end;
 
 
 procedure TfrmStructures2.miGenerateGroupscanClick(Sender: TObject);
-var gcf: TfrmGroupScanAlgoritmGenerator;
+var
+  gcf: TfrmGroupScanAlgoritmGenerator;
   previous, e: TStructelement;
   n: TTreeNode;
   err: boolean;
   address: ptruint;
-  i,j: integer;
+  i, j: integer;
 begin
-  if mainstruct<>nil then
+  if mainstruct <> nil then
   begin
-    gcf:=TfrmGroupScanAlgoritmGenerator.create(self);
+    gcf := TfrmGroupScanAlgoritmGenerator.Create(self);
 
     //fill the algoritm with what is currently selected
 
-    for i:=0 to tvStructureView.items.Count-1 do //find the first selected element
+    for i := 0 to tvStructureView.items.Count - 1 do //find the first selected element
     begin
       if tvStructureView.items[i].MultiSelected or tvStructureView.items[i].Selected then
       begin
         //found the first element, from here, add all selected siblings and fill in wildcards
-        n:=tvStructureView.items[i];
-        previous:=nil;
-        while n<>nil do
+        n := tvStructureView.items[i];
+        previous := nil;
+        while n <> nil do
         begin
 
           if n.MultiSelected or n.Selected then
           begin
-            e:=getStructElementFromNode(n);
-            if (e<>nil) then
+            e := getStructElementFromNode(n);
+            if (e <> nil) then
             begin
               //add this element (if it's a valid type)
-              if e.vartype in [vtByte..vtDouble, vtstring, vtunicodestring, vtCustom, vtPointer] then
+              if e.vartype in [vtByte..vtDouble, vtstring, vtunicodestring,
+                vtCustom, vtPointer] then
               begin
                 //get the address
-                address:=getAddressFromNode(n, getFocusedColumn, err);
+                address := getAddressFromNode(n, getFocusedColumn, err);
                 if not err then
                 begin
                   //everything ok, add it
-                  if previous<>nil then //Fill gaps with the previous element
+                  if previous <> nil then //Fill gaps with the previous element
                   begin
 
-                    j:=e.Offset-(previous.Offset+previous.Bytesize);   //get the number of bytes to fill
-                    if j>0 then
+                    j := e.Offset - (previous.Offset + previous.Bytesize);
+                    //get the number of bytes to fill
+                    if j > 0 then
                       gcf.addwildcard(j);
                   end;
 
 
-                  gcf.AddLine(e.VarType, e.CustomType, e.getValue(address, true));
-                  previous:=e;
+                  gcf.AddLine(e.VarType, e.CustomType, e.getValue(address, True));
+                  previous := e;
                 end;
               end;
             end;
           end;
-          n:=n.GetNextSibling;
+          n := n.GetNextSibling;
         end;
 
         //    gcf.addByte(value)
@@ -5561,49 +5936,53 @@ begin
 
     end;
 
-    if gcf.showmodal=mrok then
+    if gcf.showmodal = mrOk then
     begin
-      if (mainform.VarType.enabled) or (mainform.getVarType=vtGrouped) then
+      if (mainform.VarType.Enabled) or (mainform.getVarType = vtGrouped) then
       begin
-        if mainform.getVarType<>vtGrouped then
+        if mainform.getVarType <> vtGrouped then
           mainform.setVarType(vtGrouped);
 
-        mainform.scanvalue.text:=gcf.getparameters;
+        mainform.scanvalue.Text := gcf.getparameters;
       end
       else
-        showmessage(rsSF2TheGroupscanCommandHasBeenCopiedToTheClipboard);
+        ShowMessage(rsSF2TheGroupscanCommandHasBeenCopiedToTheClipboard);
 
-      clipboard.astext:=gcf.getparameters;
-
+      clipboard.astext := gcf.getparameters;
 
     end;
 
-    gcf.free;
+    gcf.Free;
 
   end;
 end;
 
 procedure TfrmStructures2.miAutoCreateClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainStruct.AutoCreate:=not mainstruct.AutoCreate;
+  if mainstruct <> nil then
+    mainStruct.AutoCreate := not mainstruct.AutoCreate;
 end;
 
 procedure TfrmStructures2.miAutoDestroyLocalClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainstruct.AutoDestroy:=not mainstruct.AutoDestroy;
+  if mainstruct <> nil then
+    mainstruct.AutoDestroy := not mainstruct.AutoDestroy;
 end;
 
 procedure TfrmStructures2.miAutoFillGapsClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainstruct.AutoFill:=not mainstruct.AutoFill;
+  if mainstruct <> nil then
+    mainstruct.AutoFill := not mainstruct.AutoFill;
 end;
 
 procedure TfrmStructures2.miChangeValueClick(Sender: TObject);
 begin
   EditValueOfSelectedNodes(getFocusedColumn);
+end;
+
+procedure TfrmStructures2.miChangeAllValuesInRowClick(Sender: TObject);
+begin
+  EditAllValuesInRowOfSelectedNodes(getFocusedColumn);
 end;
 
 procedure TfrmStructures2.miBrowseAddressClick(Sender: TObject);
@@ -5613,13 +5992,13 @@ var
   error: boolean;
   x: dword;
 begin
-  n:=tvStructureView.GetLastMultiSelected;
-  if n<>nil then
+  n := tvStructureView.GetLastMultiSelected;
+  if n <> nil then
   begin
-    a:=getAddressFromNode(n, getFocusedColumn, error);
+    a := getAddressFromNode(n, getFocusedColumn, error);
 
     if not error then
-      MemoryBrowser.hexview.address:=a;
+      MemoryBrowser.hexview.address := a;
   end;
 end;
 
@@ -5632,82 +6011,85 @@ var
   c: TStructColumn;
   savedstate: ptruint;
 begin
-  n:=tvStructureView.GetLastMultiSelected;
-  if n<>nil then
+  n := tvStructureView.GetLastMultiSelected;
+  if n <> nil then
   begin
-    c:=getFocusedColumn;
-    a:=getAddressFromNode(n, c, error);
+    c := getFocusedColumn;
+    a := getAddressFromNode(n, c, error);
 
-    savedstate:=ptruint(c.getSavedState);
+    savedstate := ptruint(c.getSavedState);
 
-    if (savedstate<>0) and (InRangeX(a, c.Address, c.address+ c.getSavedStateSize)) then
-       a:=a+(savedstate-c.address);
+    if (savedstate <> 0) and (InRangeX(a, c.Address, c.address +
+      c.getSavedStateSize)) then
+      a := a + (savedstate - c.address);
 
 
 
     if not error then
     begin
       //get the address this address points to
-      if ReadProcessMemory(processhandle, pointer(a), @a, processhandler.pointersize, x) and (x=processhandler.pointersize) then
-        MemoryBrowser.hexview.address:=a;
+      if ReadProcessMemory(processhandle, pointer(a), @a,
+        processhandler.pointersize, x) and (x = processhandler.pointersize) then
+        MemoryBrowser.hexview.address := a;
     end;
   end;
 end;
 
 
-procedure TfrmStructures2.miAddToAddresslistClick(Sender: TObject);
-var baseaddress: ptruint;
+procedure TfrmStructures2.miAddToAddressListClick(Sender: TObject);
+var
+  baseaddress: ptruint;
   offsetlist: array of integer;
   element, element2: TStructelement;
 
   sname: string;
-  n: ttreenode;
-  name, customtypename: string;
+  node: ttreenode;
+  Name, customtypename: string;
 
   i: integer;
 begin
-//  n:=tvStructureView.GetLastMultiSelected;
+  //  node:=tvStructureView.GetLastMultiSelected;
 
-  for i:=0 to tvStructureView.SelectionCount-1 do
+  for i := 0 to tvStructureView.SelectionCount - 1 do
   begin
-    n:=tvStructureView.Selections[i];
+    node := tvStructureView.Selections[i];
 
-    if n<>nil then
+    if node <> nil then
     begin
-      element:=getStructElementFromNode(n);
-      if element<>nil then
+      element := getStructElementFromNode(node);
+      if element <> nil then
       begin
-        baseaddress:=0;
-        getPointerFromNode(n, getFocusedColumn, baseaddress, offsetlist);
-        if baseaddress<>0 then
+        baseaddress := 0;
+        getPointerFromNode(node, getFocusedColumn, baseaddress, offsetlist);
+        if baseaddress <> 0 then
         begin
           //add this baseaddress with it's offsetlist to the addresslist
 
-          sname:=element.Name;
-          while (n<>nil) and (n.level>=1) do
+          sname := element.Name;
+          while (node <> nil) and (node.level >= 1) do
           begin
-            element2:=getStructElementFromNode(n);
-            if element2<>nil then
-              sname:=element.name+'->'+sname;
+            element2 := getStructElementFromNode(node);
+            if element2 <> nil then
+              sname := element.Name + '->' + sname;
 
-            n:=n.parent;
+            node := node.parent;
           end;
 
-          if element.CustomType<>nil then
-            customtypename:=element.CustomType.name
+          if element.CustomType <> nil then
+            customtypename := element.CustomType.Name
           else
-            customtypename:='';
+            customtypename := '';
 
-          name:=element.Name;
-          if name='' then
-            name:=VariableTypeToString(element.VarType);
+          Name := element.Name;
+          if Name = '' then
+            Name := VariableTypeToString(element.VarType);
 
-          mainform.addresslist.addaddress(name, inttohex(baseaddress,1), offsetlist, length(offsetlist), element.VarType, customtypename, element.Bytesize);
+          mainform.addresslist.addaddress(Name, inttohex(baseaddress, 1),
+            offsetlist, length(offsetlist), element.VarType, customtypename,
+            element.Bytesize);
         end;
 
-
       end;
-
 
       //mainform.a
     end;
@@ -5715,14 +6097,97 @@ begin
   end;
 end;
 
+procedure TfrmStructures2.miAddAllInRowToAddressListClick(Sender: TObject);
+var
+  baseaddress: ptruint;
+  offsetlist: array of integer;
+  element, elementForBuildName: TStructelement;
+
+  sname: string;
+  node, nodeForBuildName: ttreenode;
+  Name, customtypename: string;
+
+  i: integer;
+  columnIndex: integer;
+  column: TStructColumn;
+
+begin
+
+  for i := 0 to tvStructureView.SelectionCount - 1 do
+  begin
+
+    node := tvStructureView.Selections[i];
+
+    if node <> nil then
+    begin
+      element := getStructElementFromNode(node);
+      if element <> nil then
+      begin
+
+        sname := element.Name;
+
+        nodeForBuildName := node;
+
+        while (nodeForBuildName <> nil) and (nodeForBuildName.level >= 1) do
+        begin
+          elementForBuildName := getStructElementFromNode(nodeForBuildName);
+          if elementForBuildName <> nil then
+            sname := element.Name + '->' + sname;
+
+          nodeForBuildName := nodeForBuildName.parent;
+        end;
+
+        if element.CustomType <> nil then
+          customtypename := element.CustomType.Name
+        else
+          customtypename := '';
+
+        Name := element.Name;
+
+        if Name = '' then
+          Name := VariableTypeToString(element.VarType);
+
+        for columnIndex := 0 to columnCount - 1 do
+        begin
+
+          column := columns[columnIndex];
+
+          baseaddress := 0;
+          setlength(offsetlist, 0);
+          getPointerFromNode(node, column, baseaddress, offsetlist);
+
+          if baseaddress <> 0 then
+          begin
+
+            mainform.addresslist.addaddress(
+              Name + ' ' + IntToStr(columnIndex)
+              , inttohex(baseaddress, 1)
+              , offsetlist
+              , length(offsetlist)
+              , element.VarType
+              , customtypename
+              , element.Bytesize
+              );
+
+          end;
+        end;
+      end;
+    end;
+  end;
+end;
+
+
+
 procedure TfrmStructures2.Deletecurrentstructure1Click(Sender: TObject);
 begin
-  if mainstruct<>nil then
+  if mainstruct <> nil then
   begin
-    if messagedlg(rsSF2AreYouSureYouWantToDeleteTheStructureNamed+mainstruct.structname+' ?', mtConfirmation, [mbyes,mbno],0) = mryes then
+    if messagedlg(rsSF2AreYouSureYouWantToDeleteTheStructureNamed +
+      mainstruct.structname + ' ?', mtConfirmation, [mbYes, mbNo], 0) = mrYes then
     begin
-      mainstruct.free;
-      mainstruct:=nil; //should happen automatically thanks to the destroy procedure of the struct
+      mainstruct.Free;
+      mainstruct := nil;
+      //should happen automatically thanks to the destroy procedure of the struct
     end;
   end;
 end;
@@ -5735,73 +6200,80 @@ var
   startOffset: integer;
   structSize: integer;
 begin
-  if mainStruct<>nil then
+  if mainStruct <> nil then
   begin
-    sStartOffset:=inttohex(mainstruct.structuresize,1);
-    if not inputquery(rsStructureDefine, rsPleaseGiveAStartingOffsetToEvaluate, sStartOffset) then exit;
-    startOffset:=StrToInt('$'+sStartOffset);
+    sStartOffset := inttohex(mainstruct.structuresize, 1);
+    if not inputquery(rsStructureDefine, rsPleaseGiveAStartingOffsetToEvaluate,
+      sStartOffset) then
+      exit;
+    startOffset := StrToInt('$' + sStartOffset);
 
-    sStructSize:='4096';
-    if not inputquery(rsStructureDefine, rsPleaseGiveTheSizeOfTheBlockToEvaluate, sStructSize) then exit;
-    structSize:=StrToInt(sStructSize);
+    sStructSize := '4096';
+    if not inputquery(rsStructureDefine, rsPleaseGiveTheSizeOfTheBlockToEvaluate,
+      sStructSize) then
+      exit;
+    structSize := StrToInt(sStructSize);
 
 
-    mainStruct.autoGuessStruct(getFocusedColumn.Address+startOffset, startOffset, structsize);
+    mainStruct.autoGuessStruct(getFocusedColumn.Address + startOffset,
+      startOffset, structsize);
   end;
 end;
 
 procedure TfrmStructures2.miAutostructsizeClick(Sender: TObject);
-var newsize: string;
+var
+  newsize: string;
 begin
-  if mainstruct<>nil then
+  if mainstruct <> nil then
   begin
-    newsize:=inttostr(mainstruct.autoCreateStructsize);
+    newsize := IntToStr(mainstruct.autoCreateStructsize);
     if InputQuery(rsSF2AutocreateStructure, rsSF2DefaultSize, newsize) then
-      mainstruct.autoCreateStructsize:=strtoint(newsize);
+      mainstruct.autoCreateStructsize := StrToInt(newsize);
   end;
 end;
 
 procedure TfrmStructures2.setupColors;
 begin
-  fDefaultColor:=frmStructuresConfig.defaultText;
-  fMatchColor:=frmStructuresConfig.equalText;
-  fNoMatchColor:=frmStructuresConfig.differentText;
-  fAllMatchColorSame:=frmStructuresConfig.groupequalText;
-  fAllMatchColorDiff:=frmStructuresConfig.groupDifferentText;
+  fDefaultColor := frmStructuresConfig.defaultText;
+  fMatchColor := frmStructuresConfig.equalText;
+  fNoMatchColor := frmStructuresConfig.differentText;
+  fAllMatchColorSame := frmStructuresConfig.groupequalText;
+  fAllMatchColorDiff := frmStructuresConfig.groupDifferentText;
 
 
-  fDefaultColorHighlighted:=frmStructuresConfig.selecteddefaultText;
-  fMatchColorHighlighted:=frmStructuresConfig.selectedequalText;
-  fNoMatchColorHighlighted:=frmStructuresConfig.selecteddifferentText;
-  fAllMatchColorSameHighlighted:=frmStructuresConfig.selectedgroupequalText;
-  fAllMatchColorDiffHighlighted:=frmStructuresConfig.selectedgroupDifferentText;
+  fDefaultColorHighlighted := frmStructuresConfig.selecteddefaultText;
+  fMatchColorHighlighted := frmStructuresConfig.selectedequalText;
+  fNoMatchColorHighlighted := frmStructuresConfig.selecteddifferentText;
+  fAllMatchColorSameHighlighted := frmStructuresConfig.selectedgroupequalText;
+  fAllMatchColorDiffHighlighted := frmStructuresConfig.selectedgroupDifferentText;
 end;
 
 procedure TfrmStructures2.UpdateCurrentStructOptions;
 begin
-  if mainStruct<>nil then
+  if mainStruct <> nil then
   begin
-    miAutoCreate.Checked:=mainstruct.AutoCreate;
-    miAutostructsize.caption:=rsSF2AutocreateStructureSize+inttostr(mainstruct.autoCreateStructsize);
-    miAutoDestroyLocal.Checked:=mainstruct.AutoDestroy;
-    miDoNotSaveLocal.checked:=mainstruct.DoNotSaveLocal;
-    miAutoFillGaps.Checked:=mainStruct.AutoFill;
-    miDefaultHexadecimal.checked:=mainstruct.DefaultHex;
-    miRLECompression.checked:=mainstruct.RLECompression;
+    miAutoCreate.Checked := mainstruct.AutoCreate;
+    miAutostructsize.Caption :=
+      rsSF2AutocreateStructureSize + IntToStr(mainstruct.autoCreateStructsize);
+    miAutoDestroyLocal.Checked := mainstruct.AutoDestroy;
+    miDoNotSaveLocal.Checked := mainstruct.DoNotSaveLocal;
+    miAutoFillGaps.Checked := mainStruct.AutoFill;
+    miDefaultHexadecimal.Checked := mainstruct.DefaultHex;
+    miRLECompression.Checked := mainstruct.RLECompression;
 
-    caption:=rsStructureDissect+':'+mainStruct.name;
+    Caption := rsStructureDissect + ':' + mainStruct.Name;
   end
   else
-    caption:=rsStructureDissect;
+    Caption := rsStructureDissect;
 end;
 
 
 procedure TfrmStructures2.miChangeColorsClick(Sender: TObject);
 begin
   //show and wait for the user
-  frmStructuresConfig.groupbox1.Font.assign(tvStructureView.Font);
+  frmStructuresConfig.groupbox1.Font.Assign(tvStructureView.Font);
 
-  if frmStructuresConfig.showmodal=mrok then
+  if frmStructuresConfig.showmodal = mrOk then
   begin
     //just apply new colors
     setupColors; //gets the colors from the structures config
@@ -5819,51 +6291,49 @@ end;
 
 procedure TfrmStructures2.miDefaultHexadecimalClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainstruct.DefaultHex:=not mainstruct.DefaultHex;
+  if mainstruct <> nil then
+    mainstruct.DefaultHex := not mainstruct.DefaultHex;
 end;
 
 procedure TfrmStructures2.miRLECompressionClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainstruct.RLECompression:=not mainstruct.RLECompression;
+  if mainstruct <> nil then
+    mainstruct.RLECompression := not mainstruct.RLECompression;
 end;
 
 
 
 procedure TfrmStructures2.miDoNotSaveLocalClick(Sender: TObject);
 begin
-  if mainstruct<>nil then
-    mainstruct.DoNotSaveLocal:=not mainstruct.DoNotSaveLocal;
+  if mainstruct <> nil then
+    mainstruct.DoNotSaveLocal := not mainstruct.DoNotSaveLocal;
 end;
 
 procedure TfrmStructures2.miFillGapsClick(Sender: TObject);
 begin
 
-  if mainstruct<>nil then
-    mainstruct.fillGaps(getFocusedColumn.address, true);
+  if mainstruct <> nil then
+    mainstruct.fillGaps(getFocusedColumn.address, True);
 
 end;
 
 
 procedure TfrmStructures2.miOpenInNewWindowClick(Sender: TObject);
 type
-  TStructListEntry=record
+  TStructListEntry = record
     struct: TDissectedStruct;
     nodelist: TList;
   end;
-  PStructListEntry=^TStructListEntry;
+  PStructListEntry = ^TStructListEntry;
 
 var
   node: TTreenode;
   childstruct, struct: TDissectedStruct;
-  a,p: ptruint;
+  a, p: ptruint;
   f: TfrmStructures2;
   e: boolean;
   x: ptruint;
-  i,j: integer;
-
-
+  i, j: integer;
 
   structlistentry: PStructListEntry;
 
@@ -5873,39 +6343,38 @@ var
 
   nodelist: TList;
 
-
   sc: TStructColumn;
 begin
-  slist:=tlist.create;
+  slist := TList.Create;
 
-  for i:=0 to tvStructureView.SelectionCount-1 do
+  for i := 0 to tvStructureView.SelectionCount - 1 do
   begin
-    node:=tvStructureView.Selections[i];
-    childstruct:=getChildStructFromNode(node);
+    node := tvStructureView.Selections[i];
+    childstruct := getChildStructFromNode(node);
 
-    if childstruct<>nil then
+    if childstruct <> nil then
     begin
-      sli:=-1;
-      for j:=0 to slist.count-1 do
-        if PStructListEntry(slist[j])^.struct=childstruct then
+      sli := -1;
+      for j := 0 to slist.Count - 1 do
+        if PStructListEntry(slist[j])^.struct = childstruct then
         begin
-          sli:=j;
+          sli := j;
           break;
         end;
 
-      if sli=-1 then
+      if sli = -1 then
       begin
-        getmem(structlistentry,sizeof(TStructListEntry));
+        getmem(structlistentry, sizeof(TStructListEntry));
 
-        structlistentry^.struct:=childstruct;
-        structlistentry^.nodelist:=tlist.Create;
+        structlistentry^.struct := childstruct;
+        structlistentry^.nodelist := TList.Create;
 
-        nodelist:=structlistentry^.nodelist;
+        nodelist := structlistentry^.nodelist;
 
         slist.add(structlistentry);
       end
       else
-        nodelist:=PStructListEntry(slist[sli])^.nodelist;
+        nodelist := PStructListEntry(slist[sli])^.nodelist;
 
       nodelist.add(node);
     end;
@@ -5913,56 +6382,130 @@ begin
 
   //all nodes are sorted and added
 
-  for i:=0 to slist.Count-1 do
+  for i := 0 to slist.Count - 1 do
   begin
-    f:=nil;
-    struct:=PStructListEntry(slist[i])^.struct;
-    nodelist:=PStructListEntry(slist[i])^.nodelist;
-    for j:=0 to nodelist.Count-1 do
+    f := nil;
+    struct := PStructListEntry(slist[i])^.struct;
+    nodelist := PStructListEntry(slist[i])^.nodelist;
+    for j := 0 to nodelist.Count - 1 do
     begin
-      node:=nodelist[j];
+      node := nodelist[j];
 
-      a:=getAddressFromNode(node, getFocusedColumn, e); //or only getFocusedColumn?
+      a := getAddressFromNode(node, getFocusedColumn, e); //or only getFocusedColumn?
       if not e then
       begin
-        p:=0;
-        x:=0;
+        p := 0;
+        x := 0;
 
 
         ReadProcessMemory(processhandle, pointer(a), @p, ProcessHandler.pointersize, x);
-        if x=ProcessHandler.pointersize then
+        if x = ProcessHandler.pointersize then
         begin
-          if p=0 then continue;
-          if f=nil then
+          if p = 0 then
+            continue;
+          if f = nil then
           begin
-            f:=tfrmstructures2.create(application);
-            f.mainStruct:=struct;
+            f := tfrmstructures2.Create(application);
+            f.mainStruct := struct;
           end;
 
-          sc:=f.addColumn;
-          sc.AddressText:=inttohex(p,8);
+          sc := f.addColumn;
+          sc.AddressText := inttohex(p, 8);
         end;
       end;
 
     end;
 
-    if f<>nil then
+    if f <> nil then
     begin
-      f.show;
+      f.Show;
       f.InitializeFirstNode;
       f.UpdateCurrentStructOptions;
     end;
 
   end;
 
-  for i:=0 to slist.count-1 do
+  for i := 0 to slist.Count - 1 do
   begin
-    PStructListEntry(slist[i])^.nodelist.free;
+    PStructListEntry(slist[i])^.nodelist.Free;
     freemem(slist[i]);
   end;
-  slist.free;
+  slist.Free;
 
+end;
 
+procedure TfrmStructures2.miFindOutWhatAccessesThisAddressClick(Sender: TObject);
+var
+  baseaddress: ptruint;
+  offsetlist: array of integer;
+  node: ttreenode;
+  i: integer;
+  element: TStructelement;
+begin
+
+  if (not startdebuggerifneeded) then
+    exit;
+
+  for i := 0 to tvStructureView.SelectionCount - 1 do
+  begin
+
+    node := tvStructureView.Selections[i];
+
+    if node <> nil then
+    begin
+      element := getStructElementFromNode(node);
+
+      if element <> nil then
+      begin
+
+        baseaddress := 0;
+        getPointerFromNode(node, getFocusedColumn, baseaddress, offsetlist);
+        if baseaddress <> 0 then
+
+        begin
+
+          DebuggerThread.FindWhatAccesses(baseaddress, element.Bytesize);
+        end;
+      end;
+    end;
+  end;
+end;
+
+procedure TfrmStructures2.miFindOutWhatWritesThisAddressClick(Sender: TObject);
+var
+  baseaddress: ptruint;
+  offsetlist: array of integer;
+  node: ttreenode;
+  i: integer;
+  element: TStructelement;
+begin
+
+  if (not startdebuggerifneeded) then
+    exit;
+
+  for i := 0 to tvStructureView.SelectionCount - 1 do
+  begin
+
+    node := tvStructureView.Selections[i];
+
+    if node <> nil then
+    begin
+      element := getStructElementFromNode(node);
+
+      if element <> nil then
+      begin
+
+        baseaddress := 0;
+        getPointerFromNode(node, getFocusedColumn, baseaddress, offsetlist);
+        if baseaddress <> 0 then
+
+        begin
+
+          DebuggerThread.FindWhatWrites(baseaddress, element.Bytesize);
+        end;
+      end;
+    end;
+  end;
 end;
 
 
@@ -5970,7 +6513,7 @@ procedure TfrmStructures2.miFullUpgradeClick(Sender: TObject);
 var
   struct: TDissectedStruct;
   f: TfrmStructures2;
-  a,p: ptruint;
+  a, p: ptruint;
 
   node: TTreenode;
   e: boolean;
@@ -5978,33 +6521,35 @@ var
 
   se: TStructelement;
 begin
-  struct:=getChildStructFromNode(tvStructureView.GetLastMultiSelected);
-  if struct<>nil then
+  struct := getChildStructFromNode(tvStructureView.GetLastMultiSelected);
+  if struct <> nil then
     struct.addToGlobalStructList
   else
   begin
     //create a new structure from this entry
-    node:=tvStructureView.GetLastMultiSelected;
-    if node=nil then exit;
+    node := tvStructureView.GetLastMultiSelected;
+    if node = nil then
+      exit;
 
-    a:=getAddressFromNode(node, getFocusedColumn, e);
+    a := getAddressFromNode(node, getFocusedColumn, e);
     if not e then
     begin
-      p:=0;
-      x:=0;
+      p := 0;
+      x := 0;
       ReadProcessMemory(processhandle, pointer(a), @p, ProcessHandler.pointersize, x);
-      if x=ProcessHandler.pointersize then
+      if x = ProcessHandler.pointersize then
       begin
-        if p=0 then exit;
+        if p = 0 then
+          exit;
 
-        f:=tfrmstructures2.create(application);
-        f.initialaddress:=p;
-        f.show;
-        struct:=f.DefineNewStructure(4096);
+        f := tfrmstructures2.Create(application);
+        f.initialaddress := p;
+        f.Show;
+        struct := f.DefineNewStructure(4096);
 
-        se:=getStructElementFromNode(node);
-        if se<>nil then
-          se.ChildStruct:=struct;
+        se := getStructElementFromNode(node);
+        if se <> nil then
+          se.ChildStruct := struct;
 
       end;
     end;
@@ -6012,10 +6557,10 @@ begin
 
 end;
 
-procedure TfrmStructures2.miSelectStructureClick(Sender: tobject);
+procedure TfrmStructures2.miSelectStructureClick(Sender: TObject);
 //a structure has been selected from the menu. Handle it
 begin
-  mainStruct:=TdissectedStruct(TmenuItem(sender).Tag);
+  mainStruct := TdissectedStruct(TmenuItem(Sender).Tag);
 
   InitializeFirstNode;
   UpdateCurrentStructOptions;
@@ -6028,113 +6573,118 @@ var
   mi: TMenuItem;
   insertpos: integer;
 begin
-  insertpos:=structures1.IndexOf(miSeperatorStructCommandsAndList);
-  while structures1.count>insertpos+1 do
-    Structures1.Delete(insertpos+1);
+  insertpos := structures1.IndexOf(miSeperatorStructCommandsAndList);
+  while structures1.Count > insertpos + 1 do
+    Structures1.Delete(insertpos + 1);
 
-  for i:=0 to DissectedStructs.count-1 do
+  for i := 0 to DissectedStructs.Count - 1 do
   begin
-    s:=TDissectedStruct(DissectedStructs[i]).structname;
-    mi:=tmenuitem.Create(Structures1);
-    mi.Caption:=s;
-    mi.ImageIndex:=14;
-    mi.OnClick:=miSelectStructureClick;
-    mi.Tag:=ptruint(DissectedStructs[i]);
-    mi.RadioItem:=true;
-    mi.AutoCheck:=true;
-    mi.Checked:=mainStruct=TDissectedStruct(DissectedStructs[i]);
+    s := TDissectedStruct(DissectedStructs[i]).structname;
+    mi := tmenuitem.Create(Structures1);
+    mi.Caption := s;
+    mi.ImageIndex := 14;
+    mi.OnClick := miSelectStructureClick;
+    mi.Tag := ptruint(DissectedStructs[i]);
+    mi.RadioItem := True;
+    mi.AutoCheck := True;
+    mi.Checked := mainStruct = TDissectedStruct(DissectedStructs[i]);
     Structures1.Add(mi);
   end;
 end;
 
 procedure TfrmStructures2.setMainStruct(struct: TDissectedStruct);
 begin
-  fmainStruct:=struct;
+  fmainStruct := struct;
 
-  if struct=nil then
+  if struct = nil then
     tvStructureView.Items.Clear;
 
-  miCommands.Enabled:=struct<>nil;
+  miCommands.Enabled := struct <> nil;
 end;
 
 function TfrmStructures2.getColumn(i: integer): TStructColumn;
-//look through the groups to find this column
-var j,c: integer;
+  //look through the groups to find this column
+var
+  j, c: integer;
 begin
-  result:=nil;
-  c:=0;
-  for j:=0 to groupcount-1 do
+  Result := nil;
+  c := 0;
+  for j := 0 to groupcount - 1 do
   begin
-    if c+group[j].columnCount>i then
+    if c + group[j].columnCount > i then
     begin
-      result:=TStructColumn(group[j].columns[i-c]);
+      Result := TStructColumn(group[j].columns[i - c]);
       exit;
     end
     else
-      inc(c,group[j].columnCount);
+      Inc(c, group[j].columnCount);
   end;
 end;
 
 
 function TfrmStructures2.getColumnCount: integer;
-var i: integer;
+var
+  i: integer;
 begin
-  result:=0;
-  for i:=0 to groupcount-1 do
-    inc(result, group[i].columncount);
+  Result := 0;
+  for i := 0 to groupcount - 1 do
+    Inc(Result, group[i].columncount);
 end;
 
 function TfrmStructures2.getGroup(i: integer): TStructGroup;
 begin
-  result:=TStructGroup(fgroups[i]);
+  Result := TStructGroup(fgroups[i]);
 end;
 
 function TfrmStructures2.getGroupCount: integer;
 begin
-  result:=fgroups.count;
+  Result := fgroups.Count;
 end;
 
 function TfrmStructures2.getDisplayedDescription(se: TStructelement): string;
-var description, varname: string;
+var
+  description, varname: string;
 begin
-  result:='';
-  if se=nil then exit;
+  Result := '';
+  if se = nil then
+    exit;
 
-  if (se.name='') and (miShowTypeForEntriesWithNoDescription.checked) then
+  if (se.Name = '') and (miShowTypeForEntriesWithNoDescription.Checked) then
   begin
-    if se.vartype=vtCustom then
+    if se.vartype = vtCustom then
     begin
-      if se.CustomType<>nil then
-        varname:=se.CustomType.name
+      if se.CustomType <> nil then
+        varname := se.CustomType.Name
       else
-        varname:=rsSF2UnknownCustomType;
+        varname := rsSF2UnknownCustomType;
     end
     else
-      varname:=VariableTypeToString(se.VarType);
+      varname := VariableTypeToString(se.VarType);
 
-    description:=inttohex(se.Offset,4)+' - '+varname;
+    description := inttohex(se.Offset, 4) + ' - ' + varname;
 
     //show nondefault displaymethods
     case se.DisplayMethod of
-      dtHexadecimal: description:=description+rsSF2Hex;
-      dtSignedInteger: description:=description+rsSF2Signed;
+      dtHexadecimal: description := description + rsSF2Hex;
+      dtSignedInteger: description := description + rsSF2Signed;
     end;
 
-    if (se.VarType=vtPointer) and (se.ChildStruct<>nil) then
+    if (se.VarType = vtPointer) and (se.ChildStruct <> nil) then
     begin
-      description:=description+rsSF2To+se.ChildStruct.name;
-      if se.ChildStructStart<>0 then
-        description:=description+'+'+inttohex(se.ChildStructStart,1);
+      description := description + rsSF2To + se.ChildStruct.Name;
+      if se.ChildStructStart <> 0 then
+        description := description + '+' + inttohex(se.ChildStructStart, 1);
     end;
   end
   else
-    description:=inttohex(se.Offset,4)+' - '+se.Name;
+    description := inttohex(se.Offset, 4) + ' - ' + se.Name;
 
-  result:=description;
+  Result := description;
 end;
 
-procedure TfrmStructures2.tvStructureViewAdvancedCustomDrawItem(Sender: TCustomTreeView; Node: TTreeNode;
-  State: TCustomDrawState; Stage: TCustomDrawStage; var PaintImages, DefaultDraw: Boolean);
+procedure TfrmStructures2.tvStructureViewAdvancedCustomDrawItem(Sender: TCustomTreeView;
+  Node: TTreeNode; State: TCustomDrawState; Stage: TCustomDrawStage;
+  var PaintImages, DefaultDraw: boolean);
 var
   textrect: trect;
   linerect: trect;
@@ -6153,161 +6703,241 @@ var
   selected: boolean;
 
   nodescription: boolean; //if set render the description using a lighter color
-  r,g,b: byte;
+  r, g, b: byte;
 
   displacement: integer;
   //varname: string;
 
-
 begin
-  if mainstruct=nil then exit; //no rendering
+  if mainstruct = nil then
+    exit; //no rendering
 
 
-  if stage=cdPrePaint then
+  if stage = cdPrePaint then
   begin
-    se:=getStructElementFromNode(node);
-    if se<>nil then
-      sender.BackgroundColor:=se.backgroundColor;
+    se := getStructElementFromNode(node);
+    if se <> nil then
+      Sender.BackgroundColor := se.backgroundColor;
   end;
 
 
 
 
-  if stage=cdPostPaint then
+  if stage = cdPostPaint then
   begin
 
+    textrect := node.DisplayRect(True);
+    linerect := node.DisplayRect(False);
 
-    textrect:=node.DisplayRect(true);
-    linerect:=node.DisplayRect(false);
-
-    fulltextline:=linerect;
-    fulltextline.Left:=textrect.Left;
-    fulltextline.Right:=tvStructureView.ClientWidth;
+    fulltextline := linerect;
+    fulltextline.Left := textrect.Left;
+    fulltextline.Right := tvStructureView.ClientWidth;
 
     //get the next text
-    se:=getStructElementFromNode(node);
+    se := getStructElementFromNode(node);
 
-    nodescription:=(se<>nil) and (se.name='');
-    if (se=nil) then
-      description:=mainstruct.name
+    nodescription := (se <> nil) and (se.Name = '');
+    if (se = nil) then
+      description := mainstruct.Name
     else
-      description:=getDisplayedDescription(se);
+      description := getDisplayedDescription(se);
 
-    selected:=(cdsSelected in State) or (cdsMarked in state);
-    setCurrentNodeStringsInColumns(node,se,selected);
+    selected := (cdsSelected in State) or (cdsMarked in state);
+    setCurrentNodeStringsInColumns(node, se, selected);
 
 
     //draw an empty line.
-    textlinerect.left:=textrect.left;
-    textlinerect.Top:=linerect.Top;
-    textlinerect.Right:=max(tvStructureView.clientwidth, headercontrol1.left+headercontrol1.Sections.Items[headercontrol1.Sections.Count-1].Left+headercontrol1.Sections.Items[headercontrol1.Sections.Count-1].Width);
-    textlinerect.Bottom:=linerect.Bottom;
-    if textlinerect.right<textlinerect.left then
-      textlinerect.right:=textlinerect.left;
+    textlinerect.left := textrect.left;
+    textlinerect.Top := linerect.Top;
+    textlinerect.Right := max(tvStructureView.clientwidth,
+      headercontrol1.left + headercontrol1.Sections.Items[headercontrol1.Sections.Count -
+      1].Left + headercontrol1.Sections.Items[headercontrol1.Sections.Count - 1].Width);
+    textlinerect.Bottom := linerect.Bottom;
+    if textlinerect.right < textlinerect.left then
+      textlinerect.right := textlinerect.left;
 
 
     //draw the description
-    clip:=textrect;
-    clip.Right:=headercontrol1.left+headercontrol1.Sections[0].Left+headercontrol1.Sections[0].Width;
+    clip := textrect;
+    clip.Right := headercontrol1.left + headercontrol1.Sections[0].Left +
+      headercontrol1.Sections[0].Width;
 
 
     if selected then
-      sender.Canvas.Font.Color:=fDefaultColorHighlighted
+      Sender.Canvas.Font.Color := fDefaultColorHighlighted
     else
-      sender.Canvas.Font.Color:=fDefaultColor;
+      Sender.Canvas.Font.Color := fDefaultColor;
 
     if nodescription then
     begin        //blatantly stolen from DecColor   (why the fuck is there no incColor ?)
-      RedGreenBlue(ColorToRGB(sender.Canvas.Font.Color), R, G, B);
-      R := Max(0, min(255, Integer(R) + 75));
-      G := Max(0, min(255, Integer(G) + 75));
-      B := Max(0, min(255, Integer(B) + 75));
-      sender.Canvas.Font.Color := RGBToColor(R, G, B);
+      RedGreenBlue(ColorToRGB(Sender.Canvas.Font.Color), R, G, B);
+      R := Max(0, min(255, integer(R) + 75));
+      G := Max(0, min(255, integer(G) + 75));
+      B := Max(0, min(255, integer(B) + 75));
+      Sender.Canvas.Font.Color := RGBToColor(R, G, B);
     end;
 
 
-    sender.Canvas.Refresh;
-    sender.Canvas.TextRect(clip,textrect.Left,textrect.Top,description);
+    Sender.Canvas.Refresh;
+    Sender.Canvas.TextRect(clip, textrect.Left, textrect.Top, description);
 
     //draw the columns
-    for i:=0 to columnCount-1 do
+    for i := 0 to columnCount - 1 do
     begin
-      c:=columns[i];
-      clip.left:=headercontrol1.left+headercontrol1.Sections[i+1].Left;
-      clip.right:=headercontrol1.left+headercontrol1.Sections[i+1].Right;
+      c := columns[i];
+      clip.left := headercontrol1.left + headercontrol1.Sections[i + 1].Left;
+      clip.right := headercontrol1.left + headercontrol1.Sections[i + 1].Right;
 
-      sender.canvas.font.Color:=c.currentNodeColor;
+      Sender.canvas.font.Color := c.currentNodeColor;
 
-      sender.Canvas.Refresh;
+      Sender.Canvas.Refresh;
 
 
-      if miShowAddresses.checked then
-        s:=c.currentNodeAddress
+      if miShowAddresses.Checked then
+        s := c.currentNodeAddress
       else
-        s:='';
+        s := '';
 
-      s:=s+c.currentNodeValue;
-      sender.Canvas.TextRect(clip,clip.left,textrect.Top,s);
+      s := s + c.currentNodeValue;
+      Sender.Canvas.TextRect(clip, clip.left, textrect.Top, s);
     end;
 
-    sender.BackgroundColor:=clWindow;
+    Sender.BackgroundColor := clWindow;
   end;
-  DefaultDraw:=true;
+  DefaultDraw := True;
 end;
 
-procedure TfrmStructures2.EditValueOfSelectedNodes(c:TStructColumn);
-var a: PtrUInt;
+procedure TfrmStructures2.EditValueOfSelectedNodes(focusColumn: TStructColumn);
+var
+  addressNode: PtrUInt;
   error: boolean;
-  se: Tstructelement;
+  structElement: Tstructelement;
   node: TTreeNode;
   i: integer;
-  s: string;
+  stringValue: string;
   savedstate: PtrUInt;
 begin
-  node:=tvStructureView.GetLastMultiSelected;
-  if node=nil then exit;
+  node := tvStructureView.GetLastMultiSelected;
+  if node = nil then
+    exit;
 
-  se:=getStructElementFromNode(node);
-  if se<>nil then
+  structElement := getStructElementFromNode(node);
+  if structElement = nil then
+    exit;
+
+  addressNode := getAddressFromNode(node, focusColumn, error);
+  if error then
+    exit;
+
+  //show the change value dialog
+  stringValue := structElement.getValue(addressNode);
+  if InputQuery(rsSF2ChangeValue, rsSF2NewValueForThisAddress, stringValue) then
   begin
-    a:=getAddressFromNode(node, c, error);
 
-    if not error then
+    //try setting the value
+    for i := 0 to tvStructureView.SelectionCount - 1 do
     begin
-      //show the change value dialog
-      s:=se.getValue(a);
-      if InputQuery(rsSF2ChangeValue,rsSF2NewValueForThisAddress, s) then
-      begin
-        //try setting the value
-        for i:=0 to tvStructureView.SelectionCount-1 do
-        begin
-          se:=getStructElementFromNode(tvStructureView.Selections[i]);
-          a:=getAddressFromNode(tvStructureView.Selections[i], c, error);
+      structElement := getStructElementFromNode(tvStructureView.Selections[i]);
+      addressNode := getAddressFromNode(tvStructureView.Selections[i],
+        focusColumn, error);
 
 
 {
 displayaddress:=getAddressFromNode(node, columns[i], error);  //get the address to show the user
 
-savedstate:=ptruint(c.getSavedState);
+savedstate:=ptruint(focusColumn.getSavedState);
 address:=displayaddress;
 
-if (savedstate<>0) and (InRangeX(address, c.Address, c.address+ c.getSavedStateSize)) then
-  address:=address+(savedstate-c.address);
+if (savedstate<>0) and (InRangeX(address, focusColumn.Address, focusColumn.address+ focusColumn.getSavedStateSize)) then
+address:=address+(savedstate-focusColumn.address);
 
 }
 
+      if not error then
+      begin
+        savedstate := ptruint(focusColumn.getSavedState);
 
-          if not error then
-          begin
-            savedstate:=ptruint(c.getSavedState);
-            if (savedstate<>0) and (InRangeX(a, c.Address, c.address+ c.getSavedStateSize)) then
-              a:=a+(savedstate-c.address);
+        if (savedstate <> 0) and
+          (InRangeX(addressNode, focusColumn.Address, focusColumn.address +
+          focusColumn.getSavedStateSize)) then
+          addressNode := addressNode + (savedstate - focusColumn.address);
 
-            se.setvalue(a, s); //I knew there was a reason I implemented this
-          end;
-        end;
+        structElement.setvalue(addressNode, stringValue);
+        //I knew there was addressNode reason I implemented this
       end;
+
     end;
+
+  end;
+end;
+
+procedure TfrmStructures2.EditAllValuesInRowOfSelectedNodes(focusColumn: TStructColumn);
+var
+  addressNode: PtrUInt;
+  error: boolean;
+  structElement: Tstructelement;
+  node: TTreeNode;
+  i: integer;
+  stringValue: string;
+  savedstate: PtrUInt;
+  columnIndex: integer;
+  column: TStructColumn;
+begin
+  node := tvStructureView.GetLastMultiSelected;
+  if node = nil then
+    exit;
+
+  structElement := getStructElementFromNode(node);
+  if structElement = nil then
+    exit;
+
+  addressNode := getAddressFromNode(node, focusColumn, error);
+  if error then
+    exit;
+
+  //show the change value dialog
+  stringValue := structElement.getValue(addressNode);
+  if InputQuery(rsSF2ChangeValue, rsSF2NewValueForThisAddress, stringValue) then
+  begin
+
+    //try setting the value
+    for i := 0 to tvStructureView.SelectionCount - 1 do
+    begin
+      structElement := getStructElementFromNode(tvStructureView.Selections[i]);
+
+      for columnIndex := 0 to columnCount - 1 do
+      begin
+
+        column := columns[columnIndex];
+
+        addressNode := getAddressFromNode(tvStructureView.Selections[i], column, error);
+
+{
+displayaddress:=getAddressFromNode(node, columns[i], error);  //get the address to show the user
+
+savedstate:=ptruint(column.getSavedState);
+address:=displayaddress;
+
+if (savedstate<>0) and (InRangeX(address, column.Address, column.address+ column.getSavedStateSize)) then
+address:=address+(savedstate-column.address);
+}
+
+        if not error then
+        begin
+          savedstate := ptruint(column.getSavedState);
+
+          if (savedstate <> 0) and
+            (InRangeX(addressNode, column.Address, column.address +
+            column.getSavedStateSize)) then
+            addressNode := addressNode + (savedstate - column.address);
+
+          structElement.setvalue(addressNode, stringValue);
+        end;
+
+      end;
+
+    end;
+
   end;
 end;
 
@@ -6317,11 +6947,11 @@ var
   c: TStructColumn;
 begin
   //if first column is doubleclicked edit the type, else edit the value
-  m:=mouse.CursorPos;
-  m:=tvStructureView.ScreenToClient(m);
-  c:=getColumnAtXPos(m.x+tvStructureView.ScrolledLeft);
+  m := mouse.CursorPos;
+  m := tvStructureView.ScreenToClient(m);
+  c := getColumnAtXPos(m.x + tvStructureView.ScrolledLeft);
 
-  if c=nil then
+  if c = nil then
     miChangeElementClick(miChangeElement)
   else
     EditValueOfSelectedNodes(c);
@@ -6329,39 +6959,39 @@ begin
 end;
 
 procedure TfrmStructures2.miFindRelationsClick(Sender: TObject);
-var sl: TfrmStructureLinker;
+var
+  sl: TfrmStructureLinker;
 begin
   //show the "find Relations" form where the user can fill in known addresses for structures
   //the structures will then check each pointer and fill them in
 
-  sl:=TfrmStructureLinker.Create(self);
+  sl := TfrmStructureLinker.Create(self);
   sl.ShowModal;
-  sl.free;
+  sl.Free;
 
 end;
 
-procedure TfrmStructures2.addLockedAddress(shownaddress: ptruint; memoryblock: pointer; size: integer);
+procedure TfrmStructures2.addLockedAddress(shownaddress: ptruint;
+  memoryblock: pointer; size: integer);
 begin
   //add a column and lock it with the given state
 
 
   addColumn.LockAddress(shownaddress, memoryblock, size);
 
-
-
-
 end;
 
 procedure TfrmStructures2.FixPositions;
 var
-  group : TStructGroup;
-  col : TStructColumn;
-  section : THeaderSection;
-  gi, ci, globalIndex: Integer;
-  scrunch: Integer; // how much to scrunch a whole group's ClientWidth
-  each, extra: Integer; // how much to scrunch each column, and how many extra columns need another
-  colWidth: Integer;
-  marginSize, defaultSize: Integer;
+  group: TStructGroup;
+  col: TStructColumn;
+  section: THeaderSection;
+  gi, ci, globalIndex: integer;
+  scrunch: integer; // how much to scrunch a whole group's ClientWidth
+  each, extra: integer;
+  // how much to scrunch each column, and how many extra columns need another
+  colWidth: integer;
+  marginSize, defaultSize: integer;
 begin
   //commented out, appearing of scrollbars will mess with this
   {
@@ -6435,8 +7065,8 @@ begin
 end;
 
 initialization
-  DissectedStructs:=TList.create;
-  frmStructures2:=tlist.Create;
+  DissectedStructs := TList.Create;
+  frmStructures2 := TList.Create;
 
 end.
 //add expandallnodes(maxlevel)


### PR DESCRIPTION
1. Separators added to submenu "Change Type".
New MenuItem structure:
Change Type
  Byte
  2 Byte
  4 Byte
  8 Byte
  ----------
  Byte (Hex)
  2 Byte (Hex)
  4 Byte (Hex)
  8 Byte (Hex)
  ----------
  Float
  Double
  ----------
  String
  Unicode String
  ----------
  Array Of Byte
  Pointer

2. New MenuItem "8 Byte" added to submenu "Change Type".

3. Fixed a bug when the Pointer(String, Unicode String) retains Hex Flag when changing the address type through the MenuItem "Change Type".

4. New MenuItem "Change all values in row".
Now you can change all values in a row with only one command.

5. New MenuItem "Add all in row to address list".
Now you can add all addresses in a row to the Address List with only one command.

6. New MenuItem "Find out what accesses this address".
The MenuItem works in the same way as in the Main Form.

7. New MenuItem "Find out what writes to this address".
The MenuItem works in the same way as in the Main Form.

--
Best Regards