### PR TITLE
Improving Change Address Form

### DIFF
--- a/Cheat Engine/formAddressChangeUnit.lfm
+++ b/Cheat Engine/formAddressChangeUnit.lfm
@@ -460,6 +460,24 @@ object formAddressChange: TformAddressChange
       ImageIndex = 1
       OnClick = miPasteClick
     end
+    object miSeparator: TMenuItem
+      Caption = '-'
+    end
+    object miAddOffsetAbove: TMenuItem
+      Caption = 'Add Offset Above'
+      OnClick = miAddOffsetAboveClick
+    end
+    object miAddOffsetBelow: TMenuItem
+      Caption = 'Add Offset Below'
+      OnClick = miAddOffsetBelowClick
+    end
+    object miRemoveOffset: TMenuItem
+      Caption = 'Remove Offset'
+      OnClick = miRemoveOffsetClick
+    end
+    object miSepUpdate: TMenuItem
+      Caption = '-'
+    end
     object miUpdateOnReinterpretOnly: TMenuItem
       AutoCheck = True
       Caption = 'Only update the offset when the memory record gets reinterpreted'
@@ -479,6 +497,11 @@ object formAddressChange: TformAddressChange
       Caption = 'Add this address to the list'
       ImageIndex = 3
       OnClick = miAddAddressToListClick
+    end
+    object miCopyAddressToClipboard: TMenuItem
+      Caption = 'Copy this address to Clipboard'
+      ImageIndex = 0
+      OnClick = miCopyAddressToClipboardClick
     end
   end
   object caImageList: TImageList


### PR DESCRIPTION
1. Context Menu's pmPointerRow new MenuItem "Copy this address to Clipboard".

2. Changed lblPointerAddressToValue Font Color to blue. Now the user will understand that this is not just a label, this label has a context menu.

3. Adding new MenuItems to Context Menu pmOffset.
3.1 New MenuItem "Add Offset Above". MenuItem will add a new offset Textbox above the selected.
3.2 New MenuItem "Add Offset Below". MenuItem will add a new offset Textbox below the selected.
3.3 New MenuItem "Remove Offset". MenuItem will remove selected offset.

4. Adding hints to buttons "Add Offset" and "Remove Offset".
Now the user will understand that while the Ctrl key is pressed, the new offset will be added to the opposite location.

5. When Address becomes Pointer, the text field "editAddress" becomes read-only. Now the user can copy the address from there if necessary.

6. When Address becomes Pointer, the value from the text field "editAddress" becomes the base address.

7. When Address is no longer Pointer, the value from the base address becomes the value of the text field "editAddress".

8. Adding separators to Context Menus.

--
Best Regards.

