### PR TITLE
Implemented display of assigned hotkeys in hotkeys list

### DIFF
--- a/Cheat Engine/frameHotkeyConfigUnit.lfm
+++ b/Cheat Engine/frameHotkeyConfigUnit.lfm
@@ -68,10 +68,13 @@ object frameHotkeyConfig: TframeHotkeyConfig
         'Cancel the current scan'
         'Debug->Run'
       )
-      ItemHeight = 15
+      ItemHeight = 0
       OnClick = ListBox1Click
+      OnDrawItem = ListBox1DrawItem
       OnSelectionChange = ListBox1SelectionChange
+      Options = []
       PopupMenu = PopupMenu1
+      Style = lbOwnerDrawFixed
       TabOrder = 0
     end
   end

--- a/Cheat Engine/frameHotkeyConfigUnit.pas
+++ b/Cheat Engine/frameHotkeyConfigUnit.pas
@@ -51,6 +51,8 @@ type
     procedure Edit1KeyDown(Sender: TObject; var Key: Word;
       Shift: TShiftState);
     procedure Button3Click(Sender: TObject);
+    procedure ListBox1DrawItem(Control: TWinControl; Index: Integer;
+      ARect: TRect; State: TOwnerDrawState);
     procedure ListBox1SelectionChange(Sender: TObject; User: boolean);
     procedure MenuItem1Click(Sender: TObject);
   private
@@ -273,6 +275,46 @@ begin
     edit1.Text:=ConvertKeyComboToString(newhotkeys[listbox1.ItemIndex]);
     edit1.SetFocus;
   end;
+end;
+
+procedure TframeHotkeyConfig.ListBox1DrawItem(Control: TWinControl;
+  Index: Integer; ARect: TRect; State: TOwnerDrawState);
+const
+  TO_START_ALIGNMENT: array[Boolean] of TAlignment = (taLeftJustify, taRightJustify);
+var
+  OldTextStyle, NewTextStyle: TTextStyle;
+  Canvas: TCanvas;
+  Hotkey: string;
+begin
+  Canvas := TListBox(Control).Canvas;
+  if not(odBackgroundPainted in State) then
+    Canvas.FillRect(ARect);
+
+  ARect.Left += 2;
+  ARect.Right -= 2;
+
+  OldTextStyle := Canvas.TextStyle;
+  NewTextStyle.Layout:= tlCenter;
+
+  Hotkey := ConvertKeyComboToString(newhotkeys[Index]);
+  if(Hotkey <> '') then
+  begin
+    Hotkey := '(' + Hotkey + ')';
+
+    NewTextStyle.Alignment := TO_START_ALIGNMENT[not Control.UseRightToLeftAlignment];
+    Canvas.TextStyle := NewTextStyle;
+    Canvas.TextRect(ARect, ARect.Left, ARect.Top, Hotkey);
+    if Control.UseRightToLeftAlignment then
+      ARect.Left += Canvas.TextWidth(Hotkey) + 2
+    else
+      ARect.Right -= Canvas.TextWidth(Hotkey) + 2;
+  end;
+
+  NewTextStyle.Alignment:= TO_START_ALIGNMENT[Control.UseRightToLeftAlignment];
+  Canvas.TextStyle := NewTextStyle;
+  Canvas.TextRect(ARect, ARect.Left, ARect.Top, TListBox(Control).Items[Index]);
+
+  Canvas.TextStyle := OldTextStyle;
 end;
 
 procedure TframeHotkeyConfig.ListBox1SelectionChange(Sender: TObject;


### PR DESCRIPTION
Currently assigned hotkeys are not displayed in the list of function, so it's not visible what hotkeys and for what functions are assigned. This change allows to easily see what hotkeys are assigned for what functions.

![image](https://user-images.githubusercontent.com/7416072/93869324-53f43100-fcd4-11ea-9320-e6ab1d4cd769.png)
