### PR TITLE
CeShare (Small) Fixes

### DIFF
--- a/Cheat Engine/bin/autorun/ceshare/ceshare_account.lua
+++ b/Cheat Engine/bin/autorun/ceshare/ceshare_account.lua
@@ -36,7 +36,8 @@ end
 
 function ceshare.logout()
   local i=ceshare.getInternet()
-  i.postURL(ceshare.base..'logout.php')
+  local parameters='';
+  i.postURL(ceshare.base..'logout.php',parameters)
   ceshare.LoggedIn=false
 end
 

--- a/Cheat Engine/bin/autorun/ceshare/ceshare_publish.lua
+++ b/Cheat Engine/bin/autorun/ceshare/ceshare_publish.lua
@@ -174,8 +174,9 @@ function ceshare.UpdateCheat(id,data,title,headermd5, versionindependent, descri
 end
 
 function ceshare.PublishCheatClick(sender, cheatinfo) 
+  local loggedin=ceshare.LoggedIn or false
   --if not logged in, log in now
-  if ceshare.LoggedIn==nil then
+  if not loggedin then
     if not ceshare.spawnLoginDialog() then 
       return
     end


### PR DESCRIPTION
- fix logout.php never called  

Logout.php is never called, only the client/ce is (software) logged out.   
The session on the server remains active until it expires.   
May be dangerous if a script exploits this bug.  

- fix publish/update still accessible after logout  

After the initial login, the publish/update window continues to open even if a logout has occurred.