### PR TITLE
Correct createthreadandwait so that it will be able to use the timeout.

### DIFF
--- a/Cheat Engine/autoassembler.pas
+++ b/Cheat Engine/autoassembler.pas
@@ -1986,6 +1986,7 @@ begin
                   if length(slist)=2 then
                   begin
                     try
+                      s1:=slist[0];
                       j:=strtoint(trim(slist[1]));
                     except
                       raise exception.Create('Invalid timeout for createthreadandwait');


### PR DESCRIPTION
Fixes Issue #1462
It correctly sets the value to the first past of the string instead of leaving it as the whole thing.