### PR TITLE
fix freeing the wrong memory when dealing with an error in ELF64 function.

### DIFF
--- a/Cheat Engine/ceserver/symbols.c
+++ b/Cheat Engine/ceserver/symbols.c
@@ -319,8 +319,8 @@ Caller must free output manually
     if (sectionHeaders)
       free(sectionHeaders);
 
-    if (output)
-      free(output);
+    if (*output)
+      free(*output);
 
     if (tempbuffer)
       free(tempbuffer);


### PR DESCRIPTION
The same bug existed in the elf64 function.