### PR TITLE
alloc contiguously

### DIFF
--- a/DBKKernel/IOPLDispatcher.c
+++ b/DBKKernel/IOPLDispatcher.c
@@ -2441,7 +2441,7 @@ NTSTATUS DispatchIoctl(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp)
 			LowAddress.QuadPart = 0;
 			HighAddress.QuadPart = 0xffffffffffffffffI64;
 			SkipBytes.QuadPart = 0;
-			mdl = MmAllocatePagesForMdl(LowAddress, HighAddress, SkipBytes, (SIZE_T)pagecount * 4096); //do not free this, EVER
+			mdl = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, (SIZE_T)pagecount * 4096, MmCached, MM_ALLOCATE_REQUIRE_CONTIGUOUS_CHUNKS | MM_ALLOCATE_FULLY_REQUIRED); //do not free this, EVER
 			if (mdl)
 			{
 				int i;

--- a/DBKKernel/vmxoffload.c
+++ b/DBKKernel/vmxoffload.c
@@ -971,7 +971,7 @@ void vmxoffload_override(CCHAR cpunr, PKDEFERRED_ROUTINE Dpc, PVOID DeferredCont
 	LowAddress.QuadPart = 0;
 	HighAddress.QuadPart = 0xffffffffffffffffI64;
 	SkipBytes.QuadPart = 0;
-	mdl=MmAllocatePagesForMdl(LowAddress, HighAddress, SkipBytes, 64 * 1024); //do not free this, EVER
+	mdl = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, 64 * 1024, MmCached, MM_ALLOCATE_REQUIRE_CONTIGUOUS_CHUNKS | MM_ALLOCATE_FULLY_REQUIRED); //do not free this, EVER
 
 	if (mdl)
 	{

--- a/DBKKernel/vmxoffload.c
+++ b/DBKKernel/vmxoffload.c
@@ -278,7 +278,7 @@ Runs at passive mode
 	HighAddress.QuadPart = -1;
 	SkipBytes.QuadPart = 0;
 
-	DBVMMDL = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, 4 * 1024 * 1024, MmCached, 0);
+	DBVMMDL = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, 4 * 1024 * 1024, MmCached, MM_ALLOCATE_REQUIRE_CONTIGUOUS_CHUNKS | MM_ALLOCATE_FULLY_REQUIRED);
 	if (!DBVMMDL) {
 		DbgPrint("Failure allocating the required 4MB\n");
 		return;
@@ -640,7 +640,7 @@ Runs at passive mode
 					initvars->nextstack = 0x00400000 + ((UINT64)mainstack - (UINT64)vmm) + (16 * 4096) - 0x40;
 					initvars->contiguousmemory = 0;
 					
-					PMDL contiguousMDL = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, 8 * 4096, MmCached, MM_ALLOCATE_REQUIRE_CONTIGUOUS_CHUNKS);
+					PMDL contiguousMDL = MmAllocatePagesForMdlEx(LowAddress, HighAddress, SkipBytes, 8 * 4096, MmCached, MM_ALLOCATE_REQUIRE_CONTIGUOUS_CHUNKS | MM_ALLOCATE_FULLY_REQUIRED);
 					if (contiguousMDL) {
 						initvars->contiguousmemory = MmGetMdlPfnArray(contiguousMDL)[0] << 12;
 						DbgPrint("contiguous PA =%llx\n", initvars->contiguousmemory);

--- a/dbvm/vmm/epthandler.c
+++ b/dbvm/vmm/epthandler.c
@@ -134,6 +134,7 @@ void ept_hideDBVMPhysicalAddresses_callbackIntel(QWORD VirtualAddress UNUSED, QW
   PEPT_PTE eptentry=mapPhysicalMemory(eptentryAddress,8);
 
   eptentry->PFN=MAXPHYADDRMASK >> 13; //unallocated memory (using 13 as sometimes accessing the most significant bit of the allowed PA will crash a system)
+  eptentry->MEMTYPE = 0;
 
   unmapPhysicalMemory(eptentry,8);
 


### PR DESCRIPTION
This makes VMCALL_HIDEDBVMPHYSICALADDRESSESALL use less memory.