### PR TITLE
Heebeaux patch 20210606

### DIFF
--- a/Cheat Engine/formChangedAddresses.lfm
+++ b/Cheat Engine/formChangedAddresses.lfm
@@ -7,6 +7,7 @@ object frmChangedAddresses: TfrmChangedAddresses
   ClientHeight = 319
   ClientWidth = 389
   OnClose = FormClose
+  OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
   OnDestroy = FormDestroy
   OnShow = FormShow

--- a/Cheat Engine/formChangedAddresses.pas
+++ b/Cheat Engine/formChangedAddresses.pas
@@ -110,6 +110,7 @@ type
       Data: Integer; var Compare: Integer);
     procedure ChangedlistCustomDrawItem(Sender: TCustomListView;
       Item: TListItem; State: TCustomDrawState; var DefaultDraw: Boolean);
+    procedure FormCloseQuery(Sender: TObject; var CanClose: boolean); 
     procedure miCodeAddressBrowseMemoryRegionClick(Sender: TObject);
     procedure miCodeAddressCopyClick(Sender: TObject);
     procedure miCodeAddressDisassembleMemoryRegionClick(Sender: TObject);
@@ -748,6 +749,14 @@ begin
   DefaultDraw:=true;
 end;
 
+procedure TfrmChangedAddresses.FormCloseQuery(Sender: TObject;
+  var CanClose: boolean);
+begin
+  if OKButton.caption=rsStop then OKButton.Click;
+  CanClose:=true;
+end;
+
+
 procedure TfrmChangedAddresses.miCodeAddressCopyClick(Sender: TObject);
 begin
   clipboard.AsText:=editCodeAddress.Text;
@@ -1133,6 +1142,11 @@ var temp:dword;
     i: integer;
     ae: TAddressEntry;
 begin
+
+  if OKButton.Caption=rsStop then
+    if debuggerthread<>nil then
+      debuggerthread.FindWhatCodeAccessesStop(self);
+      
   if breakpoint=nil then
     action:=caFree
   else


### PR DESCRIPTION
When closing the "Find What Code Accesses" form without clicking the stop button, there is a bug where the breakpoint will still be shown as still existing in the disassembler. If you try to remove the breakpoint with the right-click context/popup menu nothing happens.  If you try to remove the breakpoint in the breakpoint list CE will lockup requiring a force close (possibly because the breakpoint reference is removed). There is also no easy/intuitive why to reopen the dialog at this address to allow one to click the stop button. Restarting CE shows no signs of the original breakpoint. These changes cause the "Find What Code Accesses" dialog to behave like the "Find what accesses/writes this value" dialog (FoundCodeUnit) when the dialog is closed without clicking stop first.