### PR TITLE
Update ultimap2.c

### DIFF
--- a/DBKKernel/ultimap2.c
+++ b/DBKKernel/ultimap2.c
@@ -1,4 +1,4 @@
-#pragma warning( disable: 4100 4706)
+#pragma warning( disable: 4100 4706 4996)
 
 #include <ntifs.h>
 #include <ntddk.h>


### PR DESCRIPTION
in vs2019, will warning as follows:

warning C4996: 'wcsncpy': This function or variable may be unsafe. Consider using wcsncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.