### PR TITLE
Expanded group scan pointer fields to support explicitly scanning for static/dynamic pointers

### DIFF
--- a/Cheat Engine/commontypedefs.pas
+++ b/Cheat Engine/commontypedefs.pas
@@ -13,6 +13,7 @@ type TScanOption=(soUnknownValue=0,soExactValue=1,soValueBetween=2,soBiggerThan=
 type TScanType=(stNewScan=0, stFirstScan=1, stNextScan=2);
 type TRoundingType=(rtRounded=0,rtExtremerounded=1,rtTruncated=2);
 type TVariableType=(vtByte=0, vtWord=1, vtDword=2, vtQword=3, vtSingle=4, vtDouble=5, vtString=6, vtUnicodeString=7, vtByteArray=8, vtBinary=9, vtAll=10, vtAutoAssembler=11, vtPointer=12, vtCustom=13, vtGrouped=14, vtByteArrays=15, vtCodePageString=16); //all ,grouped and MultiByteArray are special types
+type TPointerType=(ptStatic=1, ptDynamic=2, ptAny=3); // used for pointer variables in group scans
 type TCustomScanType=(cstNone, cstAutoAssembler, cstCPP, cstDLLFunction);
 type TFastScanMethod=(fsmNotAligned=0, fsmAligned=1, fsmLastDigits=2);
 

--- a/Cheat Engine/groupscancommandparser.pas
+++ b/Cheat Engine/groupscancommandparser.pas
@@ -39,7 +39,7 @@ type
       bytesize: integer;
       command: string;
       picked: boolean;
-
+      pointertype: TPointerType; // for vtPointer this restricts whether the pointer is static, dynamic, or either
     end;
 
     blocksize: integer;
@@ -112,6 +112,7 @@ begin
     elements[j].valuefloat:=0;
     elements[j].customtype:=nil;
     elements[j].bytesize:=1;
+    elements[j].pointertype:=ptAny;
     elements[j].offset:=calculatedBlocksize;
     elements[j].command:=command;
 
@@ -238,11 +239,24 @@ begin
 
         vtPointer:
         begin
-          //convert it to a normal type
-          if processhandler.is64Bit then
-            elements[j].vartype:=vtQword
+          if value = 'S' then
+          begin
+            elements[j].pointertype:=ptStatic;
+            elements[j].wildcard:=true;
+          end
+          else if value = 'D' then
+          begin
+            elements[j].pointertype:=ptDynamic;
+            elements[j].wildcard:=true;
+          end
           else
-            elements[j].vartype:=vtDword;
+          begin
+            //convert it to a normal type
+            if processhandler.is64Bit then
+              elements[j].vartype:=vtQword
+            else
+              elements[j].vartype:=vtDword;
+          end;
         end;
 
         vtSingle, vtDouble:


### PR DESCRIPTION
This PR adds additional syntax to the groupscan pointer fields so that `P:S` and `P:D` can be used in addition to `P:*` in order to scan for static and dynamic pointers. Pointers are considered static if they point to MEM_MAPPED or MEM_IMAGE regions, or dynamic if they do not point to such a region.

Internally, this splits the pointer lookup into two, so that there is a separate lookup for each type (dynamic/static). The lookups are only populated when they are used by the groupscan.

Apologies for any strangeness in the code - it's been nearly 8 years since I wrote any Delphi.