### PR TITLE
Add executable pointer to groupscan and and fix lookup init bug in groupscan parser.

### DIFF
--- a/Cheat Engine/commontypedefs.pas
+++ b/Cheat Engine/commontypedefs.pas
@@ -13,7 +13,7 @@ type TScanOption=(soUnknownValue=0,soExactValue=1,soValueBetween=2,soBiggerThan=
 type TScanType=(stNewScan=0, stFirstScan=1, stNextScan=2);
 type TRoundingType=(rtRounded=0,rtExtremerounded=1,rtTruncated=2);
 type TVariableType=(vtByte=0, vtWord=1, vtDword=2, vtQword=3, vtSingle=4, vtDouble=5, vtString=6, vtUnicodeString=7, vtByteArray=8, vtBinary=9, vtAll=10, vtAutoAssembler=11, vtPointer=12, vtCustom=13, vtGrouped=14, vtByteArrays=15, vtCodePageString=16); //all ,grouped and MultiByteArray are special types
-type TPointerType=(ptStatic=1, ptDynamic=2, ptAny=3); // used for pointer variables in group scans
+type TPointerType=(ptStatic=1, ptDynamic=2, ptExecutable=4, ptAny=7); // used for pointer variables in group scans. currently not using this as a bitfield but values selected to make it easy if any future features want to.
 type TCustomScanType=(cstNone, cstAutoAssembler, cstCPP, cstDLLFunction);
 type TFastScanMethod=(fsmNotAligned=0, fsmAligned=1, fsmLastDigits=2);
 

--- a/Cheat Engine/groupscancommandparser.pas
+++ b/Cheat Engine/groupscancommandparser.pas
@@ -9,6 +9,8 @@ This unit contains the class that reads a groupscan command and parses it. The r
 interface
 
 
+
+
 {$ifdef jni}
 uses Classes, SysUtils, strutils, CustomTypeHandler, commonTypeDefs;
 {$else}
@@ -39,7 +41,7 @@ type
       bytesize: integer;
       command: string;
       picked: boolean;
-      pointertype: TPointerType; // for vtPointer this restricts whether the pointer is static, dynamic, or either
+      pointertype: TPointerType; // for vtPointer this restricts whether the pointer is static, dynamic, executable, or any
     end;
 
     blocksize: integer;
@@ -247,6 +249,11 @@ begin
           else if value = 'D' then
           begin
             elements[j].pointertype:=ptDynamic;
+            elements[j].wildcard:=true;
+          end
+          else if value = 'E' then
+          begin
+            elements[j].pointertype:=ptExecutable;
             elements[j].wildcard:=true;
           end
           else


### PR DESCRIPTION
This PR adds additional support for scanning for executable pointers in groupscan, using `P:E` syntax. This finds any pointers that point to memory that is executable, no matter whether it is static or not. Can be useful for finding code pointers in structs, which is very helpful in packed/JIT applications where `P:S` wouldn't get you much mileage due to nothing being associated with image/mapped regions.

To summarise:

- `P:*` finds any valid pointer.
- `P:S` finds any valid pointer to regions that are `MEM_IMAGE` or `MEM_MAPPED` type.
- `P:D` finds any valid pointer to regions that are not `MEM_IMAGE` or `MEM_MAPPED` type.
- `P:E` finds any valid pointer to regions that are executable, regardless of being static/dynamic.

Following on from #1654, there was an errant 'break;' line in the memscan code that initialises the lookup trees, causing one of the lookup tables to not be properly initialised when the first pointer field used S or D pointer types. This was causing an access violation if you tried to groupscan for something like 'P:S P:D', which I didn't catch because my test cases either started with 'P:*' or only had 'P:S' or 'P:D', not both - sorry! This PR fixes that issue too.