### PR TITLE
fix: AppVeyor CI & gtutorial target path

### DIFF
--- a/Cheat Engine/Tutorial/graphical/project1.lpi
+++ b/Cheat Engine/Tutorial/graphical/project1.lpi
@@ -21,7 +21,7 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="gtutorial-$(TargetCPU)"/>
+            <Filename Value="..\..\bin\gtutorial-$(TargetCPU)"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
@@ -53,7 +53,7 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="gtutorial-$(TargetCPU)"/>
+            <Filename Value="..\..\bin\gtutorial-$(TargetCPU)"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
@@ -78,7 +78,7 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="gtutorial-$(TargetCPU)"/>
+            <Filename Value="..\..\bin\gtutorial-$(TargetCPU)"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
@@ -259,7 +259,7 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="gtutorial-$(TargetCPU)"/>
+      <Filename Value="..\..\bin\gtutorial-$(TargetCPU)"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,160 +1,36 @@
-# AppVeyor build configuration
-# https://www.appveyor.com/docs/build-configuration
-# https://www.appveyor.com/docs/appveyor-yml/
-#---------------------------------#
-#      general configuration      #
-#---------------------------------#
+# TODO: replace Dropbox links with more trusted ones (e.g. branch with git-lfs)
+version: "{branch}-{build}"
 
-# CI build version format
-version: 1.0.1.0.0.7.{build}-{branch}
+image: Visual Studio 2019
 
-#---------------------------------#
-#    environment configuration    #
-#---------------------------------#
+# init:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-# Build worker image (VM template)
-image: Visual Studio 2017
-# Enable Windows RDP Client Access to Build Worker
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-#---------------------------------#
-#       build configuration       #
-#---------------------------------#
-
-# add several platforms to build matrix:
-platform:
-  - Win32
-
-# Scripts that run after cloning repository
 install:
-  - cmd: echo Download lazarus-1.6.4-fpc-3.0.2-win32
-  - cmd: curl -fsSL -o lazarus-1.6.4-fpc-3.0.2-win32.exe "https://www.dropbox.com/s/4l1h2ku0srtscfo/lazarus-1.6.4-fpc-3.0.2-win32.exe?dl=1"
-  - cmd: echo Installing lazarus-1.6.4-fpc-3.0.2-win32
-  - cmd: lazarus-1.6.4-fpc-3.0.2-win32.exe /verysilent
-  - cmd: echo Downloading lazarus-1.6.4-fpc-3.0.2-cross-x86_64-win64-win32
-  - cmd: curl -fsSL -o lazarus-1.6.4-fpc-3.0.2-cross-x86_64-win64-win32.exe "https://www.dropbox.com/s/vulmr71jdnokxuj/lazarus-1.6.4-fpc-3.0.2-cross-x86_64-win64-win32.exe?dl=1"
-  - cmd: echo Installing lazarus-1.6.4-fpc-3.0.2-cross-x86_64-win64-win32
-  - cmd: lazarus-1.6.4-fpc-3.0.2-cross-x86_64-win64-win32.exe /verysilent
-  - cmd: echo Downloading lazarus-1.6.4-fpc-3.0.2-cross-arm-wince-win32
-  - cmd: curl -fsSL -o lazarus-1.6.4-fpc-3.0.2-cross-arm-wince-win32.exe "https://www.dropbox.com/s/7vyye0rz6cj1ad0/lazarus-1.6.4-fpc-3.0.2-cross-arm-wince-win32.exe?dl=1"
-  - cmd: echo Installing lazarus-1.6.4-fpc-3.0.2-cross-arm-wince-win32.exe
-  - cmd: lazarus-1.6.4-fpc-3.0.2-cross-arm-wince-win32.exe /verysilent
-  - cmd: rmdir /S /Q c:\lazarus\docs
-  - cmd: rmdir /S /Q c:\lazarus\examples
+  - cmd: |
+      echo Downloading and installing "Lazarus win32"...
+      curl -fsSL -o lazarus-win32.exe "https://www.dropbox.com/s/rydwa7b1vhi3x6a/lazarus-2.0.12-fpc-3.2.0-win32.exe?raw=1"
+      lazarus-win32.exe /verysilent
+      echo Downloading and installing "cross-x86_64-win64" addon...
+      curl -fsSL -o lazarus-cross-x86_64-win64.exe "https://www.dropbox.com/s/bvhpsv7knbrorot/lazarus-2.0.12-fpc-3.2.0-cross-x86_64-win64-win32.exe?raw=1"
+      lazarus-cross-x86_64-win64.exe /verysilent
+      rmdir /S /Q c:\lazarus\docs
+      rmdir /S /Q c:\lazarus\examples
 
-# Build scripts
 build_script:
-  - cmd: for /F "tokens=*" %%i in ('dir /A:-D /B /S "*.lpi"') do ("c:\lazarus\lazbuild" "%%i" --build-all)
+  - ps: .\build_release.ps1
 
-# scripts to run after build
 after_build:
-  # zip the build archive
   - tree /F "Cheat Engine\bin"
-  - 7z a Cheat-Engine-%APPVEYOR_REPO_COMMIT%.zip "Cheat Engine\bin"
+  - 7z a Cheat-Engine-%APPVEYOR_REPO_COMMIT%.zip ".\Cheat Engine\bin\*" -r -x!*.dbg -x!*.o -x!*.a -x!*.ppu -x!*.or -x!*.res
 
-#---------------------------------#
-#       tests configuration       #
-#---------------------------------#
-
-# to disable automatic tests
 test: off
 
-#---------------------------------#
-#      artifacts configuration    #
-#---------------------------------#
-
-#specify artifacts to upload
 artifacts:
   - path: Cheat-Engine-%APPVEYOR_REPO_COMMIT%.zip
     name: Cheat-Engine-%APPVEYOR_REPO_COMMIT%  
 
-#---------------------------------#
-#     deployment configuration    #
-#---------------------------------#
-
-# to disable deployment
 deploy: off
 
-#---------------------------------#
-#        global handlers          #
-#---------------------------------#
-
-# on successful build
-on_success:
-  - ECHO "BUILD VICTORY"
-
-# on build failure
-on_failure:
-  - ECHO "TRY AND TRY AGAIN"
-
-# after build failure or success
-on_finish:
-# Debug with blocked RDP Access
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-# https://www.appveyor.com/docs/environment-variables/
-# Environment variables that are set by AppVeyor for every build:
-# APPVEYOR - True if build runs in AppVeyor environment;
-  - ECHO %APPVEYOR%
-# CI - True if build runs in AppVeyor environment;
-  - ECHO %CI%
-# APPVEYOR_API_URL - AppVeyor Build Agent API URL;
-  - ECHO %APPVEYOR_API_URL%
-# APPVEYOR_ACCOUNT_NAME - account name;
-  - ECHO %APPVEYOR_ACCOUNT_NAME%
-# APPVEYOR_PROJECT_ID - AppVeyor unique project ID;
-  - ECHO %APPVEYOR_PROJECT_ID%
-# APPVEYOR_PROJECT_NAME - project name;
-  - ECHO %APPVEYOR_PROJECT_NAME%
-# APPVEYOR_PROJECT_SLUG - project slug (as seen in project details URL);
-  - ECHO %APPVEYOR_PROJECT_SLUG%
-# APPVEYOR_BUILD_FOLDER - path to clone directory;
-  - ECHO %APPVEYOR_BUILD_FOLDER%
-# APPVEYOR_BUILD_ID - AppVeyor unique build ID;
-  - ECHO %APPVEYOR_BUILD_ID%
-# APPVEYOR_BUILD_NUMBER - build number;
-  - ECHO %APPVEYOR_BUILD_NUMBER%
-# APPVEYOR_BUILD_VERSION - build version;
-  - ECHO %APPVEYOR_BUILD_VERSION%
-# APPVEYOR_PULL_REQUEST_NUMBER - GitHub Pull Request number;
-  - ECHO %APPVEYOR_PULL_REQUEST_NUMBER%
-# APPVEYOR_PULL_REQUEST_TITLE - GitHub Pull Request title
-  - ECHO %APPVEYOR_PULL_REQUEST_TITLE%
-# APPVEYOR_JOB_ID - AppVeyor unique job ID;
-  - ECHO %APPVEYOR_JOB_ID%
-# APPVEYOR_JOB_NAME - job name;
-  - ECHO %APPVEYOR_JOB_NAME%
-# APPVEYOR_REPO_PROVIDER - github, bitbucket, kiln, vso or gitlab;
-  - ECHO %APPVEYOR_REPO_PROVIDER%
-# APPVEYOR_REPO_SCM - git or mercurial;
-  - ECHO %APPVEYOR_REPO_SCM%
-# APPVEYOR_REPO_NAME - repository name in format owner-name/repo-name;
-  - ECHO %APPVEYOR_REPO_NAME%
-# APPVEYOR_REPO_BRANCH - build branch. For Pull Request commits it is base branch PR is merging into;
-  - ECHO %APPVEYOR_REPO_BRANCH%
-# APPVEYOR_REPO_TAG - true if build has started by pushed tag; otherwise false;
-  - ECHO %APPVEYOR_REPO_TAG%
-# APPVEYOR_REPO_TAG_NAME - contains tag name for builds started by tag; otherwise this variable is undefined;
-  - ECHO %APPVEYOR_REPO_TAG_NAME%
-# APPVEYOR_REPO_COMMIT - commit ID (SHA);
-  - ECHO %APPVEYOR_REPO_COMMIT%
-# APPVEYOR_REPO_COMMIT_AUTHOR - commit author’s name;
-  - ECHO %APPVEYOR_REPO_COMMIT_AUTHOR%
-# APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL - commit author’s email address;
-  - ECHO %APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%
-# APPVEYOR_REPO_COMMIT_TIMESTAMP - commit date/time;
-  - ECHO %APPVEYOR_REPO_COMMIT_TIMESTAMP%
-# APPVEYOR_REPO_COMMIT_MESSAGE - commit message;
-  - ECHO %APPVEYOR_REPO_COMMIT_MESSAGE%
-# APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED - the rest of commit message after line break (if exists);
-  - ECHO %APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED%
-# APPVEYOR_SCHEDULED_BUILD - True if the build runs by scheduler;
-  - ECHO %APPVEYOR_SCHEDULED_BUILD%
-# APPVEYOR_FORCED_BUILD (True or undefined) - builds started by “New build” button or from the same API;
-  - ECHO %APPVEYOR_FORCED_BUILD%
-# APPVEYOR_RE_BUILD (True or undefined) - build started by “Re-build commit/PR” button of from the same API;
-  - ECHO %APPVEYOR_RE_BUILD%
-# PLATFORM - platform name set on Build tab of project settings (or through platform parameter in appveyor.yml);
-  - ECHO %PLATFORM%
-# CONFIGURATION - configuration name set on Build tab of project settings (or through configuration parameter in appveyor.yml);
-  - ECHO %CONFIGURATION%
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/build_release.ps1
+++ b/build_release.ps1
@@ -1,0 +1,47 @@
+$cePath = "C:\projects\cheat-engine\Cheat Engine\"
+
+$projects = @()
+$projects += ,@("cecore.lpi", "Default", "", "")
+$projects += ,@("cheatengine.lpi", "Release 32-Bit", "Release 64-Bit", "Release 64-Bit O4 AVX2")
+$projects += ,@("allochook\allochook.lpi", "64", "32", "")
+$projects += ,@("ceregreset\ceregreset.lpi", "Release", "", "")
+$projects += ,@("dbk32\Kernelmodule unloader\Kernelmoduleunloader.lpi", "default", "", "")
+$projects += ,@("debuggertest\debuggertest.lpi", "default", "", "")
+$projects += ,@("launcher\cheatengine.lpi", "release", "", "")
+$projects += ,@("luaclient\luaclient.lpi", "Release 32", "Release 64", "")
+$projects += ,@("luaclient\testapp\luaclienttest.lpi", "Release", "", "")
+$projects += ,@("plugin\DebugEventLog\src\DebugEventLog.lpi", "Default", "", "")
+$projects += ,@("plugin\example\exampleplugin.lpi", "Default", "", "")
+$projects += ,@("plugin\forcedinjection\forcedinjection.lpi", "release", "Release 64-bit", "")
+$projects += ,@("sfx\level2\standalonephase2.lpi", "Release", "", "")
+$projects += ,@("speedhack\speedhack.lpi", "32-bit", "64-bit", "")
+$projects += ,@("speedhack\speedhacktest\speedhacktest.lpi", "default", "", "")
+$projects += ,@("Tutorial\tutorial.lpi", "release 32-bit", "release 64-bit", "")
+$projects += ,@("Tutorial\graphical\project1.lpi", "Release 32", "Release 64", "")
+$projects += ,@("VEHDebug\vehdebug.lpi", "release 64", "release 32", "")
+$projects += ,@("windowsrepair\windowsrepair.lpi", "Release", "", "")
+$projects += ,@("winhook\winhook.lpi", "Release 32", "Release 64", "")
+$projects += ,@("xmplayer\xmplayer.lpi", "Default", "", "")
+
+echo "Projects to build:"
+for ($x = 0; $x -lt 21; $x++)
+{
+	$file = $projects[$x][0]
+	$path = "$cePath$file"
+	echo $path
+}
+
+for ($x = 0; $x -lt 21; $x++)
+{
+	$file = $projects[$x][0]
+	for ($y = 1; $y -lt 4; $y++)
+	{
+		if ($projects[$x][$y] -ne "")
+		{
+			$buildMode = $projects[$x][$y]
+			$path = "$cePath$file"
+			echo "--- BUILDING $file IN BUILD MODE: $buildMode ---"
+			c:\lazarus\lazbuild $path --build-all --build-mode="$buildMode"
+		}
+	}
+}


### PR DESCRIPTION
Changes:

- Fixed AppVeyor CI. Cheat Engine now builds successfully on AppVeyor.
- Changed target path of gtutorial project (it now builds on `bin` folder).

Currently the needed files for build (lazarus and cross-compiler addon) are fetched from my dropbox, this is not the best method to download the [binaries](https://sourceforge.net/projects/lazarus/files/Lazarus%20Windows%2032%20bits/Lazarus%202.0.12/) and it should be replaced. Maybe Git LFS or something similar.

Also I know the `build_release.ps1` it's a bit crap, but it's needed to parse all distinct build modes to the projects.

Demo AppVeyor build: https://ci.appveyor.com/project/n0bodysec/cheat-engine/builds/39792450 ([download logs](https://ci.appveyor.com/api/buildjobs/7a1w88gp4usnm2ih/log))
Artifacts (they will last one month from now): https://ci.appveyor.com/project/n0bodysec/cheat-engine/builds/39792450/artifacts