### PR TITLE
Fix loadTable causing access violation.

### DIFF
--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -1432,19 +1432,21 @@ begin
         ActivateSelected;}
 
     end;
-
-    if TMemoryRecord(node.data).Active then
-    begin
-      //arrow spot is clicked
-      //nothing->increased->decreased->nothing->...
-      if inrange(x, checkboxend+1, checkboxend+9) then
+    
+    if node.data <> nil then
+      if TMemoryRecord(node.data).Active then
       begin
-        if TMemoryRecord(node.data).allowIncrease then TMemoryRecord(node.data).allowDecrease:=true
-        else
-        if TMemoryRecord(node.data).allowDecrease then TMemoryRecord(node.data).allowDecrease:=false
-        else
-          TMemoryRecord(node.data).allowIncrease:=true
+        //arrow spot is clicked
+        //nothing->increased->decreased->nothing->...
+        if inrange(x, checkboxend+1, checkboxend+9) then
+        begin
+          if TMemoryRecord(node.data).allowIncrease then TMemoryRecord(node.data).allowDecrease:=true
+          else
+          if TMemoryRecord(node.data).allowDecrease then TMemoryRecord(node.data).allowDecrease:=false
+          else
+            TMemoryRecord(node.data).allowIncrease:=true
 
+        end;
       end;
     end;
 


### PR DESCRIPTION
When executing loadTable() from lua script in a memory record without merging, an Access violation happens because the script is activated (and apparently executed) in the middle of the TAddresslist.TreeviewMouseDown event handler. When a loading new table without merging happens the table data is cleared and this happens in the middle of a function. When TAddresslist.TreeviewMouseDown tries to finish running the data is gone and an access violation happens when trying to use a dangling pointer. Added a check to see if the data is still there.