### PR TITLE
Fixed:Unable to write assembly code to 64bit address when using binutils

### DIFF
--- a/Cheat Engine/gnuassembler.pas
+++ b/Cheat Engine/gnuassembler.pas
@@ -386,7 +386,7 @@ begin
                   sections[j].name:='_'+p1;
 
                   try
-                    sections[j].address:=strtoint(p2)
+                    sections[j].address:=StrToQWord(p2)
                   except
                     sections[j].address:=symhandler.getAddressFromName(p2);
                   end;


### PR DESCRIPTION
![img](https://user-images.githubusercontent.com/56913432/128949392-a317f242-0ab2-4610-9adc-022395346dce.png)

Currently, when using binutils, assembly code cannot be written directly to 64-bit memory address.
The image shows the address just before writing.
As you can see in the image, the upper 4 bytes of the address are dropped out and written.
After changing strtoint to StrToQWord, the assembly code can now be written normally.