### PR TITLE
Remember hex choice for AOB

### DIFF
--- a/Cheat Engine/formAddressChangeUnit.pas
+++ b/Cheat Engine/formAddressChangeUnit.pas
@@ -1574,6 +1574,7 @@ begin
      or (fMemoryRecord.vartype = vtQword)
      or (fMemoryRecord.vartype = vtSingle)
      or (fMemoryRecord.vartype = vtDouble)
+     or (fMemoryRecord.vartype = vtByteArray)
      then
   begin
     cbHex.checked:=fMemoryRecord.ShowAsHex;


### PR DESCRIPTION
Problem:When  double-clicking the address field in the addresslist, it always unchecks the show as hexidecimal(for AOB data type).
This fixes that