### PR TITLE
Update DBKKernel.vcxproj

### DIFF
--- a/DBKKernel/DBKKernel.vcxproj
+++ b/DBKKernel/DBKKernel.vcxproj
@@ -276,15 +276,6 @@ makecab /f "$(ProjectDir)\dbk64.ddf"
       <AdditionalDependencies>$(DDK_LIB_PATH)Ntstrsafe.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/INTEGRITYCHECK %(AdditionalOptions)</AdditionalOptions>
     </Link>
-    <DriverSign>
-      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
-    </DriverSign>
-    <PostBuildEvent>
-      <Command>"$(WDKBinRoot_x64)\signtool.exe" sign /a /ac "$(TargetDir)..\release\sig\GlobalSign Root CA.crt" /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 "$(TargetPath)"</Command>
-    </PostBuildEvent>
-    <PostBuildEvent>
-      <Message>Sign the CE driver</Message>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>


### PR DESCRIPTION
Remove signature option from 'Release without sig|x64' introduced by commit 0fe89e725f06faea0d8f3bdfe5c9894cd9d1a5a1