### PR TITLE
Fix mono lookup for .ctor methodnames

### DIFF
--- a/Cheat Engine/bin/autorun/monoscript.lua
+++ b/Cheat Engine/bin/autorun/monoscript.lua
@@ -822,7 +822,7 @@ function mono_symbolLookupCallback(symbol)
   local namespace=''
 
   if (#parts>0) then
-    methodname=parts[#parts]
+    methodname=(symbol:find("[:.]%.cc?tor$") ~= nil and '.' or '')..parts[#parts]
     if (#parts>1) then
       classname=parts[#parts-1]
       if (#parts>2) then


### PR DESCRIPTION
Fixes https://github.com/cheat-engine/cheat-engine/issues/1887
after change 22b1dcb19636a5e03da25626ddd3fbecc184d5a7