### PR TITLE
Fixed resize issue when opening address list edit

### DIFF
--- a/Cheat Engine/formAddressChangeUnit.pas
+++ b/Cheat Engine/formAddressChangeUnit.pas
@@ -123,7 +123,7 @@ type
     property offset[Index: Integer]: TOffsetInfo read getOffset;
 
     procedure processAddress; //reads the base address and all the offsets and shows what it all does
-    procedure setupPositionsAndSizes;
+    procedure setupPositionsAndSizes(const updateClientSize: boolean = True);
 
     procedure addOffsetAroundSelectedOffset(const addAbove: boolean; const selectedOffset: TOffsetInfo);
     procedure appendOffset(newOffset: TOffsetInfo);
@@ -888,7 +888,7 @@ begin
 end;
 
 
-procedure TPointerInfo.setupPositionsAndSizes;
+procedure TPointerInfo.setupPositionsAndSizes(const updateClientSize: boolean = True);
 var
   i: integer;
 begin
@@ -900,7 +900,10 @@ begin
 
   processAddress;
 
-  ClientHeight:=btnAddOffset.Top+btnAddOffset.Height+3;       //triggers onresize
+  if updateClientSize then
+  begin
+    ClientHeight:=btnAddOffset.Top+btnAddOffset.Height+3;       //triggers onresize
+  end
   //Width will be set using the UpdateLabels method of individial offsets when the current offset is too small
 
 
@@ -1149,8 +1152,7 @@ begin
   baseAddress.AnchorSideRight.side:=asrRight;
   baseAddress.Anchors:=[akLeft, akTop, akRight];
 
-
-  setupPositionsAndSizes;
+  setupPositionsAndSizes(False); // Update sizes but not ClientSize, it will mess up when form is not fully initialized
 end;
 
 {%endregion TPointerInfo }


### PR DESCRIPTION
Removed ClientSize update in constructor of offset change form because it sets the offset inputs like a small size window

Steps to reproduce:
1. Create manual address and check "pointer" checkbox. Close window.
2. Double click new memory record "address" column in address list. Notice the wrong input sizes for the pointer offset fields.

Before:
![image](https://user-images.githubusercontent.com/1107063/151720166-42d521ff-567d-41df-a575-51be25383fc3.png)

After:
![image](https://user-images.githubusercontent.com/1107063/151720199-77013ff5-a1b1-4823-80f4-3d50e9f9aabf.png)
