### PR TITLE
Change type-multiple memrec-apply show as hex to all

### DIFF
--- a/Cheat Engine/addresslist.pas
+++ b/Cheat Engine/addresslist.pas
@@ -1126,6 +1126,7 @@ begin
       MemRecItems[i].VarType:=newtype;
       MemRecItems[i].Extra:=extra;
       MemRecItems[i].CustomTypeName:=customtypename;
+      MemRecItems[i].ShowAsHex:= memrec.ShowAsHex; 
 
       MemRecItems[i].treenode.update;
     end;


### PR DESCRIPTION
Bug:When changing memory record type, checking the "Hexadecimal" box only applies it to the last highlighted memrec.