### PR TITLE
lua_allocateMemory force PAGE_EXECUTE_READWRITE as protection.

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -13820,12 +13820,12 @@ begin
       prot:=PAGE_EXECUTE_READWRITE;
 
 
-    a:=VirtualAllocEx(processhandle,base,size,MEM_COMMIT or MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    a:=VirtualAllocEx(processhandle,base,size,MEM_COMMIT or MEM_RESERVE, prot);
     if a=nil then
     begin
       //try to fix a mistake
       base:=FindFreeBlockForRegion(ptruint(base),size);
-      a:=VirtualAllocEx(processhandle,base,size,MEM_COMMIT or MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+      a:=VirtualAllocEx(processhandle,base,size,MEM_COMMIT or MEM_RESERVE, prot);
       if a=nil then exit(0);
     end;
 


### PR DESCRIPTION
lua_allocateMemory don't respect protection parameter. It's just forcing PAGE_EXECUTE_READWRITE as protection parameter.