### PR TITLE
OnlyWhileDown attribute check

### DIFF
--- a/Cheat Engine/MemoryRecordUnit.pas
+++ b/Cheat Engine/MemoryRecordUnit.pas
@@ -1574,7 +1574,7 @@ begin
 
         if tempnode.ChildNodes[i].NodeName='Hotkey' then
         begin
-          a:=tempnode.Attributes.GetNamedItem('OnlyWhileDown');
+          a:=tempnode.ChildNodes[i].Attributes.GetNamedItem('OnlyWhileDown');
           if (a<>nil) then
             hk.OnlyWhileDown:=a.TextContent='1';
 


### PR DESCRIPTION
OnlyWhileDown attribute check does so on parent ('Hotkeys') node instead of child ('Hotkeys') node causing loaded tables not to enable restore on release. Move check to child node