### PR TITLE
Fix lua string.split

### DIFF
--- a/Cheat Engine/LuaHandler.pas
+++ b/Cheat Engine/LuaHandler.pas
@@ -14824,6 +14824,7 @@ var
   s: string;
   sep: string;
 
+  bStackSpace: boolean;
   arr: TStringDynArray;
   i: integer;
 begin
@@ -14834,11 +14835,13 @@ begin
     sep:=Lua_ToString(L,2);
 
     arr:=SplitString(s,sep);
+    if lua_checkstack(L, length(arr)) then
+    begin
+      for i:=0 to length(arr)-1 do
+          lua_pushstring(L, arr[i]);
+      result:=length(arr);
+    end;
 
-    for i:=0 to length(arr)-1 do
-      lua_pushstring(L, arr[i]);
-
-    result:=length(arr);
   end;
 end;
 


### PR DESCRIPTION
Problem:
If the SplitString has too many results CE will crash
(example)
```lua
str = ""
for i=1,550 do
str = str..i.."\n"
end

lines = {str:split("\n")}
return lines
```

Fix:
Perform a lua_checkstack before the pushes to the stack
