### PR TITLE
Fixed typo in injection script for x64 apps

### DIFF
--- a/Cheat Engine/bin/autorun/java.lua
+++ b/Cheat Engine/bin/autorun/java.lua
@@ -394,11 +394,11 @@ function javaInjectAgent()
         mov r8,arg1
         mov r9,arg2
 
-        mov [rsp],cmd
-        mov [rsp+8],arg0
-        mov [rsp+10],arg1
-        mov [rsp+18],arg2
-        mov [rsp+20],pipename
+        mov [rsp],rcx
+        mov [rsp+8],rdx
+        mov [rsp+10],r8
+        mov [rsp+18],r9
+        mov [rsp+20],rax 
 
         call jvm.JVM_EnqueueOperation
         mov [result],eax


### PR DESCRIPTION
Problem:
Injecting a Java agent into x64 applications causes the application to throw an access violation error
Reason:
Typo in the code:
```asm
mov rcx,cmd			;saving address to rcx
mov rdx,arg0
mov r8,arg1
mov r9,arg2
               
mov [rsp],cmd			;but don't using it
mov [rsp+8],arg0
mov [rsp+10],arg1
mov [rsp+18],arg2
mov [rsp+20],pipename
```
Authors:
Solved by Dark Byte in this thread: https://forum.cheatengine.org/viewtopic.php?t=619851