### PR TITLE
Allow for scans of large memory regions (>0xFFFFFFFF bytes)

### DIFF
--- a/Cheat Engine/memscan.pas
+++ b/Cheat Engine/memscan.pas
@@ -6594,7 +6594,7 @@ var
   i,j: integer;
   totalProcessMemorySize: qword;
   blocksize: dword;
-  leftfromprevious: dword;
+  leftfromprevious: qword;
   offsetincurrentregion: PtrUint;
   
   currentblocksize: qword;
@@ -6846,7 +6846,7 @@ var
   Blocksize: qword;
   currentblocksize: qword;
   totalProcessMemorySize: qword;
-  leftfromprevious: dword;
+  leftfromprevious: qword;
   offsetincurrentregion: qword;
 
   isWritable, isExecutable, isCopyOnWrite{$ifdef darwin}, isDirty{$endif}: boolean;


### PR DESCRIPTION
As documented here https://www.youtube.com/watch?v=FiMv3OPoLXw by Chris Fayte, Cheat engine fails to find values in this game unless using the CE Kernel routines. The "query memory region routines" in particular. The reason seems to be that the region containing the values being searched for is reported by VirtualQueryEx as 0x180001000 in size.  When using the kernel routines the size is smaller (~0x7000000).  _leftfromprevious_ is declared as a dword and with a blocksize low enough to have a value over 0xFFFFFFFF left from the region size after subtracting the first group of blocks, the math is off and a large portion of the end of the memory region is skipped.