### PR TITLE
Fixing "application_minimize" function

### DIFF
--- a/Cheat Engine/luaapplication.pas
+++ b/Cheat Engine/luaapplication.pas
@@ -34,8 +34,12 @@ begin
 end;
 
 function application_minimize(L: PLua_State): integer; cdecl;
+var
+  activeWindow: TForm;
 begin
-  TApplication(luaclass_getClassObject(L)).Minimize;
+  activeWindow := Screen.ActiveForm;
+  if Assigned(activeWindow) then
+    activeWindow.WindowState := wsMinimized;
   result:=0;
 end;
 


### PR DESCRIPTION
If you minimize the Main Cheat Engine Window, all other windows gets minimized as well, and I think it could be a bit annoying.