### PR TITLE
Added a few new functions and fixed some stuff in the data collector and the form

### DIFF
--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
@@ -1834,7 +1834,7 @@ void CPipeServer::GetTypeOfMonoType()
 void CPipeServer::GetReflectionTypeOfClassType()
 {
 	void* type = (void*)ReadQword(); //MonoType*
-	WriteDword((UINT64)mono_type_get_object(type)); //ReflectionType*
+	WriteQword((UINT64)mono_type_get_object(type)); //ReflectionType*
 }
 
 
@@ -2328,6 +2328,12 @@ void CPipeServer::InvokeMethod(void)
 	{
 		MonoObject* exception = {};
 		result = mono_runtime_invoke(method, pThis, arry, &exception);
+		if (!result)
+		{
+			WriteByte(MONO_TYPE_VOID);
+			WriteQword((UINT64)result);
+			return;
+		}
 		void* klass = mono_object_get_class(result);
 		void* type = klass ? mono_class_get_type(klass) : NULL;
 		int returntype = type ? mono_type_get_type(type) : MONO_TYPE_VOID;

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
@@ -56,7 +56,7 @@ void ErrorThrow(void)
 
 
 int looper = 0;
-LONG NTAPI ErrorFilter(struct _EXCEPTION_POINTERS *ExceptionInfo)
+LONG NTAPI ErrorFilter(struct _EXCEPTION_POINTERS* ExceptionInfo)
 {
 	if ((ExpectingAccessViolations) && (GetCurrentThreadId() == ExpectingAccessViolationsThread) && (ExceptionInfo->ExceptionRecord->ExceptionCode == 0xc0000005))
 	{
@@ -81,49 +81,49 @@ uint64_t ErrorRBP;
 uint64_t ErrorRSP;
 
 
-void ErrorFilter(int signr, siginfo_t *info, void *uap)
+void ErrorFilter(int signr, siginfo_t* info, void* uap)
 {
-    char s[200];
-    snprintf(s,200, "Errorfilter %d", signr);
-    OutputDebugString(s);
-    ucontext_t *uap_c=(ucontext_t *)uap;
-    //check if it's the serverthread, and if so, change the instruction pointer to ErrorThrow
-    uint64_t tid;
+	char s[200];
+	snprintf(s, 200, "Errorfilter %d", signr);
+	OutputDebugString(s);
+	ucontext_t* uap_c = (ucontext_t*)uap;
+	//check if it's the serverthread, and if so, change the instruction pointer to ErrorThrow
+	uint64_t tid;
 
 #ifdef __APPLE__
-    pthread_threadid_np(NULL, &tid);
+	pthread_threadid_np(NULL, &tid);
 #else
-    tid=(uint64_t)gettid();
+	tid = (uint64_t)gettid();
 #endif
-    
-    if ((ExpectingAccessViolations) && (tid==ExpectingAccessViolationsThread))
-    {
-        OutputDebugString("It is this thread. Jumping to state saved in onError");
-        
-        longjmp(onError,1);
-        
-    }
-    else
-    {
-         OutputDebugString("calling original handler");
-    
-        if (old_sa[signr].sa_flags & SA_SIGINFO)
-            old_sa[signr].sa_sigaction(signr, info, uap);
-        else
-            old_sa[signr].sa_handler(signr);
-    }
+
+	if ((ExpectingAccessViolations) && (tid == ExpectingAccessViolationsThread))
+	{
+		OutputDebugString("It is this thread. Jumping to state saved in onError");
+
+		longjmp(onError, 1);
+
+	}
+	else
+	{
+		OutputDebugString("calling original handler");
+
+		if (old_sa[signr].sa_flags & SA_SIGINFO)
+			old_sa[signr].sa_sigaction(signr, info, uap);
+		else
+			old_sa[signr].sa_handler(signr);
+	}
 }
 #endif
 
 
 CPipeServer::CPipeServer(void)
-{  
-  attached = FALSE;
-  limitedConnection = FALSE;
-  il2cpp = FALSE;
-  UWPMode = FALSE;
-  mono_selfthread = NULL;
-  mono_runtime_is_shutting_down = NULL;
+{
+	attached = FALSE;
+	limitedConnection = FALSE;
+	il2cpp = FALSE;
+	UWPMode = FALSE;
+	mono_selfthread = NULL;
+	mono_runtime_is_shutting_down = NULL;
 
 
 
@@ -133,19 +133,19 @@ CPipeServer::CPipeServer(void)
 
 	AddVectoredExceptionHandler(1, ErrorFilter);
 #else
-    sprintf((char*)datapipename, "cemonodc_pid%d",GetCurrentProcessId());
-    
-    int i;
-    for (i=10; i<12; i++)
-    {
-        new_sa[i].sa_sigaction=ErrorFilter;
-        new_sa[i].sa_flags=SA_SIGINFO;
-        sigemptyset(&new_sa[i].sa_mask);
-         
-        //sigaction(10, &new_sa, &old_sa);
-        sigaction(i, &new_sa[i], &old_sa[i]);
-    }
-    
+	sprintf((char*)datapipename, "cemonodc_pid%d", GetCurrentProcessId());
+
+	int i;
+	for (i = 10; i < 12; i++)
+	{
+		new_sa[i].sa_sigaction = ErrorFilter;
+		new_sa[i].sa_flags = SA_SIGINFO;
+		sigemptyset(&new_sa[i].sa_mask);
+
+		//sigaction(10, &new_sa, &old_sa);
+		sigaction(i, &new_sa[i], &old_sa[i]);
+	}
+
 #endif
 }
 
@@ -161,7 +161,7 @@ CPipeServer::~CPipeServer(void)
 char* CPipeServer::ReadString(void)
 {
 	WORD length = ReadWord();
-	char *result = (char *)malloc(length + 1);
+	char* result = (char*)malloc(length + 1);
 	if (length)
 		Read(result, length);
 	result[length] = 0;
@@ -252,7 +252,7 @@ void CPipeServer::CreatePipeandWaitForconnect(void)
 
 		pipehandle = MDC_ServerPipe;
 		MDC_ServerPipe = 0; //indicates that it got read out
-		
+
 		//OutputDebugStringA("Retrieved a pipe\n");
 		//OutputDebugStringA("calling ConnectNamedPipe\n");
 
@@ -271,14 +271,14 @@ void CPipeServer::CreatePipeandWaitForconnect(void)
 			}
 		}
 	}
-	
+
 #else
-    if ((pipehandle) && (pipehandle != INVALID_HANDLE_VALUE))
-        ClosePipe(pipehandle);
-    
-    pipehandle = INVALID_HANDLE_VALUE;
-    while (pipehandle==INVALID_HANDLE_VALUE)
-      pipehandle = ::CreateNamedPipe((char*)datapipename);
+	if ((pipehandle) && (pipehandle != INVALID_HANDLE_VALUE))
+		ClosePipe(pipehandle);
+
+	pipehandle = INVALID_HANDLE_VALUE;
+	while (pipehandle == INVALID_HANDLE_VALUE)
+		pipehandle = ::CreateNamedPipe((char*)datapipename);
 #endif
 
 	//OutputDebugStringA("At the end of CreatePipeandWaitForconnect\n");
@@ -287,44 +287,44 @@ void CPipeServer::CreatePipeandWaitForconnect(void)
 
 void __cdecl customfreeimplementation(PVOID address)
 {
-//	free(address);
-	//freaking memleak !!!!!
+	//	free(address);
+		//freaking memleak !!!!!
 }
 
 #if defined __linux__ || defined __ANDROID__
-char *findModulePath(char *modulename)
+char* findModulePath(char* modulename)
 {
-  //On android I could use /proc/self/filemap_list but it's not a thing on linux, so...
-  //read out /proc/self/maps
-  char *result=NULL;
-  FILE *f=NULL;
-  OutputDebugString("findModulePath(\"%s\")",modulename);
-  f=fopen("/proc/self/maps", "r");
-  if (f)
-  {
-    char s[512];
-    while (fgets(s, 511, f))
-    {
-      if (strstr(s,modulename))
-      {
-        char modulepath[256];
-        modulepath[0]='\0';
+	//On android I could use /proc/self/filemap_list but it's not a thing on linux, so...
+	//read out /proc/self/maps
+	char* result = NULL;
+	FILE* f = NULL;
+	OutputDebugString("findModulePath(\"%s\")", modulename);
+	f = fopen("/proc/self/maps", "r");
+	if (f)
+	{
+		char s[512];
+		while (fgets(s, 511, f))
+		{
+			if (strstr(s, modulename))
+			{
+				char modulepath[256];
+				modulepath[0] = '\0';
 
-        OutputDebugString("found libmono: %s\n", s);
-        //here I can choose between parsing the string, for the path, or look up the address range in /proc/self/map_files
-        //we've got the string anyhow, so...
-        sscanf(s, "%*llx-%*llx %*s %*s %*s %*s %[^\t\n]\n", modulepath);
+				OutputDebugString("found libmono: %s\n", s);
+				//here I can choose between parsing the string, for the path, or look up the address range in /proc/self/map_files
+				//we've got the string anyhow, so...
+				sscanf(s, "%*llx-%*llx %*s %*s %*s %*s %[^\t\n]\n", modulepath);
 
-        OutputDebugString("modulepath=%s\n",modulepath);
+				OutputDebugString("modulepath=%s\n", modulepath);
 
-        result=strdup(modulepath);
-        break;
-      }
-    }
-    fclose(f);
-  }
+				result = strdup(modulepath);
+				break;
+			}
+		}
+		fclose(f);
+	}
 
-  return result;
+	return result;
 }
 #endif
 
@@ -332,59 +332,59 @@ char *findModulePath(char *modulename)
 void CPipeServer::InitMono()
 {
 
-    
-	  OutputDebugStringA((char *)"CPipeServer::InitMono");
-    il2cpp = FALSE;
+
+	OutputDebugStringA((char*)"CPipeServer::InitMono");
+	il2cpp = FALSE;
 
 #ifndef _WINDOWS
-    void *hMono=NULL;
-    int hasRealMonoHandle=0;
-	  OutputDebugStringA((char*)"InitMono on non windows");
-    void *fp=dlsym(RTLD_DEFAULT, "mono_thread_attach");
-    OutputDebugStringA("dlsym(RTLD_DEFAULT, \"mono_thread_attach\") returned %p\n", fp);
+	void* hMono = NULL;
+	int hasRealMonoHandle = 0;
+	OutputDebugStringA((char*)"InitMono on non windows");
+	void* fp = dlsym(RTLD_DEFAULT, "mono_thread_attach");
+	OutputDebugStringA("dlsym(RTLD_DEFAULT, \"mono_thread_attach\") returned %p\n", fp);
 
-    if (fp)
-    {
-      hMono=fp;
-    }
-    else
-    {
-      OutputDebugString("dlerror()=%s\n", dlerror);
+	if (fp)
+	{
+		hMono = fp;
+	}
+	else
+	{
+		OutputDebugString("dlerror()=%s\n", dlerror);
 
-        fp=dlsym(RTLD_DEFAULT, "il2cpp_thread_attach");
-        OutputDebugStringA("dlsym(RTLD_DEFAULT, \"il2cpp_thread_attach\") returned %p\n", fp);
+		fp = dlsym(RTLD_DEFAULT, "il2cpp_thread_attach");
+		OutputDebugStringA("dlsym(RTLD_DEFAULT, \"il2cpp_thread_attach\") returned %p\n", fp);
 
-        if (fp)
-        {
-            il2cpp = TRUE;
-            hMono=fp;
-        }
-    }
+		if (fp)
+		{
+			il2cpp = TRUE;
+			hMono = fp;
+		}
+	}
 
 #if defined __linux__ || defined __ANDROID__
-    if (fp==NULL)
-    {
-      //find the path to libmono.so and load that
-      char *path=findModulePath((char*)"libmono.so");
-      if (path)
-      {
-        OutputDebugString("calling dlopen on %s\n", path);
-        hMono=dlopen(path,RTLD_NOW);
-        OutputDebugString("hMono is now %p\n", hMono);
+	if (fp == NULL)
+	{
+		//find the path to libmono.so and load that
+		char* path = findModulePath((char*)"libmono.so");
+		if (path)
+		{
+			OutputDebugString("calling dlopen on %s\n", path);
+			hMono = dlopen(path, RTLD_NOW);
+			OutputDebugString("hMono is now %p\n", hMono);
 
-        if (hMono)
-          hasRealMonoHandle=1;
+			if (hMono)
+				hasRealMonoHandle = 1;
 
-        free(path);
-      }
-    }
+			free(path);
+		}
+	}
 #endif
 #endif
-    
+
 #ifdef _WINDOWS
 	HMODULE hMono = GetModuleHandleA("mono.dll");
-	
-		
+
+
 
 	if (!hMono)
 	{
@@ -400,24 +400,24 @@ void CPipeServer::InitMono()
 				do
 				{
 					if (GetProcAddress(me.hModule, "mono_thread_attach"))
-						hMono = me.hModule;							
+						hMono = me.hModule;
 
 					if (GetProcAddress(me.hModule, "il2cpp_thread_attach"))
 					{
 						il2cpp = true;
 						hMono = me.hModule;
 					}
-						
+
 				} while (!hMono && Module32Next(ths, &me));
 
 			}
 			CloseHandle(ths);
 		}
 	}
-    #endif //WINDOWS
+#endif //WINDOWS
 
 	WriteQword((UINT64)hMono);
-    
+
 	if (hMono)
 	{
 		std::stringstream x;
@@ -425,12 +425,12 @@ void CPipeServer::InitMono()
 		x << "Mono dll found at " << std::hex << hMono << "\n";
 		//OutputDebugStringA(x.str().c_str());
 
-    #ifndef _WINDOWS
-		if (hasRealMonoHandle==0)
-		  hMono=RTLD_DEFAULT;
-    #endif
-        
-        
+#ifndef _WINDOWS
+		if (hasRealMonoHandle == 0)
+			hMono = RTLD_DEFAULT;
+#endif
+
+
 		if (attached == FALSE)
 		{
 
@@ -483,6 +483,9 @@ void CPipeServer::InitMono()
 				mono_class_get_image = (MONO_CLASS_GET_IMAGE)GetProcAddress(hMono, "il2cpp_class_get_image");
 
 				mono_class_is_generic = (MONO_CLASS_IS_GENERIC)GetProcAddress(hMono, "il2cpp_class_is_generic");
+				mono_class_is_enum = (MONO_CLASS_IS_ENUM)GetProcAddress(hMono, "il2cpp_class_is_enum");
+				mono_class_is_valuetype = (MONO_CLASS_IS_VALUETYPE)GetProcAddress(hMono, "il2cpp_class_is_valuetype");
+				mono_class_is_subclass_of = (MONO_CLASS_IS_SUBCLASS_OF)GetProcAddress(hMono, "il2cpp_class_is_subclass_of");
 				mono_class_vtable = (MONO_CLASS_VTABLE)GetProcAddress(hMono, "il2cpp_class_vtable");
 				mono_class_from_mono_type = (MONO_CLASS_FROM_MONO_TYPE)GetProcAddress(hMono, "il2cpp_class_from_mono_type");
 				mono_class_get_element_class = (MONO_CLASS_GET_ELEMENT_CLASS)GetProcAddress(hMono, "il2cpp_class_get_element_class");
@@ -497,6 +500,7 @@ void CPipeServer::InitMono()
 				mono_field_get_parent = (MONO_FIELD_GET_PARENT)GetProcAddress(hMono, "il2cpp_field_get_parent");
 				mono_field_get_offset = (MONO_FIELD_GET_OFFSET)GetProcAddress(hMono, "il2cpp_field_get_offset");
 				mono_field_get_flags = (MONO_FIELD_GET_FLAGS)GetProcAddress(hMono, "il2cpp_field_get_flags");
+				mono_field_get_value_object = (MONO_FIELD_GET_VALUE_OBJECT)GetProcAddress(hMono, "il2cpp_field_get_value_object");
 
 				mono_type_get_name = (MONO_TYPE_GET_NAME)GetProcAddress(hMono, "il2cpp_type_get_name");
 				mono_type_get_type = (MONO_TYPE_GET_TYPE)GetProcAddress(hMono, "il2cpp_type_get_type");
@@ -538,11 +542,14 @@ void CPipeServer::InitMono()
 				mono_string_new = (MONO_STRING_NEW)GetProcAddress(hMono, "il2cpp_string_new");
 				mono_string_to_utf8 = (MONO_STRING_TO_UTF8)GetProcAddress(hMono, "il2cpp_string_to_utf8");
 				mono_array_new = (MONO_ARRAY_NEW)GetProcAddress(hMono, "il2cpp_array_new");
+				mono_array_element_size = (MONO_ARRAY_ELEMENT_SIZE)GetProcAddress(hMono, "il2cpp_array_element_size");
 				mono_value_box = (MONO_VALUE_BOX)GetProcAddress(hMono, "il2cpp_value_box");
 				mono_object_unbox = (MONO_OBJECT_UNBOX)GetProcAddress(hMono, "il2cpp_object_unbox");
 				mono_object_new = (MONO_OBJECT_NEW)GetProcAddress(hMono, "il2cpp_object_new");
 
 				mono_class_get_type = (MONO_CLASS_GET_TYPE)GetProcAddress(hMono, "il2cpp_class_get_type");
+				mono_type_get_class = (MONO_TYPE_GET_CLASS)GetProcAddress(hMono, "il2cpp_type_get_class");
+				mono_type_get_class = mono_type_get_class ? mono_type_get_class : (MONO_TYPE_GET_CLASS)GetProcAddress(hMono, "il2cpp_type_get_class_or_element_class");
 
 				mono_method_desc_search_in_image = (MONO_METHOD_DESC_SEARCH_IN_IMAGE)GetProcAddress(hMono, "il2cpp_method_desc_search_in_image");
 				mono_runtime_invoke = (MONO_RUNTIME_INVOKE)GetProcAddress(hMono, "il2cpp_runtime_invoke");
@@ -597,7 +604,7 @@ void CPipeServer::InitMono()
 				mono_get_root_domain = (MONO_GET_ROOT_DOMAIN)GetProcAddress(hMono, "mono_get_root_domain");
 				mono_thread_attach = (MONO_THREAD_ATTACH)GetProcAddress(hMono, "mono_thread_attach");
 				mono_thread_detach = (MONO_THREAD_DETACH)GetProcAddress(hMono, "mono_thread_detach");
-                mono_thread_cleanup = (MONO_THREAD_CLEANUP)GetProcAddress(hMono, "mono_thread_cleanup");
+				mono_thread_cleanup = (MONO_THREAD_CLEANUP)GetProcAddress(hMono, "mono_thread_cleanup");
 
 				mono_object_get_class = (MONO_OBJECT_GET_CLASS)GetProcAddress(hMono, "mono_object_get_class");
 
@@ -610,7 +617,7 @@ void CPipeServer::InitMono()
 
 				mono_image_get_name = (MONO_IMAGE_GET_NAME)GetProcAddress(hMono, "mono_image_get_name");
 				mono_image_get_filename = (MONO_IMAGE_GET_FILENAME)GetProcAddress(hMono, "mono_image_get_filename");
-				
+
 				mono_image_get_table_info = (MONO_IMAGE_GET_TABLE_INFO)GetProcAddress(hMono, "mono_image_get_table_info");
 				mono_image_rva_map = (MONO_IMAGE_RVA_MAP)GetProcAddress(hMono, "mono_image_rva_map");
 
@@ -631,7 +638,11 @@ void CPipeServer::InitMono()
 				mono_class_get_fields = (MONO_CLASS_GET_FIELDS)GetProcAddress(hMono, "mono_class_get_fields");
 				mono_class_get_parent = (MONO_CLASS_GET_PARENT)GetProcAddress(hMono, "mono_class_get_parent");
 				mono_class_get_image = (MONO_CLASS_GET_IMAGE)GetProcAddress(hMono, "mono_class_get_image");
-				mono_class_is_generic = (MONO_CLASS_IS_GENERIC)GetProcAddress(hMono, "mono_class_is_generic");
+				mono_class_is_generic = (MONO_CLASS_IS_GENERIC)GetProcAddress(hMono, "mono_class_is_generic"); 
+				mono_class_is_enum = (MONO_CLASS_IS_ENUM)GetProcAddress(hMono, "mono_class_is_enum");
+				mono_class_is_valuetype = (MONO_CLASS_IS_VALUETYPE)GetProcAddress(hMono, "mono_class_is_valuetype");
+				mono_class_is_subclass_of = (MONO_CLASS_IS_SUBCLASS_OF)GetProcAddress(hMono, "mono_class_is_subclass_of");
+
 				mono_class_vtable = (MONO_CLASS_VTABLE)GetProcAddress(hMono, "mono_class_vtable");
 				mono_class_from_mono_type = (MONO_CLASS_FROM_MONO_TYPE)GetProcAddress(hMono, "mono_class_from_mono_type");
 				mono_class_get_element_class = (MONO_CLASS_GET_ELEMENT_CLASS)GetProcAddress(hMono, "mono_class_get_element_class");
@@ -688,6 +699,7 @@ void CPipeServer::InitMono()
 				mono_string_new = (MONO_STRING_NEW)GetProcAddress(hMono, "mono_string_new");
 				mono_string_to_utf8 = (MONO_STRING_TO_UTF8)GetProcAddress(hMono, "mono_string_to_utf8");
 				mono_array_new = (MONO_ARRAY_NEW)GetProcAddress(hMono, "mono_array_new");
+				mono_array_element_size = (MONO_ARRAY_ELEMENT_SIZE)GetProcAddress(hMono, "mono_array_element_size");
 				mono_value_box = (MONO_VALUE_BOX)GetProcAddress(hMono, "mono_value_box");
 				mono_object_unbox = (MONO_OBJECT_UNBOX)GetProcAddress(hMono, "mono_object_unbox");
 				mono_object_new = (MONO_OBJECT_NEW)GetProcAddress(hMono, "mono_object_new");
@@ -695,6 +707,7 @@ void CPipeServer::InitMono()
 				mono_get_enum_class = (MONO_GET_ENUM_CLASS)GetProcAddress(hMono, "mono_get_enum_class");
 
 				mono_class_get_type = (MONO_CLASS_GET_TYPE)GetProcAddress(hMono, "mono_class_get_type");
+				mono_type_get_class = (MONO_TYPE_GET_CLASS)GetProcAddress(hMono, "mono_type_get_class");
 				mono_class_get_nesting_type = (MONO_CLASS_GET_NESTING_TYPE)GetProcAddress(hMono, "mono_class_get_nesting_type");
 
 				mono_method_desc_search_in_image = (MONO_METHOD_DESC_SEARCH_IN_IMAGE)GetProcAddress(hMono, "mono_method_desc_search_in_image");
@@ -711,10 +724,10 @@ void CPipeServer::InitMono()
 				mono_field_static_set_value = (MONO_FIELD_STATIC_SET_VALUE)GetProcAddress(hMono, "mono_field_static_set_value");
 
 				mono_runtime_is_shutting_down = (MONO_RUNTIME_IS_SHUTTING_DOWN)GetProcAddress(hMono, "mono_runtime_is_shutting_down");
-				domain = mono_get_root_domain();		
+				domain = mono_get_root_domain();
 			}
 
-			ConnectThreadToMonoRuntime();			
+			ConnectThreadToMonoRuntime();
 		}
 		//else
 		//	OutputDebugStringA("Already attached");
@@ -724,42 +737,42 @@ void CPipeServer::InitMono()
 
 void CPipeServer::ConnectThreadToMonoRuntime()
 {
-  mono_selfthread=NULL;
-  //OutputDebugString("CPipeServer::ConnectThreadToMonoRuntime() : mono_thread_attach=%p\n",mono_thread_attach);
-  if (mono_thread_attach)
-  {
+	mono_selfthread = NULL;
+	//OutputDebugString("CPipeServer::ConnectThreadToMonoRuntime() : mono_thread_attach=%p\n",mono_thread_attach);
+	if (mono_thread_attach)
+	{
 
-    if (il2cpp)
-        mono_selfthread = mono_thread_attach(mono_domain_get());
-    else
-    {
-      if (mono_get_root_domain)
-      {
-        void* domain = mono_get_root_domain();
-        mono_selfthread = mono_thread_attach(domain);
-      }
-    }
-  }
+		if (il2cpp)
+			mono_selfthread = mono_thread_attach(mono_domain_get());
+		else
+		{
+			if (mono_get_root_domain)
+			{
+				void* domain = mono_get_root_domain();
+				mono_selfthread = mono_thread_attach(domain);
+			}
+		}
+	}
 
 	attached = mono_selfthread != NULL;
 }
 
 void CPipeServer::Object_New()
 {
-	void *domain;
+	void* domain;
 	if (mono_get_root_domain)
-		domain = (void *)mono_get_root_domain();
+		domain = (void*)mono_get_root_domain();
 	else
-		domain = (void *)mono_domain_get();
+		domain = (void*)mono_domain_get();
 
-	void *klass = (void *)ReadQword();
-	void *object=mono_object_new(domain, klass);
+	void* klass = (void*)ReadQword();
+	void* object = mono_object_new(domain, klass);
 	WriteQword((UINT64)object);
 }
 
 void CPipeServer::Object_Init()
 {
-	void *object = (void *)ReadQword();
+	void* object = (void*)ReadQword();
 	try
 	{
 		mono_runtime_object_init(object);
@@ -771,15 +784,15 @@ void CPipeServer::Object_Init()
 		//OutputDebugStringA("Error initializing object:\n");
 		//OutputDebugStringA(e);
 	}
-	
+
 
 }
 
 void CPipeServer::Object_GetClass()
 {
-	void *object = (void *)ReadQword();
-	char *classname;
-	void *klass;
+	void* object = (void*)ReadQword();
+	char* classname;
+	void* klass;
 
 	ExpectingAccessViolations = FALSE;
 
@@ -819,7 +832,7 @@ void CPipeServer::Object_GetClass()
 	}
 }
 
-void _cdecl DomainEnumerator(void *domain, std::vector<UINT64> *v)
+void _cdecl DomainEnumerator(void* domain, std::vector<UINT64>* v)
 {
 	v->push_back((UINT_PTR)domain);
 }
@@ -848,17 +861,17 @@ void CPipeServer::EnumDomains(void)
 
 void CPipeServer::SetCurrentDomain(void)
 {
-	void *domain = (void *)ReadQword();
+	void* domain = (void*)ReadQword();
 	int r;
 	if (mono_domain_set)
 		r = mono_domain_set(domain, FALSE);
 	else
 		r = 0;
 
-	WriteDword(r);	
+	WriteDword(r);
 }
 
-void _cdecl AssemblyEnumerator(void *assembly, std::vector<UINT64> *v)
+void _cdecl AssemblyEnumerator(void* assembly, std::vector<UINT64>* v)
 {
 	v->push_back((UINT_PTR)assembly);
 }
@@ -872,9 +885,9 @@ void CPipeServer::EnumAssemblies()
 	if (il2cpp)
 	{
 		DWORD i;
-		
-		SIZE_T nrofassemblies=0;	
-		UINT_PTR *assemblies;
+
+		SIZE_T nrofassemblies = 0;
+		UINT_PTR* assemblies;
 		assemblies = il2cpp_domain_get_assemblies(mono_domain_get(), &nrofassemblies); //in il2cpp you don't need to free this
 
 		WriteDword((DWORD)nrofassemblies);
@@ -909,8 +922,8 @@ void CPipeServer::EnumImages()
 	if (il2cpp)
 	{
 		SIZE_T nrofassemblies = 0;
-		UINT_PTR *assemblies;
-		assemblies = il2cpp_domain_get_assemblies(mono_domain_get(), &nrofassemblies); 
+		UINT_PTR* assemblies;
+		assemblies = il2cpp_domain_get_assemblies(mono_domain_get(), &nrofassemblies);
 
 		for (i = 0; i < nrofassemblies; i++)
 			v.push_back((UINT_PTR)assemblies[i]);
@@ -924,18 +937,18 @@ void CPipeServer::EnumImages()
 	//now build the reply
 	int32_t replypos = 0;
 	int replysize = (int)v.size() * 256;
-	char *reply = (char*)malloc(replysize);
+	char* reply = (char*)malloc(replysize);
 
 	for (i = 0; i < v.size(); i++)
-	{	
-		if ((replypos + 512+8+2) >= replysize) //512+8+2 : max size of path allowed, image pointer and stringlength
+	{
+		if ((replypos + 512 + 8 + 2) >= replysize) //512+8+2 : max size of path allowed, image pointer and stringlength
 		{
-			replysize = replysize * 2 + 512+8+2;  
+			replysize = replysize * 2 + 512 + 8 + 2;
 			reply = (char*)realloc(reply, replysize);
 		}
 
-		void* image=mono_assembly_get_image((void*)v[i]);
-		*(UINT64 *)&reply[replypos] = (UINT_PTR)image;
+		void* image = mono_assembly_get_image((void*)v[i]);
+		*(UINT64*)&reply[replypos] = (UINT_PTR)image;
 
 		replypos += 8;
 
@@ -949,7 +962,7 @@ void CPipeServer::EnumImages()
 		if (len > 512)
 			len = 512;
 
-		*(WORD *)&reply[replypos] = (WORD)len;
+		*(WORD*)&reply[replypos] = (WORD)len;
 		replypos += 2;
 
 		memcpy(&reply[replypos], name, len);
@@ -966,15 +979,15 @@ void CPipeServer::EnumImages()
 
 void CPipeServer::GetImageFromAssembly()
 {
-	void *assembly = (void *)ReadQword();
-	void *image = mono_assembly_get_image(assembly);
+	void* assembly = (void*)ReadQword();
+	void* image = mono_assembly_get_image(assembly);
 	WriteQword((UINT_PTR)image);
 }
 
 void CPipeServer::GetImageName()
 {
-	void *image = (void *)ReadQword();
-	char *s = mono_image_get_name(image);
+	void* image = (void*)ReadQword();
+	char* s = mono_image_get_name(image);
 
 	WriteWord((WORD)strlen(s));
 	Write(s, (int)strlen(s));
@@ -982,8 +995,8 @@ void CPipeServer::GetImageName()
 
 void CPipeServer::GetImageFileName()
 {
-	void *image = (void *)ReadQword();
-	char *s = mono_image_get_filename(image);
+	void* image = (void*)ReadQword();
+	char* s = mono_image_get_filename(image);
 
 	WriteWord((WORD)strlen(s));
 	Write(s, (int)strlen(s));
@@ -996,9 +1009,9 @@ void CPipeServer::GetImageFileName()
 WORD UTF8TOUTF16(char* szUtf8) {
 #if (_WINDOWS && (_MSC_VER <= 1916))
 	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> convert;
-	
+
 	try {
-		std::wstring dest=convert.from_bytes(szUtf8);
+		std::wstring dest = convert.from_bytes(szUtf8);
 		return *(WORD*)&dest[0];
 	}
 	catch (const std::range_error&) {
@@ -1013,8 +1026,8 @@ WORD UTF8TOUTF16(char* szUtf8) {
 
 void CPipeServer::EnumClassesInImageEx()
 {
-	
-	void *image = (void *)ReadQword();
+
+	void* image = (void*)ReadQword();
 	if (image == NULL)
 	{
 		WriteDword(0);
@@ -1024,7 +1037,7 @@ void CPipeServer::EnumClassesInImageEx()
 	std::vector<UINT64> classes;
 	CMemStream reply;
 	int i;
-	
+
 	if (il2cpp)
 	{
 		int count = 0;
@@ -1035,30 +1048,30 @@ void CPipeServer::EnumClassesInImageEx()
 
 		for (i = 0; i < count; i++)
 		{
-			void *c = il2cpp_image_get_class(image, i);
+			void* c = il2cpp_image_get_class(image, i);
 			reply.WriteQword((UINT64)c);
 
 			if (c)
 			{
 
-				void *parent = mono_class_get_parent ? mono_class_get_parent(c) : 0;
+				void* parent = mono_class_get_parent ? mono_class_get_parent(c) : 0;
 				reply.WriteQword((UINT64)parent);
 
-				void *nestingtype = mono_class_get_nesting_type ? mono_class_get_nesting_type(c) : 0;
+				void* nestingtype = mono_class_get_nesting_type ? mono_class_get_nesting_type(c) : 0;
 				reply.WriteQword((UINT64)parent);
 
-				char *name = mono_class_get_name(c);
+				char* name = mono_class_get_name(c);
 				WORD sl = (WORD)strlen(name);
 				reply.WriteWord(sl);
 				reply.Write(name, sl);
 
-				char *ns = mono_class_get_namespace(c);
+				char* ns = mono_class_get_namespace(c);
 				sl = (WORD)strlen(ns);
 				reply.WriteWord(sl);
 				reply.Write(ns, sl);
 
 				std::string fullname = GetFullTypeNameStr(c, 1, MONO_TYPE_NAME_FORMAT_REFLECTION);
-				
+
 				reply.WriteWord((WORD)fullname.size());
 				reply.Write((PVOID)fullname.c_str(), (unsigned int)fullname.size());
 			}
@@ -1077,8 +1090,8 @@ void CPipeServer::EnumClassesInImageEx()
 	else
 	{
 		//mono
-				
-		void *tdef = mono_image_get_table_info ? mono_image_get_table_info(image, MONO_TABLE_TYPEDEF) : NULL;
+
+		void* tdef = mono_image_get_table_info ? mono_image_get_table_info(image, MONO_TABLE_TYPEDEF) : NULL;
 		if (tdef)
 		{
 			int tdefcount = mono_table_info_get_rows ? mono_table_info_get_rows(tdef) : NULL;
@@ -1086,23 +1099,23 @@ void CPipeServer::EnumClassesInImageEx()
 
 			for (i = 0; i < tdefcount; i++)
 			{
-				void *c = mono_class_get(image, MONO_TOKEN_TYPE_DEF | (i + 1));
+				void* c = mono_class_get(image, MONO_TOKEN_TYPE_DEF | (i + 1));
 				reply.WriteQword((UINT64)c);
 				if (c != NULL)
-				{				
+				{
 
-					void *parent = mono_class_get_parent ? mono_class_get_parent(c) : 0;
+					void* parent = mono_class_get_parent ? mono_class_get_parent(c) : 0;
 					reply.WriteQword((UINT64)parent);
 
-					void *nestingtype = mono_class_get_nesting_type ? mono_class_get_nesting_type(c) : 0;
+					void* nestingtype = mono_class_get_nesting_type ? mono_class_get_nesting_type(c) : 0;
 					reply.WriteQword((UINT64)nestingtype);
 
-					char *name = mono_class_get_name(c);
+					char* name = mono_class_get_name(c);
 					WORD sl = (WORD)strlen(name);
 					reply.WriteWord(sl);
 					reply.Write(name, sl);
 
-					char *ns = mono_class_get_namespace(c);
+					char* ns = mono_class_get_namespace(c);
 					sl = (WORD)strlen(ns);
 					reply.WriteWord(sl);
 					reply.Write(ns, sl);
@@ -1124,7 +1137,7 @@ void CPipeServer::EnumClassesInImageEx()
 		}
 		else
 			reply.WriteDword(0);
-		
+
 	}
 
 	WriteDword(reply.GetSize());
@@ -1134,7 +1147,7 @@ void CPipeServer::EnumClassesInImageEx()
 void CPipeServer::EnumClassesInImage()
 {
 	int i;
-	void *image = (void *)ReadQword();
+	void* image = (void*)ReadQword();
 	if (image == NULL)
 	{
 		WriteDword(0);
@@ -1147,12 +1160,12 @@ void CPipeServer::EnumClassesInImage()
 		if (il2cpp_image_get_class_count)
 			count = il2cpp_image_get_class_count(image);
 
-		
+
 		WriteDword(count);
 
 
 		for (i = 0; i < count; i++)
-		{	
+		{
 			if (il2cpp_image_get_class)
 			{
 				void* c = il2cpp_image_get_class(image, i);
@@ -1160,7 +1173,7 @@ void CPipeServer::EnumClassesInImage()
 
 				if (c)
 				{
-					char *name = mono_class_get_name(c);
+					char* name = mono_class_get_name(c);
 					WriteString(name);
 
 					name = mono_class_get_namespace(c);
@@ -1176,7 +1189,7 @@ void CPipeServer::EnumClassesInImage()
 	else
 	{
 
-		void *tdef = mono_image_get_table_info(image, MONO_TABLE_TYPEDEF);
+		void* tdef = mono_image_get_table_info(image, MONO_TABLE_TYPEDEF);
 		if (tdef)
 		{
 			int tdefcount = mono_table_info_get_rows(tdef);
@@ -1184,10 +1197,10 @@ void CPipeServer::EnumClassesInImage()
 
 			for (i = 0; i < tdefcount; i++)
 			{
-				void *c = mono_class_get(image, MONO_TOKEN_TYPE_DEF | (i + 1));
+				void* c = mono_class_get(image, MONO_TOKEN_TYPE_DEF | (i + 1));
 				if (c != NULL)
 				{
-					char *name = mono_class_get_name(c);
+					char* name = mono_class_get_name(c);
 
 					WriteQword((UINT_PTR)c);
 
@@ -1230,9 +1243,9 @@ void CPipeServer::EnumClassesInImage()
 
 void CPipeServer::EnumFieldsInClass()
 {
-	void *c = (void *)ReadQword();
-	void *iter = NULL;
-	void *field;
+	void* c = (void*)ReadQword();
+	void* iter = NULL;
+	void* field;
 
 	do
 	{
@@ -1241,7 +1254,7 @@ void CPipeServer::EnumFieldsInClass()
 
 		if (field)
 		{
-			void *fieldtype = mono_field_get_type(field);
+			void* fieldtype = mono_field_get_type(field);
 			WriteQword((UINT_PTR)fieldtype);
 			WriteDword(mono_type_get_type(fieldtype));
 			WriteQword((UINT_PTR)mono_field_get_parent(field));
@@ -1286,9 +1299,9 @@ void CPipeServer::EnumFieldsInClass()
 
 void CPipeServer::EnumMethodsInClass()
 {
-	void *c = (void *)ReadQword();
-	void *iter = NULL;
-	void *method;
+	void* c = (void*)ReadQword();
+	void* iter = NULL;
+	void* method;
 
 	do
 	{
@@ -1297,7 +1310,7 @@ void CPipeServer::EnumMethodsInClass()
 
 		if (method)
 		{
-			char *name;
+			char* name;
 			uint32_t flags;
 
 			name = mono_method_get_name(method);
@@ -1322,9 +1335,9 @@ void CPipeServer::EnumMethodsInClass()
 }
 
 void CPipeServer::CompileMethod()
-{	
-	void *method = (void *)ReadQword();	
-	
+{
+	void* method = (void*)ReadQword();
+
 
 	if (il2cpp)
 	{
@@ -1332,13 +1345,13 @@ void CPipeServer::CompileMethod()
 	}
 	else
 	{
-		void *result = NULL;
+		void* result = NULL;
 		try
 		{
-			void *klass = mono_method_get_class(method);
+			void* klass = mono_method_get_class(method);
 			if (klass)
 			{
-				if ((mono_class_is_generic && (mono_class_is_generic(klass) == 0)) || (mono_class_is_generic==NULL)) //good luck if is_generic is missing (unity adds it but not all mono games are unity)
+				if ((mono_class_is_generic && (mono_class_is_generic(klass) == 0)) || (mono_class_is_generic == NULL)) //good luck if is_generic is missing (unity adds it but not all mono games are unity)
 				{
 					result = mono_compile_method(method);
 				}
@@ -1352,18 +1365,18 @@ void CPipeServer::CompileMethod()
 		}
 		WriteQword((UINT_PTR)result);
 	}
-	
-	
-	
-	
+
+
+
+
 }
 
 void CPipeServer::GetMethodHeader()
 {
 	if (mono_method_get_header)
 	{
-		void *method = (void *)ReadQword();
-		void *result = mono_method_get_header(method);
+		void* method = (void*)ReadQword();
+		void* result = mono_method_get_header(method);
 		WriteQword((UINT_PTR)result);
 	}
 	else
@@ -1379,9 +1392,9 @@ void CPipeServer::GetILCode()
 	}
 	else
 	{
-		void *methodheader = (void *)ReadQword();
+		void* methodheader = (void*)ReadQword();
 		UINT32 code;
-		void *result = mono_method_header_get_code(methodheader, &code, NULL);
+		void* result = mono_method_header_get_code(methodheader, &code, NULL);
 		WriteQword((UINT_PTR)result);
 		WriteDword(code);
 	}
@@ -1391,9 +1404,9 @@ void CPipeServer::RvaMap()
 {
 	if (mono_image_rva_map)
 	{
-		void *image = (void *)ReadQword();
+		void* image = (void*)ReadQword();
 		UINT32 offset = ReadDword();
-		void *result = mono_image_rva_map(image, offset);
+		void* result = mono_image_rva_map(image, offset);
 
 		WriteQword((UINT_PTR)result);
 	}
@@ -1413,11 +1426,11 @@ void CPipeServer::GetJitInfo()
 	}
 	else
 	{
-		void *domain = (void *)ReadQword();
+		void* domain = (void*)ReadQword();
 		if (domain == NULL)
-			domain = (void *)mono_get_root_domain();
-		void *address = (void *)ReadQword();
-		void *jitinfo = mono_jit_info_table_find(domain, address);
+			domain = (void*)mono_get_root_domain();
+		void* address = (void*)ReadQword();
+		void* jitinfo = mono_jit_info_table_find(domain, address);
 		WriteQword((UINT_PTR)jitinfo);
 		if (jitinfo)
 		{
@@ -1430,13 +1443,13 @@ void CPipeServer::GetJitInfo()
 
 void CPipeServer::FindClass()
 {
-	void *image = (void *)ReadQword();
+	void* image = (void*)ReadQword();
 	WORD length = ReadWord();
-	char *cn = NULL;
-	char *ns = NULL;
-	void *klass;
+	char* cn = NULL;
+	char* ns = NULL;
+	void* klass;
 
-	cn = (char *)malloc(length + 1);
+	cn = (char*)malloc(length + 1);
 	if (length)
 		Read(cn, length);
 
@@ -1444,7 +1457,7 @@ void CPipeServer::FindClass()
 
 	length = ReadWord();
 
-	ns = (char *)malloc(length + 1);
+	ns = (char*)malloc(length + 1);
 	if (length)
 		Read(ns, length);
 
@@ -1467,10 +1480,10 @@ void CPipeServer::FindClass()
 
 void CPipeServer::FindMethod()
 {
-	void *klass = (void *)ReadQword();
+	void* klass = (void*)ReadQword();
 	WORD length = ReadWord();
-	char *methodname = (char *)malloc(length + 1);
-	void *method = NULL;
+	char* methodname = (char*)malloc(length + 1);
+	void* method = NULL;
 	if (length)
 		Read(methodname, length);
 	methodname[length] = 0;
@@ -1482,8 +1495,8 @@ void CPipeServer::FindMethod()
 
 void CPipeServer::GetMethodName()
 {
-	void *method = (void *)ReadQword();
-	char *methodname = mono_method_get_name(method);
+	void* method = (void*)ReadQword();
+	char* methodname = mono_method_get_name(method);
 
 	WriteWord((WORD)strlen(methodname));
 	Write(methodname, (WORD)strlen(methodname));
@@ -1491,19 +1504,19 @@ void CPipeServer::GetMethodName()
 
 void CPipeServer::GetMethodClass()
 {
-	void *method = (void *)ReadQword();
-	void *result = mono_method_get_class(method);
+	void* method = (void*)ReadQword();
+	void* result = mono_method_get_class(method);
 	WriteQword((UINT_PTR)result);
 }
 
 
 void CPipeServer::GetKlassName()
 {
-	void *klass = (void *)ReadQword();
+	void* klass = (void*)ReadQword();
 	if (klass && mono_class_get_name)
 	{
 
-		char *classname = mono_class_get_name(klass);
+		char* classname = mono_class_get_name(klass);
 
 		std::string sName = std::string(classname);
 
@@ -1526,10 +1539,10 @@ void CPipeServer::GetKlassName()
 void CPipeServer::GetClassNamespace()
 {
 
-	void *klass = (void *)ReadQword();
+	void* klass = (void*)ReadQword();
 	if (klass && mono_class_get_namespace)
 	{
-		char *classname = mono_class_get_namespace(klass);
+		char* classname = mono_class_get_namespace(klass);
 
 		WriteWord((WORD)strlen(classname));
 		Write(classname, (WORD)strlen(classname));
@@ -1541,12 +1554,12 @@ void CPipeServer::GetClassNamespace()
 void CPipeServer::FreeMethod()
 {
 	if (mono_free_method)
-		mono_free_method((void *)ReadQword());
+		mono_free_method((void*)ReadQword());
 }
 
 void CPipeServer::FreeObject()
 {
-	
+
 	//not yet implemented
 }
 
@@ -1557,26 +1570,26 @@ void CPipeServer::GetMonoDataCollectorVersion()
 
 void CPipeServer::NewString()
 {
-	void *domain = (void *)ReadQword();
+	void* domain = (void*)ReadQword();
 	if (domain == NULL)
-		domain = (void *)mono_get_root_domain();
+		domain = (void*)mono_get_root_domain();
 
-	char *s=ReadString();
+	char* s = ReadString();
 	free(s);
 
-	void *string=mono_string_new(domain, s);
+	void* string = mono_string_new(domain, s);
 	WriteQword((UINT_PTR)string);
 }
 
 void CPipeServer::DisassembleMethod()
-{	
-	void *method = (void *)ReadQword();
+{
+	void* method = (void*)ReadQword();
 	if (!il2cpp)
 	{
-		void *methodheader = mono_method_get_header(method);
+		void* methodheader = mono_method_get_header(method);
 		UINT32 codesize, maxstack;
-		void *ilcode = mono_method_header_get_code(methodheader, &codesize, &maxstack);
-		char *disassembly = mono_disasm_code(NULL, method, ilcode, (void *)((UINT_PTR)ilcode + codesize));
+		void* ilcode = mono_method_header_get_code(methodheader, &codesize, &maxstack);
+		char* disassembly = mono_disasm_code(NULL, method, ilcode, (void*)((UINT_PTR)ilcode + codesize));
 
 		WriteWord((WORD)strlen(disassembly));
 		Write(disassembly, (WORD)strlen(disassembly));
@@ -1586,7 +1599,7 @@ void CPipeServer::DisassembleMethod()
 
 void CPipeServer::GetMethodParameters()
 {
-	void *method = (void *)ReadQword();
+	void* method = (void*)ReadQword();
 	int i;
 
 	if (il2cpp)
@@ -1595,7 +1608,7 @@ void CPipeServer::GetMethodParameters()
 		WriteByte(paramcount);
 		for (i = 0; i < paramcount; i++)
 		{
-			char *paramname = il2cpp_method_get_param_name(method, i);
+			char* paramname = il2cpp_method_get_param_name(method, i);
 			WriteString1(paramname);
 		}
 
@@ -1603,7 +1616,7 @@ void CPipeServer::GetMethodParameters()
 		{
 			for (i = 0; i < paramcount; i++)
 			{
-				void *paramtype = il2cpp_method_get_param(method, i);
+				void* paramtype = il2cpp_method_get_param(method, i);
 
 				if (paramtype)
 					WriteDword(mono_type_get_type(paramtype));
@@ -1613,7 +1626,7 @@ void CPipeServer::GetMethodParameters()
 		}
 
 		{
-			void *returntype = il2cpp_method_get_return_type(method);
+			void* returntype = il2cpp_method_get_return_type(method);
 			if (returntype)
 				WriteDword(mono_type_get_type(returntype));
 			else
@@ -1624,14 +1637,14 @@ void CPipeServer::GetMethodParameters()
 	else
 	{
 
-		void *methodsignature = mono_method_signature(method);
-		
+		void* methodsignature = mono_method_signature(method);
+
 
 		if (methodsignature)
 		{
 			int paramcount = mono_signature_get_param_count(methodsignature);
-			char **names = (char **)calloc(sizeof(char *), paramcount);
-			mono_method_get_param_names(method, (const char **)names);
+			char** names = (char**)calloc(sizeof(char*), paramcount);
+			mono_method_get_param_names(method, (const char**)names);
 			WriteByte(paramcount);
 			for (i = 0; i < paramcount; i++)
 			{
@@ -1647,9 +1660,9 @@ void CPipeServer::GetMethodParameters()
 			if (paramcount)
 			{
 				gpointer iter = NULL;
-				MonoType *paramtype;
-				
-				for (i=0; i< paramcount; i++)
+				MonoType* paramtype;
+
+				for (i = 0; i < paramcount; i++)
 				{
 					paramtype = mono_signature_get_params((MonoMethodSignature*)methodsignature, &iter);
 
@@ -1661,7 +1674,7 @@ void CPipeServer::GetMethodParameters()
 			}
 
 			{
-				MonoType *returntype = mono_signature_get_return_type(methodsignature);
+				MonoType* returntype = mono_signature_get_return_type(methodsignature);
 				if (returntype)
 					WriteDword(mono_type_get_type(returntype));
 				else
@@ -1681,30 +1694,30 @@ void CPipeServer::GetMethodParameters()
 
 void CPipeServer::GetMethodSignature()
 {
-	void *method = (void *)ReadQword();
+	void* method = (void*)ReadQword();
 	int i;
 
 	if (il2cpp)
 	{
 		int paramcount = il2cpp_method_get_param_count(method);
-		char *name;
+		char* name;
 		void* type;
 
 		WriteByte(paramcount);
 
 		for (i = 0; i < paramcount; i++)
 		{
-			name=il2cpp_method_get_param_name(method, i);
-			WriteString1(name);				
+			name = il2cpp_method_get_param_name(method, i);
+			WriteString1(name);
 		}
 
 		for (i = 0; i < paramcount; i++)
 		{
-			type=il2cpp_method_get_param(method, i);
-			name=il2cpp_type_get_name(type);
-			WriteString(name);			
+			type = il2cpp_method_get_param(method, i);
+			name = il2cpp_type_get_name(type);
+			WriteString(name);
 		}
-			
+
 
 		type = il2cpp_method_get_return_type(method);
 		name = il2cpp_type_get_name(type);
@@ -1714,19 +1727,19 @@ void CPipeServer::GetMethodSignature()
 	else
 	{
 
-		void *methodsignature = mono_method_signature(method);
-		char *sig = mono_signature_get_desc(methodsignature, TRUE);
+		void* methodsignature = mono_method_signature(method);
+		char* sig = mono_signature_get_desc(methodsignature, TRUE);
 		int paramcount = mono_signature_get_param_count(methodsignature);
 
-		
+
 
 		WriteByte(paramcount);
 
 		if (paramcount)
 		{
-			char **names = (char **)calloc(sizeof(char *), paramcount);
+			char** names = (char**)calloc(sizeof(char*), paramcount);
 
-			mono_method_get_param_names(method, (const char **)names);
+			mono_method_get_param_names(method, (const char**)names);
 
 			for (i = 0; i < paramcount; i++)
 			{
@@ -1748,11 +1761,11 @@ void CPipeServer::GetMethodSignature()
 		g_free(sig);
 
 		//12/5/2014:send the returntype as well
-		void *returntype = mono_signature_get_return_type(methodsignature);
+		void* returntype = mono_signature_get_return_type(methodsignature);
 
 		if (returntype)
 		{
-			char *tname = mono_type_get_name(returntype);
+			char* tname = mono_type_get_name(returntype);
 			if (tname)
 			{
 				WriteByte((BYTE)strlen(tname));
@@ -1769,10 +1782,10 @@ void CPipeServer::GetMethodSignature()
 
 void CPipeServer::GetParentClass(void)
 {
-	void *klass = (void *)ReadQword();
+	void* klass = (void*)ReadQword();
 	UINT_PTR parent = 0;
 	if (klass)
-		 parent = mono_class_get_parent ? (UINT_PTR)mono_class_get_parent(klass) : 0;
+		parent = mono_class_get_parent ? (UINT_PTR)mono_class_get_parent(klass) : 0;
 
 	WriteQword(parent);
 }
@@ -1780,7 +1793,7 @@ void CPipeServer::GetParentClass(void)
 void CPipeServer::GetClassNestingType(void)
 {
 	UINT_PTR nestingtype = 0;
-	void *klass = (void *)ReadQword();
+	void* klass = (void*)ReadQword();
 	if (klass)
 		nestingtype = mono_class_get_nesting_type ? (UINT_PTR)mono_class_get_nesting_type(klass) : 0;
 
@@ -1790,30 +1803,48 @@ void CPipeServer::GetClassNestingType(void)
 
 void CPipeServer::GetClassImage(void)
 {
-    UINT_PTR image = 0;
-	void *klass = (void *)ReadQword();
+	UINT_PTR image = 0;
+	void* klass = (void*)ReadQword();
 	if (klass)
 		image = mono_class_get_image ? (UINT_PTR)mono_class_get_image(klass) : 0;
 
 	WriteQword(image);
 }
 
+void CPipeServer::GetClassType()
+{
+	void* kls = (void*)ReadQword();
+	WriteQword((UINT64)mono_class_get_type(kls));
+}
+
+void CPipeServer::GetClassOfType()
+{
+	void* type = (void*)ReadQword();
+	WriteQword((UINT64)mono_type_get_class(type));
+}
+
+void CPipeServer::GetTypeOfMonoType()
+{
+	void* type = (void*)ReadQword();
+	WriteDword((UINT64)mono_type_get_type(type));
+}
+
 
 void CPipeServer::GetVTableFromClass(void)
 {
-	void *domain = (void *)ReadQword();
-	void *klass = (void *)ReadQword();
+	void* domain = (void*)ReadQword();
+	void* klass = (void*)ReadQword();
 
 	if (il2cpp)
 	{
 		WriteQword(0);
 	}
 	else
-	{		
+	{
 		if (domain == NULL)
-			domain = (void *)mono_get_root_domain();
-		
-		void *vtable = (domain && klass) ? mono_class_vtable(domain, klass) : NULL;
+			domain = (void*)mono_get_root_domain();
+
+		void* vtable = (domain && klass) ? mono_class_vtable(domain, klass) : NULL;
 
 		WriteQword((UINT_PTR)vtable);
 	}
@@ -1822,8 +1853,8 @@ void CPipeServer::GetVTableFromClass(void)
 
 void CPipeServer::GetStaticFieldAddressFromClass(void)
 {
-	void *domain = (void *)ReadQword();
-	void *klass = (void *)ReadQword();
+	void* domain = (void*)ReadQword();
+	void* klass = (void*)ReadQword();
 
 	if (il2cpp)
 	{
@@ -1832,12 +1863,12 @@ void CPipeServer::GetStaticFieldAddressFromClass(void)
 	else
 	{
 		if (domain == NULL)
-			domain = (void *)mono_get_root_domain();
-		
-		void *vtable = (domain && klass) ? mono_class_vtable(domain, klass) : NULL;
+			domain = (void*)mono_get_root_domain();
+
+		void* vtable = (domain && klass) ? mono_class_vtable(domain, klass) : NULL;
 		if (vtable)
 		{
-			void *staticdata = mono_vtable_get_static_field_data(vtable);
+			void* staticdata = mono_vtable_get_static_field_data(vtable);
 			WriteQword((UINT_PTR)staticdata);
 		}
 		else
@@ -1847,11 +1878,11 @@ void CPipeServer::GetStaticFieldAddressFromClass(void)
 
 void CPipeServer::GetTypeClass(void)
 {
-	void *field = (void *)ReadQword();  // TODO: this should be monotype but EnumFieldsInClass effectively returns fieldtype ptr
-	void *type = field ? mono_field_get_type(field) : NULL;
-	void *klass;
+	void* field = (void*)ReadQword();  // TODO: this should be monotype but EnumFieldsInClass effectively returns fieldtype ptr
+	void* type = field ? mono_field_get_type(field) : NULL;
+	void* klass;
 
-	if (il2cpp)		
+	if (il2cpp)
 		klass = type ? il2cpp_class_from_type(type) : NULL;
 	else
 		klass = type ? mono_class_from_mono_type(type) : NULL;
@@ -1861,24 +1892,24 @@ void CPipeServer::GetTypeClass(void)
 
 void CPipeServer::GetArrayElementClass(void)
 {
-	void *klass = (void *)ReadQword();
-	void *eklass = klass ? mono_class_get_element_class(klass) : NULL;
+	void* klass = (void*)ReadQword();
+	void* eklass = klass ? mono_class_get_element_class(klass) : NULL;
 	WriteQword((UINT_PTR)eklass);
 }
 
 void CPipeServer::FindMethodByDesc(void)
 {
-	void *image = (void *)ReadQword();
-	char *fqMethodName = ReadString();
+	void* image = (void*)ReadQword();
+	char* fqMethodName = ReadString();
 
 	if (il2cpp)
 	{
 		WriteQword(0);
 	}
 	else
-	{	
-		void *mmd = fqMethodName ? mono_method_desc_new(fqMethodName, 1) : NULL;
-		void *method = mmd && image ? mono_method_desc_search_in_image(mmd, image) : NULL;
+	{
+		void* mmd = fqMethodName ? mono_method_desc_new(fqMethodName, 1) : NULL;
+		void* method = mmd && image ? mono_method_desc_search_in_image(mmd, image) : NULL;
 		WriteQword((UINT_PTR)method);
 		FreeString(fqMethodName);
 	}
@@ -1904,10 +1935,10 @@ void *CPipeServer::ReadObjectArray(void *domain)
 	char *ptr = (char*)arr;
 	*(int*)ptr = nargs;
 	ptr += sizeof(int);
-	
+
 	void **args = (void**)(ptr);
 	ptr += nargs * sizeof(void*);
-	
+
 	// copy types so free can be properly executed
 	memcpy(ptr, types, nargs * sizeof(char));
 
@@ -2011,7 +2042,7 @@ void* CPipeServer::ReadObject(void* domain, MonoTypeEnum type, void *addr)
 		if (size > 0)
 		{
 			Read(addr, size);
-			result = (void *) *((UINT64*)addr);			
+			result = (void *) *((UINT64*)addr);
 		}
 		break;
 	}
@@ -2026,13 +2057,13 @@ void* CPipeServer::ReadObject(void* domain, MonoTypeEnum type, void *addr)
 			Read(addr, size);
 		}
 		break;
-            
-    default:
-        break;
-            
+
+	default:
+		break;
+
 	}
-   
-    
+
+
 	return result;
 }
 
@@ -2062,10 +2093,10 @@ void CPipeServer::WriteObject(void* object)
 				WriteString(c);
 				free(c);
 #else
-                //todo: unsure about this
-                std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-                std::string dest = convert.to_bytes((char16_t *)ptr);
-                WriteString(dest.c_str());
+				//todo: unsure about this
+				std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+				std::string dest = convert.to_bytes((char16_t *)ptr);
+				WriteString(dest.c_str());
 #endif
 			}
 			else
@@ -2175,8 +2206,8 @@ void CPipeServer::InvokeMethod(void)
 			void *methodsignature = mono_method_signature(method);
 			paramcount = methodsignature ? mono_signature_get_param_count(methodsignature) : 0;
 		}
-		
-		
+
+
 		int nargs = GetObjectArraySize(arr);
 		void **args = GetObjectArrayArgs(arr);
 		if (nargs == paramcount)
@@ -2186,13 +2217,13 @@ void CPipeServer::InvokeMethod(void)
 
 			try
 			{
-				result = mono_runtime_invoke(method, pThis, args, NULL);				
+				result = mono_runtime_invoke(method, pThis, args, NULL);
 			}
 			catch (...)
 			{
 				result = NULL;
 			}
-			
+
 
 			if ((!il2cpp) && (domain != olddomain))
 				mono_domain_set(olddomain, FALSE);
@@ -2202,7 +2233,7 @@ void CPipeServer::InvokeMethod(void)
 	WriteObject(result);
 }
 */
-	
+
 void CPipeServer::InvokeMethod(void)
 {
 
@@ -2259,9 +2290,9 @@ void CPipeServer::InvokeMethod(void)
 		case MONO_TYPE_R4:
 		{
 			void* f;
-		    Read(&f, 4);
-		    args[i] = (UINT64)(void*)f;
-		    arry[i] = &args[i];
+			Read(&f, 4);
+			args[i] = (UINT64)(void*)f;
+			arry[i] = &args[i];
 		}break;
 		case MONO_TYPE_R8:
 		{
@@ -2383,10 +2414,10 @@ void CPipeServer::InvokeMethod(void)
 		WriteByte(0);
 	}
 }
-		
+
 void CPipeServer::LoadAssemblyFromFile(void)
 {
-	char *imageName = ReadString();
+	char* imageName = ReadString();
 	if (il2cpp)
 	{
 		WriteQword(0);
@@ -2395,19 +2426,19 @@ void CPipeServer::LoadAssemblyFromFile(void)
 	{
 
 		int status;
-		void *domain = (void *)mono_get_root_domain();
+		void* domain = (void*)mono_get_root_domain();
 		mono_domain_set(domain, FALSE);
 
-		void *assembly = mono_assembly_open(imageName, &status);
-		void *image = mono_assembly_get_image(assembly);
-		void *c = mono_class_from_name(image, (char*)"", (char*)"test");
+		void* assembly = mono_assembly_open(imageName, &status);
+		void* image = mono_assembly_get_image(assembly);
+		void* c = mono_class_from_name(image, (char*)"", (char*)"test");
 
 		WriteQword((UINT_PTR)assembly);
 
 		if (mono_jit_exec)
 		{
 			int argc;
-			char *argv = (char *)"BLA";
+			char* argv = (char*)"BLA";
 			mono_jit_exec(domain, assembly, 1, &argv);
 		}
 	}
@@ -2418,11 +2449,11 @@ std::string CPipeServer::GetFullTypeNameStr(void* klass, char isKlass, int namef
 {
 	try
 	{
-		void *ptype = klass && isKlass ? mono_class_get_type(klass) : klass;
-	
+		void* ptype = klass && isKlass ? mono_class_get_type(klass) : klass;
+
 		if (ptype)
 		{
-			char *fullname;
+			char* fullname;
 			if (il2cpp)
 				fullname = il2cpp_type_get_name(ptype);
 			else
@@ -2457,7 +2488,7 @@ std::string CPipeServer::GetFullTypeNameStr(void* klass, char isKlass, int namef
 	}
 	catch (...)
 	{
-		return "(exception)";		
+		return "(exception)";
 	}
 
 
@@ -2466,46 +2497,46 @@ std::string CPipeServer::GetFullTypeNameStr(void* klass, char isKlass, int namef
 void CPipeServer::GetFullTypeName(void)
 {
 	//ExpectingAccessViolations = TRUE;
-    
-    //1-(8-1-4)
+
+	//1-(8-1-4)
 
 	try
 	{
-		void *klass = (void *)ReadQword();
+		void* klass = (void*)ReadQword();
 		char isKlass = ReadByte();
-		void *ptype = klass && isKlass ? mono_class_get_type(klass) : klass;
+		void* ptype = klass && isKlass ? mono_class_get_type(klass) : klass;
 		int nameformat = ReadDword();
 
 		if (ptype)
 		{
-			char *fullname;
+			char* fullname;
 			if (il2cpp)
-				fullname=il2cpp_type_get_name(ptype);								
+				fullname = il2cpp_type_get_name(ptype);
 			else
 				fullname = mono_type_get_name_full ? mono_type_get_name_full(ptype, nameformat) : mono_type_get_name(ptype); //fallback on type_get_name in case of non exported mono_type_get_name_full
 
-			if (fullname) 
+			if (fullname)
 			{
 				std::string sName = std::string(fullname);
 
-                if ((BYTE)fullname[0] == 0xEE) {
-                    char szUeName[32];
-                    auto plus = strchr(fullname, '+');
-                    if (plus) {
-                        sprintf_s(szUeName, 32, "\\u%04X+\\u%04X", UTF8TOUTF16(fullname), UTF8TOUTF16(plus+1));
-                        sName = szUeName;
-                    }
-                    else {
-                        sprintf_s(szUeName, 32, "\\u%04X", UTF8TOUTF16(fullname));
-                        sName = szUeName;
-                    }
-                }
+				if ((BYTE)fullname[0] == 0xEE) {
+					char szUeName[32];
+					auto plus = strchr(fullname, '+');
+					if (plus) {
+						sprintf_s(szUeName, 32, "\\u%04X+\\u%04X", UTF8TOUTF16(fullname), UTF8TOUTF16(plus + 1));
+						sName = szUeName;
+					}
+					else {
+						sprintf_s(szUeName, 32, "\\u%04X", UTF8TOUTF16(fullname));
+						sName = szUeName;
+					}
+				}
 
-                WriteWord((WORD)sName.size());
-                Write((PVOID)sName.c_str(), (WORD)sName.size());
+				WriteWord((WORD)sName.size());
+				Write((PVOID)sName.c_str(), (WORD)sName.size());
 			}
-            else
-                WriteWord(0);
+			else
+				WriteWord(0);
 		}
 		else
 		{
@@ -2515,20 +2546,58 @@ void CPipeServer::GetFullTypeName(void)
 	catch (...)
 	{
 		//OutputDebugStringA("GetFullTypeName exception\n");
-		WriteWord(0);		
+		WriteWord(0);
 	}
 	//ExpectingAccessViolations = FALSE;
 
-		
+
 }
 
 void CPipeServer::IsGenericClass()
 {
-	void *klass = (void *)ReadQword();
-    if (mono_class_is_generic)
-        WriteByte(mono_class_is_generic(klass));
-    else
-        WriteByte(0); //not supported
+	void* klass = (void*)ReadQword();
+	if (mono_class_is_generic)
+		WriteByte(mono_class_is_generic(klass));
+	else
+		WriteByte(0); //not supported
+}
+
+void CPipeServer::IsEnumClass()
+{
+	void* klass = (void*)ReadQword();
+	if (mono_class_is_enum)
+		WriteByte(mono_class_is_enum(klass));
+	else
+		WriteByte(0); //not supported
+}
+
+void CPipeServer::IsValueTypeClass()
+{
+	void* klass = (void*)ReadQword();
+	if (mono_class_is_valuetype)
+		WriteByte(mono_class_is_valuetype(klass));
+	else
+		WriteByte(0); //not supported
+}
+
+void CPipeServer::IsSubClassOf()
+{
+	void* klass = (void*)ReadQword();
+	void* parentklass = (void*)ReadQword();
+	bool checkInteface = (void*)ReadByte();
+	if (mono_class_is_subclass_of)
+		WriteByte(mono_class_is_subclass_of(klass,parentklass,checkInteface));
+	else
+		WriteByte(0); //not supported
+}
+
+void CPipeServer::GetArrayElementSize()
+{
+	void* klass = (void*)ReadQword();
+	if (mono_array_element_size)
+		WriteDword(mono_array_element_size(klass));
+	else
+		WriteDword(0);
 }
 
 void CPipeServer::IsIL2CPP()
@@ -2538,11 +2607,11 @@ void CPipeServer::IsIL2CPP()
 
 void CPipeServer::FillOptionalFunctionList()
 {
-    QWORD _mono_type_get_name_full=ReadQword();
-    
-    if ((mono_type_get_name_full==NULL) && (_mono_type_get_name_full!=0)) mono_type_get_name_full=(MONO_TYPE_GET_NAME_FULL)_mono_type_get_name_full;
-    
-    WriteByte(1);
+	QWORD _mono_type_get_name_full = ReadQword();
+
+	if ((mono_type_get_name_full == NULL) && (_mono_type_get_name_full != 0)) mono_type_get_name_full = (MONO_TYPE_GET_NAME_FULL)_mono_type_get_name_full;
+
+	WriteByte(1);
 }
 
 void CPipeServer::GetStaticFieldValue()
@@ -2555,19 +2624,19 @@ void CPipeServer::GetStaticFieldValue()
 	{
 		if (il2cpp_field_static_get_value)
 		{
-			il2cpp_field_static_get_value(Field, &val);		
+			il2cpp_field_static_get_value(Field, &val);
 		}
 
 	}
 	else
 	{
 		if (mono_field_static_get_value)
-        {
-            if (mono_field_get_flags)
-            {
-                int flags=mono_field_get_flags(Field);
+		{
+			if (mono_field_get_flags)
+			{
+				int flags = mono_field_get_flags(Field);
 				if (flags & 0x10) //0x10=FIELD_ATTRIBUTE_STATIC
-                {
+				{
 					if ((flags & 0x8040) && mono_field_get_value_object && mono_object_unbox && mono_object_isinst && mono_get_enum_class) //FIELD_ATTRIBUTE_LITERAL | FIELD_ATTRIBUTE_HAS_DEFAULT (for constant/enum fields)
 					{
 						void* obj = mono_field_get_value_object(mono_get_root_domain(), Field, nullptr);
@@ -2582,12 +2651,12 @@ void CPipeServer::GetStaticFieldValue()
 					}
 					else
 					{
-						NOTENUM:
+					NOTENUM:
 						if (mono_vtable_get_static_field_data)
 						{
-							void *sfd=mono_vtable_get_static_field_data(Vtable);
-                    
-							if (sfd>(void*)0x10000)
+							void* sfd = mono_vtable_get_static_field_data(Vtable);
+
+							if (sfd > (void*)0x10000)
 							{
 								if (mono_class_instance_size)
 								{
@@ -2596,7 +2665,7 @@ void CPipeServer::GetStaticFieldValue()
 									{
 										mono_field_static_get_value(Vtable, Field, &val);
 									}
-								}   
+								}
 							}
 						}
 						else
@@ -2608,9 +2677,9 @@ void CPipeServer::GetStaticFieldValue()
 							}
 						}
 					}
-                }
-            }
-        }
+				}
+			}
+		}
 	}
 
 	WriteQword(val);
@@ -2639,7 +2708,7 @@ void CPipeServer::SetStaticFieldValue()
 
 void CPipeServer::Start(void)
 {
-   
+
 	BYTE command;
 
 	OutputDebugString("CPipeServer::Start\n");
@@ -2649,15 +2718,15 @@ void CPipeServer::Start(void)
 			return;
 
 		CreatePipeandWaitForconnect();
-        
+
 		try
 		{
 
-            
+
 			while (TRUE)
 			{
 				command = ReadByte();
-        ExpectingAccessViolations = TRUE;
+				ExpectingAccessViolations = TRUE;
 #ifdef _WINDOWS
 				ExpectingAccessViolationsThread = GetCurrentThreadId();
 #elif __APPLE__
@@ -2673,8 +2742,8 @@ void CPipeServer::Start(void)
 				}
 
 				if (limitedConnection)
-					ConnectThreadToMonoRuntime();					
-				
+					ConnectThreadToMonoRuntime();
+
 
 				switch (command)
 				{
@@ -2842,13 +2911,25 @@ void CPipeServer::Start(void)
 					IsGenericClass();
 					break;
 
+				case MONOCMD_ISCLASSENUM:
+					IsEnumClass();
+					break;
+
+				case MONOCMD_ISCLASSVALUETYPE:
+					IsValueTypeClass();
+					break;
+
+				case MONOCMD_ISCLASSISSUBCLASSOF:
+					IsSubClassOf();
+					break;
+
 				case MONOCMD_ISIL2CPP:
 					IsIL2CPP();
 					break;
-                        
+
 				case MONOCMD_FILLOPTIONALFUNCTIONLIST:
-				  FillOptionalFunctionList();
-				  break;
+					FillOptionalFunctionList();
+					break;
 
 				case MONOCMD_GETSTATICFIELDVALUE:
 					GetStaticFieldValue();
@@ -2866,6 +2947,18 @@ void CPipeServer::Start(void)
 					GetClassNestingType();
 					break;
 
+				case MONOCMD_GETCLASSTYPE:
+					GetClassType();
+					break;
+
+				case MONOCMD_GETCLASSOFTYPE:
+					GetClassOfType();
+					break;
+					
+				case MONOCMD_GETTYPEOFMONOTYPE:
+					GetTypeOfMonoType();
+					break;
+
 
 				case MONOCMD_FREE:
 					FreeObject();
@@ -2881,7 +2974,11 @@ void CPipeServer::Start(void)
 
 				case MONOCMD_LIMITEDCONNECTION:
 					limitedConnection = true;
-					break;					
+					break;
+
+				case MONOCMD_ARRAYELEMENTSIZE:
+					GetArrayElementSize();
+					break;
 
 				}
 
@@ -2899,19 +2996,19 @@ void CPipeServer::Start(void)
 
 			}
 		}
-		catch (char *e)
+		catch (char* e)
 		{
 			//Pipe error, or something else that wasn't caught. Exit the connection and start over
-      char s[200];
-      snprintf(s,200,"Pipe error: %s", e);
+			char s[200];
+			snprintf(s, 200, "Pipe error: %s", e);
 			OutputDebugStringA(s);
 
 			if (attached)
 			{
 				try
 				{
-				  if (mono_thread_detach && mono_selfthread)
-				    mono_thread_detach(mono_selfthread);
+					if (mono_thread_detach && mono_selfthread)
+						mono_thread_detach(mono_selfthread);
 
 					attached = FALSE;
 				}
@@ -2930,8 +3027,8 @@ void CPipeServer::Start(void)
 			{
 				try
 				{
-				  if (mono_thread_detach && mono_selfthread)
-				    mono_thread_detach(mono_selfthread);
+					if (mono_thread_detach && mono_selfthread)
+						mono_thread_detach(mono_selfthread);
 
 					attached = FALSE;
 				}
@@ -2939,13 +3036,12 @@ void CPipeServer::Start(void)
 				{
 
 				}
-				
-				
+
+
 			}
 		}
 
 	}
 
 }
-
 

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
@@ -504,6 +504,7 @@ void CPipeServer::InitMono()
 
 				mono_type_get_name = (MONO_TYPE_GET_NAME)GetProcAddress(hMono, "il2cpp_type_get_name");
 				mono_type_get_type = (MONO_TYPE_GET_TYPE)GetProcAddress(hMono, "il2cpp_type_get_type");
+				mono_type_get_object = (MONO_TYPE_GET_OBJECT)GetProcAddress(hMono, "il2cpp_type_get_object");
 				mono_type_get_name_full = (MONO_TYPE_GET_NAME_FULL)GetProcAddress(hMono, "il2cpp_type_get_name_full");
 
 				mono_method_get_name = (MONO_METHOD_GET_NAME)GetProcAddress(hMono, "il2cpp_method_get_name");
@@ -661,6 +662,7 @@ void CPipeServer::InitMono()
 
 				mono_type_get_name = (MONO_TYPE_GET_NAME)GetProcAddress(hMono, "mono_type_get_name");
 				mono_type_get_type = (MONO_TYPE_GET_TYPE)GetProcAddress(hMono, "mono_type_get_type");
+				mono_type_get_object = (MONO_TYPE_GET_OBJECT)GetProcAddress(hMono, "mono_type_get_object");
 				mono_type_get_name_full = (MONO_TYPE_GET_NAME_FULL)GetProcAddress(hMono, "mono_type_get_name_full");
 
 				mono_method_get_name = (MONO_METHOD_GET_NAME)GetProcAddress(hMono, "mono_method_get_name");
@@ -1829,6 +1831,12 @@ void CPipeServer::GetTypeOfMonoType()
 	WriteDword((UINT64)mono_type_get_type(type));
 }
 
+void CPipeServer::GetReflectionTypeOfClassType()
+{
+	void* type = (void*)ReadQword(); //MonoType*
+	WriteDword((UINT64)mono_type_get_object(type)); //ReflectionType*
+}
+
 
 void CPipeServer::GetVTableFromClass(void)
 {
@@ -2957,6 +2965,10 @@ void CPipeServer::Start(void)
 					
 				case MONOCMD_GETTYPEOFMONOTYPE:
 					GetTypeOfMonoType();
+					break;
+
+				case MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE:
+					GetReflectionTypeOfClassType();
 					break;
 
 

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -66,6 +66,13 @@
 #define MONOCMD_NEWSTRING 48
 #define MONOCMD_ENUMIMAGES 49
 #define MONOCMD_ENUMCLASSESINIMAGEEX 50
+#define MONOCMD_ISCLASSENUM 51
+#define MONOCMD_ISCLASSVALUETYPE 52
+#define MONOCMD_ISCLASSISSUBCLASSOF 53
+#define MONOCMD_ARRAYELEMENTSIZE 54
+#define MONOCMD_GETCLASSTYPE 55
+#define MONOCMD_GETCLASSOFTYPE 56
+#define MONOCMD_GETTYPEOFMONOTYPE 57					 
 
 
 typedef struct {} MonoType;
@@ -121,8 +128,9 @@ typedef int (__cdecl *MONO_CLASS_INSTANCE_SIZE)(void *klass);
 typedef void* (__cdecl *MONO_CLASS_FROM_MONO_TYPE)(void *type);
 typedef void* (__cdecl *MONO_CLASS_GET_ELEMENT_CLASS)(void *klass);
 typedef int (__cdecl *MONO_CLASS_IS_GENERIC)(void *klass);
-
-
+typedef bool (__cdecl *MONO_CLASS_IS_ENUM)(void *klass);
+typedef bool (__cdecl *MONO_CLASS_IS_VALUETYPE)(void *klass);
+typedef bool (__cdecl *MONO_CLASS_IS_SUBCLASS_OF)(void *klass, void* parentKlass, bool check_interface);
 
 typedef int (__cdecl *MONO_CLASS_NUM_FIELDS)(void *klass);
 typedef int (__cdecl *MONO_CLASS_NUM_METHODS)(void *klass);
@@ -138,7 +146,8 @@ typedef char* (__cdecl *MONO_TYPE_GET_NAME_FULL)(void *type, int format);
 typedef int (__cdecl *MONO_FIELD_GET_FLAGS)(void *type);
 typedef void* (__cdecl * MONO_FIELD_GET_VALUE_OBJECT)(void *domain, void* field, void* object);
 
-
+typedef int (__cdecl *MONO_FIELD_GET_FLAGS)(void *type);
+typedef void* (__cdecl * MONO_FIELD_GET_VALUE_OBJECT)(void *domain, void* field, void* object);
 
 
 typedef char* (__cdecl *MONO_METHOD_GET_NAME)(void *method);
@@ -184,6 +193,7 @@ typedef void* (__cdecl *MONO_IMAGE_LOADED)(void *aname);
 typedef void* (__cdecl *MONO_STRING_NEW)(void *domain, const char *text);
 typedef char* (__cdecl *MONO_STRING_TO_UTF8)(void*);
 typedef void* (__cdecl *MONO_ARRAY_NEW)(void *domain, void *eclass, uintptr_t n);
+typedef int (__cdecl *MONO_ARRAY_ELEMENT_SIZE)(void * klass);
 typedef void* (__cdecl *MONO_OBJECT_TO_STRING)(void *object, void **exc);
 typedef void* (__cdecl *MONO_OBJECT_NEW)(void *domain, void *klass);
 
@@ -256,7 +266,9 @@ private:
 	MONO_CLASS_INSTANCE_SIZE mono_class_instance_size;
 	MONO_CLASS_FROM_MONO_TYPE mono_class_from_mono_type;
 	MONO_CLASS_IS_GENERIC mono_class_is_generic;
-
+	MONO_CLASS_IS_ENUM mono_class_is_enum;
+	MONO_CLASS_IS_VALUETYPE mono_class_is_valuetype;
+	MONO_CLASS_IS_SUBCLASS_OF mono_class_is_subclass_of;
 	MONO_DOMAIN_FOREACH mono_domain_foreach;
 	MONO_DOMAIN_SET mono_domain_set;
 	MONO_DOMAIN_GET mono_domain_get;
@@ -299,6 +311,8 @@ private:
 
 	MONO_TYPE_GET_NAME mono_type_get_name;
 	MONO_TYPE_GET_TYPE mono_type_get_type;
+	MONO_TYPE_IS_STRUCT mono_type_is_struct;
+	MONO_TYPE_GET_CLASS mono_type_get_class;													  
 	MONO_TYPE_GET_NAME_FULL mono_type_get_name_full;
 	MONO_FIELD_GET_FLAGS mono_field_get_flags;
 	MONO_FIELD_GET_VALUE_OBJECT mono_field_get_value_object;
@@ -424,6 +438,9 @@ private:
 	void GetParentClass();
 	void GetClassNestingType();
 	void GetClassImage();
+	void GetClassType();
+	void GetClassOfType();
+	void GetTypeOfMonoType();
 	void GetVTableFromClass();
 	void GetStaticFieldAddressFromClass();
 	void GetTypeClass();
@@ -436,8 +453,12 @@ private:
 	void Object_New();
 	void Object_Init();
 	void IsGenericClass();
+	void IsEnumClass();
+	void IsValueTypeClass();
+	void IsSubClassOf();
+	void GetArrayElementSize();
 	void IsIL2CPP();
-    void FillOptionalFunctionList(); //mainly for unixbased systems
+	void FillOptionalFunctionList(); //mainly for unixbased systems
 	void GetStaticFieldValue();
 	void SetStaticFieldValue();
 	void GetMonoDataCollectorVersion();

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -7,7 +7,7 @@
 
 
                                 //yyyymmdd
-#define MONO_DATACOLLECTORVERSION 20230302 
+#define MONO_DATACOLLECTORVERSION 20230409 
 
 #define MONO_TYPE_NAME_FORMAT_IL  0
 #define MONO_TYPE_NAME_FORMAT_REFLECTION  1

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -141,8 +141,11 @@ typedef void* (__cdecl *MONO_FIELD_GET_PARENT)(void *field);
 typedef int (__cdecl *MONO_FIELD_GET_OFFSET)(void *field);
 
 typedef char* (__cdecl *MONO_TYPE_GET_NAME)(void *type);
+typedef void* (__cdecl* MONO_TYPE_GET_CLASS)(void* type);
 typedef int (__cdecl *MONO_TYPE_GET_TYPE)(void *type);
 typedef char* (__cdecl *MONO_TYPE_GET_NAME_FULL)(void *type, int format);
+typedef bool(__cdecl* MONO_TYPE_IS_STRUCT)(void* type);
+
 typedef int (__cdecl *MONO_FIELD_GET_FLAGS)(void *type);
 typedef void* (__cdecl * MONO_FIELD_GET_VALUE_OBJECT)(void *domain, void* field, void* object);
 
@@ -353,6 +356,7 @@ private:
 	MONO_STRING_NEW mono_string_new;
 	MONO_STRING_TO_UTF8 mono_string_to_utf8;
 	MONO_ARRAY_NEW mono_array_new;
+	MONO_ARRAY_ELEMENT_SIZE mono_array_element_size;
 	MONO_OBJECT_TO_STRING mono_object_to_string;
 	MONO_OBJECT_NEW mono_object_new;
 	MONO_FREE mono_free;

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -72,7 +72,8 @@
 #define MONOCMD_ARRAYELEMENTSIZE 54
 #define MONOCMD_GETCLASSTYPE 55
 #define MONOCMD_GETCLASSOFTYPE 56
-#define MONOCMD_GETTYPEOFMONOTYPE 57					 
+#define MONOCMD_GETTYPEOFMONOTYPE 57
+#define MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE 58					 
 
 
 typedef struct {} MonoType;
@@ -143,6 +144,7 @@ typedef int (__cdecl *MONO_FIELD_GET_OFFSET)(void *field);
 typedef char* (__cdecl *MONO_TYPE_GET_NAME)(void *type);
 typedef void* (__cdecl* MONO_TYPE_GET_CLASS)(void* type);
 typedef int (__cdecl *MONO_TYPE_GET_TYPE)(void *type);
+typedef void* (__cdecl *MONO_TYPE_GET_OBJECT)(void *type);
 typedef char* (__cdecl *MONO_TYPE_GET_NAME_FULL)(void *type, int format);
 typedef bool(__cdecl* MONO_TYPE_IS_STRUCT)(void* type);
 
@@ -314,6 +316,7 @@ private:
 
 	MONO_TYPE_GET_NAME mono_type_get_name;
 	MONO_TYPE_GET_TYPE mono_type_get_type;
+	MONO_TYPE_GET_OBJECT mono_type_get_object; //return a ReflectionType* object
 	MONO_TYPE_IS_STRUCT mono_type_is_struct;
 	MONO_TYPE_GET_CLASS mono_type_get_class;													  
 	MONO_TYPE_GET_NAME_FULL mono_type_get_name_full;
@@ -445,6 +448,7 @@ private:
 	void GetClassType();
 	void GetClassOfType();
 	void GetTypeOfMonoType();
+	void GetReflectionTypeOfClassType();
 	void GetVTableFromClass();
 	void GetStaticFieldAddressFromClass();
 	void GetTypeClass();

--- a/Cheat Engine/bin/autorun/dotnetinfo.lua
+++ b/Cheat Engine/bin/autorun/dotnetinfo.lua
@@ -232,7 +232,7 @@ local function getClassFields(Class)
       StaticFieldAddress=mono_class_getStaticFieldAddress(0,Class.Handle)
     end
          
-    local fields=mono_class_enumFields(Class.Handle, true)
+    local fields=mono_class_enumFields(Class.Handle, true, true)
     for i=1,#fields do
       local e={}
       e.Handle=fields[i].field

--- a/Cheat Engine/bin/autorun/monoscript.lua
+++ b/Cheat Engine/bin/autorun/monoscript.lua
@@ -2191,11 +2191,8 @@ function mono_class_enumFields(class, includeParents, expandedStructs)
 
         namelength=monopipe.readWord();
         fields[index].typename=monopipe.readString(namelength);
-        if not(expandedStructs) or (not(fields[index].isStatic) and not(fields[index].isConst)) then --do not want to include static fields for structs cause they may cause endless cycle e.g. in Vector2
-          index=index+1
-        else
-          fields[index] = nil
-        end
+        index=index+1
+        
       end
 
     until (classfield==nil) or (classfield==0)
@@ -2210,7 +2207,7 @@ function mono_class_enumFields(class, includeParents, expandedStructs)
   if expandedStructs then
     for k,v in pairs(mainFields) do
       local lockls = mono_field_getClass(v.field)
-      if ((v.monotype==MONO_TYPE_VALUETYPE) and not(mono_class_isEnum(lockls))) then
+      if ((v.monotype==MONO_TYPE_VALUETYPE) and not(mono_class_isEnum(lockls)) and not(mono_class_isSubClassOf(mono_field_getClass(v.field),class))) then --does not want to infinitely loop if the struct has some static member of the same class
          local subFields = GetFields(lockls, includeParents, expandedStructs)
          --print(v.name, v.typename, fu(v.monotype))
          if #subFields >0 then

--- a/Cheat Engine/bin/autorun/monoscript.lua
+++ b/Cheat Engine/bin/autorun/monoscript.lua
@@ -1323,6 +1323,7 @@ end
 
 
 function mono_enumAssemblies()
+  if 1 then return mono_enumAssembliesOld() end --please remove it only when launching the next update
   local result=nil
   --if debug_canBreak() then return nil end
   if monopipe then

--- a/Cheat Engine/bin/autorun/monoscript.lua
+++ b/Cheat Engine/bin/autorun/monoscript.lua
@@ -19,9 +19,9 @@ local dpiscale=getScreenDPI()/96
 
 --[[local]] monocache={}
 
-mono_timeout=0--3000 --change to 0 to never timeout (meaning: 0 will freeze your face off if it breaks on a breakpoint, just saying ...)
+mono_timeout=3000 --change to 0 to never timeout (meaning: 0 will freeze your face off if it breaks on a breakpoint, just saying ...)
 
-MONO_DATACOLLECTORVERSION=20230302
+MONO_DATACOLLECTORVERSION=20230409
 
 MONOCMD_INITMONO=0
 MONOCMD_OBJECT_GETCLASS=1
@@ -77,7 +77,13 @@ MONOCMD_NEWSTRING=48
 
 MONOCMD_ENUMIMAGES=49 
 MONOCMD_ENUMCLASSESINIMAGEEX=50
-
+MONOCMD_ISCLASSENUM = 51
+MONOCMD_ISCLASSVALUETYPE = 52
+MONOCMD_ISCLASSISSUBCLASSOF = 53
+MONOCMD_ARRAYELEMENTSIZE = 54
+MONOCMD_GETCLASSTYPE = 55
+MONOCMD_GETCLASSOFTYPE = 56
+MONOCMD_GETTYPEOFMONOTYPE = 57
 
 MONO_TYPE_END        = 0x00       -- End of List
 MONO_TYPE_VOID       = 0x01
@@ -131,7 +137,7 @@ monoTypeToVartypeLookup[MONO_TYPE_I8]=vtQword
 monoTypeToVartypeLookup[MONO_TYPE_U8]=vtQword
 monoTypeToVartypeLookup[MONO_TYPE_R4]=vtSingle
 monoTypeToVartypeLookup[MONO_TYPE_R8]=vtDouble
-monoTypeToVartypeLookup[MONO_TYPE_STRING]=vtString --pointer to a string object
+monoTypeToVartypeLookup[MONO_TYPE_STRING]=vtPointer --pointer to a string object
 monoTypeToVartypeLookup[MONO_TYPE_PTR]=vtPointer
 monoTypeToVartypeLookup[MONO_TYPE_BYREF]=vtPointer
 monoTypeToVartypeLookup[MONO_TYPE_CLASS]=vtPointer
@@ -1522,6 +1528,39 @@ function mono_class_isgeneric(class)
   return result;
 end
 
+function mono_class_isEnum(klass)
+ if not klass or klass==0 then return false end
+ monopipe.lock()
+ monopipe.writeByte(MONOCMD_ISCLASSENUM)
+ monopipe.writeQword(klass)
+ local retv = monopipe.readByte()
+ monopipe.unlock()
+ return retv==1
+end
+
+function mono_class_isValueType(klass)
+ if not klass or klass==0 then return false end
+ monopipe.lock()
+ monopipe.writeByte(MONOCMD_ISCLASSVALUETYPE)
+ monopipe.writeQword(klass)
+ local retv = monopipe.readByte()
+ monopipe.unlock()
+ return retv==1
+end
+
+function mono_class_isSubClassOf(klass,parentklass,checkInterfaces)
+ checkInterfaces = checkInterfaces and 1 or 0
+ if not klass or klass==0 then return false end
+ monopipe.lock()
+ monopipe.writeByte(MONOCMD_ISCLASSISSUBCLASSOF)
+ monopipe.writeQword(klass)
+ monopipe.writeQword(parentklass)
+ monopipe.writeByte(checkInterfaces)
+ local retv = monopipe.readByte()
+ monopipe.unlock()
+ return retv==1
+end
+
 function mono_isil2cpp(class)
   local result=false
   monopipe.lock()
@@ -1643,13 +1682,13 @@ function mono_class_getImage(class)
 end
 
 
-function mono_type_getClass(monotype)
+function mono_field_getClass(field)
   --if debug_canBreak() then return nil end
 
   local result=0
   monopipe.lock()
   monopipe.writeByte(MONOCMD_GETTYPECLASS)
-  monopipe.writeQword(monotype)  
+  monopipe.writeQword(field)  
 
   result=monopipe.readQword()
 
@@ -1657,6 +1696,35 @@ function mono_type_getClass(monotype)
   return result;
 end
 
+function mono_class_get_type(kls)
+  if not kls or kls==0 then return nil end
+  monopipe.lock()
+  monopipe.writeByte(MONOCMD_GETCLASSTYPE)
+  monopipe.writeQword(kls)
+  local retv = monopipe.readQword()
+  monopipe.unlock()
+ return retv
+end
+
+function mono_type_get_class(monotype)
+  if not monotype or monotype==0 then return nil end
+  monopipe.lock()
+  monopipe.writeByte(MONOCMD_GETCLASSOFTYPE)
+  monopipe.writeQword(monotype)
+  local retv = monopipe.readQword()
+  monopipe.unlock()
+ return retv
+end
+
+function mono_type_get_type(monotype)
+  if not monotype or monotype==0 then return nil end
+  monopipe.lock()
+  monopipe.writeByte(MONOCMD_GETTYPEOFMONOTYPE)
+  monopipe.writeQword(monotype)
+  local retv = monopipe.readDword()
+  monopipe.unlock()
+ return retv
+end
 function mono_class_getArrayElementClass(klass)
   --if debug_canBreak() then return nil end
 
@@ -2033,66 +2101,93 @@ function mono_class_getStaticFieldAddress(domain, class)
   return result;
 end
 
-function mono_class_enumFields(class, includeParents)
-  --if debug_canBreak() then return nil end
+function mono_class_enumFields(class, includeParents, expandedStructs)
+  local function GetFields(class, includeParents, expandedStructs)
+    local classfield;
+    local index=1;
+    local fields={}
+
+    if monopipe==nil then return fields end
 
 
-  local classfield;
-  local index=1;
-  local fields={}
-  
-  if monopipe==nil then return fields end
-    
-  
-  if includeParents then
-    local parent=mono_class_getParent(class)
-    if (parent) and (parent~=0) then
-      fields=mono_class_enumFields(parent, includeParents);
-      index=#fields+1;      
-    end
-  end
-  
-
-  monopipe.lock()
-  
-  
-  --mono_class_getParent
-
-  monopipe.writeByte(MONOCMD_ENUMFIELDSINCLASS)
-  monopipe.writeQword(class)
-
-  repeat
-    classfield=monopipe.readQword()
-    if (classfield~=nil) and (classfield~=0) then
-      local namelength;
-      fields[index]={}
-      fields[index].field=classfield
-      fields[index].type=monopipe.readQword()
-      fields[index].monotype=monopipe.readDword()
-
-      fields[index].parent=monopipe.readQword()
-      fields[index].offset=monopipe.readDword()
-      fields[index].flags=monopipe.readDword()
-     
-      fields[index].isStatic=(bAnd(fields[index].flags, bOr(FIELD_ATTRIBUTE_STATIC, FIELD_ATTRIBUTE_HAS_FIELD_RVA))) ~= 0 --check mono for other fields you'd like to test
-      fields[index].isConst=(bAnd(fields[index].flags, FIELD_ATTRIBUTE_LITERAL)) ~= 0
-
-      namelength=monopipe.readWord();
-      fields[index].name=monopipe.readString(namelength);
-
-      namelength=monopipe.readWord();
-      fields[index].typename=monopipe.readString(namelength);
-      index=index+1
+    if includeParents then
+      local parent=mono_class_getParent(class)
+      if (parent) and (parent~=0) then
+        fields=GetFields(parent, includeParents, expandedStructs);
+        index=#fields+1;
+      end
     end
 
-  until (classfield==nil) or (classfield==0)
 
-  if monopipe then
-    monopipe.unlock()
+    monopipe.lock()
+
+
+    --mono_class_getParent
+
+    monopipe.writeByte(MONOCMD_ENUMFIELDSINCLASS)
+    monopipe.writeQword(class)
+
+    repeat
+      classfield=monopipe.readQword()
+      if (classfield~=nil) and (classfield~=0) then
+        local namelength;
+        fields[index]={}
+        fields[index].field=classfield
+	    fields[index].type=monopipe.readQword()
+        fields[index].monotype=monopipe.readDword()
+
+        fields[index].parent=monopipe.readQword()
+        fields[index].offset=monopipe.readDword()
+        fields[index].flags=monopipe.readDword()
+
+        fields[index].isStatic=(bAnd(fields[index].flags, bOr(FIELD_ATTRIBUTE_STATIC, FIELD_ATTRIBUTE_HAS_FIELD_RVA))) ~= 0 --check mono for other fields you'd like to test
+        fields[index].isConst=(bAnd(fields[index].flags, FIELD_ATTRIBUTE_LITERAL)) ~= 0
+
+        namelength=monopipe.readWord();
+        fields[index].name=monopipe.readString(namelength);
+
+        namelength=monopipe.readWord();
+        fields[index].typename=monopipe.readString(namelength);
+        if not(expandedStructs) or (not(fields[index].isStatic) and not(fields[index].isConst)) then --do not want to include static fields for structs cause they may cause endless cycle e.g. in Vector2
+          index=index+1
+        else
+          fields[index] = nil
+        end
+      end
+
+    until (classfield==nil) or (classfield==0)
+
+    if monopipe then
+      monopipe.unlock()
+    end
+
+    return fields
+  end
+  local mainFields = GetFields(class, includeParents, expandedStructs)
+  if expandedStructs then
+    for k,v in pairs(mainFields) do
+      local lockls = mono_field_getClass(v.field)
+      if ((v.monotype==MONO_TYPE_VALUETYPE or v.monotype==MONO_TYPE_GENERICINST) and not(mono_class_isEnum(lockls))) then
+         local subFields = GetFields(lockls, includeParents, expandedStructs)
+         --print(v.name, v.typename, fu(v.monotype))
+         if #subFields >0 then
+            if subFields[1].offset == 0x10 then
+               for kk,vv in pairs(subFields) do
+                   vv.offset = vv.offset-0x10+v.offset
+               end
+            end
+            subFields[1].name = mainFields[k].name..'.'..subFields[1].name
+            for i=2, #subFields do
+                subFields[i].name = mainFields[k].name..'.'..subFields[i].name
+                mainFields[#mainFields+1] = subFields[i]
+            end
+            mainFields[k] = subFields[1]
+         end
+      end
+    end
   end
 
-  return fields
-
+  return mainFields
 end
 
 function mono_class_enumMethods(class, includeParents)
@@ -3196,6 +3291,15 @@ function monoform_miGetILCodeClick(sender)
   end
 end
 
+function mono_array_element_size(arrayKlass)
+  if not arrayKlass or arrayKlass==0 then return 0 end
+  monopipe.lock()
+  monopipe.writeByte(MONOCMD_ARRAYELEMENTSIZE)
+  monopipe.writeQword(arrayKlass)
+  local retv = monopipe.readQword()
+  monopipe.unlock()
+  return retv
+end
 function monoform_miDissectShowStruct(s, address)
   if s then
     --show it
@@ -4431,7 +4535,7 @@ function monoform_exportStructInternal(s, caddr, recursive, static, structmap, m
   local hasStatic = false
   structure_beginUpdate(s)
   
-  local fields=mono_class_enumFields(caddr,true)
+  local fields=mono_class_enumFields(caddr,true,true)
   local str -- string struct
   local childstructs = {}
   local i
@@ -4464,9 +4568,9 @@ function monoform_exportStructInternal(s, caddr, recursive, static, structmap, m
            ce.Name="Length"
            if targetIs64Bit() then
              ce.Offset=0x10
-	   else
-             ce.Offset=0x8
-	   end
+		   else
+			 ce.Offset=0x8
+		   end
 
            ce.Vartype=vtDword
            ce=mono_StringStruct.addElement()
@@ -4488,7 +4592,7 @@ function monoform_exportStructInternal(s, caddr, recursive, static, structmap, m
         --print("bla")
         local typename = monoform_escapename(fields[i].typename)
         if typename ~= nil then
-          local typeval = mono_type_getClass(fields[i].field)
+          local typeval = mono_field_getClass(fields[i].field)
           --print(string.format("PTR: %X: %s", typeval, typename))
           cs = monoform_exportStruct(typeval, typename, recursive, false, structmap, makeglobal)
           if cs~=nil then e.setChildStruct(cs) end
@@ -4496,7 +4600,7 @@ function monoform_exportStructInternal(s, caddr, recursive, static, structmap, m
       elseif ft == MONO_TYPE_SZARRAY then
         --print("bla2")
         local typename = monoform_escapename(fields[i].typename)
-        local arraytype = mono_type_getClass(fields[i].field)
+        local arraytype = mono_field_getClass(fields[i].field)
         local elemtype = mono_class_getArrayElementClass(arraytype)
 	--print(typename)
 
@@ -4524,6 +4628,8 @@ function monoform_exportArrayStruct(arraytype, elemtype, typename, recursive, st
 end
 
 function monoform_exportArrayStructInternal(acs, arraytype, elemtype, recursive, structmap, makeglobal, reload)
+  --print("monoform_exportArrayStructInternal")
+  --print(fu(arraytype),mono_class_getFullName(arraytype))
   if acs~=nil then
     cs = monoform_exportStruct(elemtype, nil, recursive, false, structmap, makeglobal)
     if cs~=nil and reload then
@@ -4537,29 +4643,50 @@ function monoform_exportArrayStructInternal(acs, arraytype, elemtype, recursive,
       end
       ce.Vartype=vtDword
       ce.setChildStruct(cs)
-      
+
       local j
-      local psize
-      if targetIs64Bit() then
-        psize=8
-      else
-        psize=4
-      end
- 	
-      for j=0, 9 do -- Arbitrarily add 10 elements
-        ce=acs.addElement()
-        ce.Name=string.format("Item[%d]",j)
-        
+      local psize = arraytype and mono_array_element_size(arraytype) or nil
+	  psize = psize and psize or (targetIs64Bit() and 8 or 4)
+
         local start
         if targetIs64Bit() then
           start=0x20
         else
           start=0x10
         end
-          
-        ce.Offset=j*psize+start
-        ce.Vartype=vtPointer
-        ce.setChildStruct(cs)
+      local elementkls = mono_class_getArrayElementClass(arraytype)
+      local elementmonotype = mono_type_get_type(mono_class_get_type(elementkls))
+      if ((elementmonotype==MONO_TYPE_VALUETYPE or elementmonotype==MONO_TYPE_GENERICINST) and not(mono_class_isEnum(elementkls)) and #mono_class_enumFields(elementkls,true,true) > 0) then
+         --print("yep, a struct")
+         local subfield = mono_class_enumFields(elementkls)
+         local suboffset = subfield[1].offset == 0x10 and 0x10 or 0
+         for k,v in pairs(subfield) do
+           local nm = v.name..'('..mono_class_getName(mono_field_getClass(v.field))..')'
+          --print(elementmonotype, mono_class_isEnum(elementkls) and 1 or 0)
+          for j=0, 9 do -- Arbitrarily add 10 elements
+            ce=acs.addElement()
+            ce.Name=string.format("[%d]%s",j,nm)
+            ce.Offset=j*psize+start+v.offset-suboffset
+            ce.Vartype= monoTypeToVarType( v.monotype ) --vtPointer
+			if ce.Vartype == vtDword then
+			  ce.DisplayMethod = 'dtSignedInteger'
+			end
+            --ce.setChildStruct(cs)
+          end
+         end
+      else
+        local nm = mono_class_getName(elementkls)
+        --print(elementmonotype, mono_class_isEnum(elementkls) and 1 or 0)
+        for j=0, 9 do -- Arbitrarily add 10 elements
+          ce=acs.addElement()
+          ce.Name=string.format("[%d]%s",j,nm)
+          ce.Offset=j*psize+start
+          ce.Vartype= monoTypeToVarType( elementmonotype ) --vtPointer
+		if ce.Vartype == vtDword then
+		  ce.DisplayMethod = 'dtSignedInteger'
+		end
+          --ce.setChildStruct(cs)
+        end
       end
       structure_endUpdate(acs)
     end


### PR DESCRIPTION
Mono Change logs:
1. Now data dissector and data collector form shows each struct expanded in the fields section
2. Fix in dotnetinfo.lua to get the subfields of a struct using mono_class_enumFields
3. Added the following functions:
  mono_class_isEnum
  mono_class_isValueType
  mono_class_isSubClassOf
  mono_class_get_type
  mono_type_get_class
  mono_type_get_type
^ These minor functions are very helpful in reversing a unity game.  
4. The previous mono_type_getClass function was not correctly named. It is now renamed to mono_field_getClass, because this is what it actually does
5. Fix in dotnetinfo.lua to properly add a "." between namespace and class for parent classes when writing inheritance
6. Minor bug fix for creating a pointer for in data dissector System.String object from monoscript.lua
7. Data dissection of arrays(including Lists, Dictionary e.t.c) is very in-depth, and each element is properly shown including the detailed structs.
