### PR TITLE
Correct a typo in emurpm.lua

### DIFF
--- a/Cheat Engine/bin/autorun/emurpm.lua
+++ b/Cheat Engine/bin/autorun/emurpm.lua
@@ -6,7 +6,7 @@ local function fileExists(filename)
     f:close()
     return true
   else
-    return fale
+    return false
   end
 end
 


### PR DESCRIPTION
Corrected a typo in emurpm.lua.
- `fale` -> `false`