### PR TITLE
Fix typos in tutorial

### DIFF
--- a/Cheat Engine/Tutorial/Unit10.pas
+++ b/Cheat Engine/Tutorial/Unit10.pas
@@ -96,7 +96,7 @@ resourcestring
     'In these cases you must find out how to distinguish between your and the enemies objects.'+#13#10+
     'Sometimes this is as easy as checking the first 4 bytes (Function pointer table) which often point to a unique location '+
     'for the player, and sometimes it''s a team number, or a pointer to a pointer to a pointer to a pointer to a pointer to a '+
-    'playername. It all depends on the complexity of the game, and your luck'+#13#10+
+    'player name. It all depends on the complexity of the game, and your luck'+#13#10+
     ''+#13#10+
     'The easiest method is finding what addresses the code you found writes to and then use the dissect data feature to '+
     'compare against two structures. (Your unit(s)/player and the enemies) And then see if you can find out a way to '+
@@ -113,7 +113,7 @@ resourcestring
     ''+#13#10+
     ''+#13#10+
     'Tip: Health is a float'+#13#10+
-    'Tip2: There are multiple solutions';
+    'Tip 2: There are multiple solutions';
   rsU10ThisWasTheLastTutorial = 'This was the last tutorial and you skipped it. You lose';
 
 procedure TPlayer.Hit(damage: integer);

--- a/Cheat Engine/Tutorial/Unit2.pas
+++ b/Cheat Engine/Tutorial/Unit2.pas
@@ -64,7 +64,7 @@ resourcestring
     ' bytes after the address are 0, but I wouldn''t take the bet.'+#13#10+
     'Single, double, and the other scans just don''t work, because they store the value in a different way.'+#13#10+
     ''+#13#10+
-    'When the value type is set correctly, make sure the scantype is set to ''Exact Value'''+#13#10+
+    'When the value type is set correctly, make sure the scan type is set to ''Exact Value'''+#13#10+
     'Then fill in the number your health is in the value box. And click ''First Scan'''+#13#10+
     'After a while (if you have an extremely slow pc) the scan is done and the results are shown in the list on the'+
     ' left.'+#13#10+

--- a/Cheat Engine/Tutorial/Unit3.pas
+++ b/Cheat Engine/Tutorial/Unit3.pas
@@ -43,14 +43,14 @@ uses Unit4, Unit5, frmHelpUnit, cetranslator;
 resourcestring
   rsStep3UnknownInitialValuePW = 'Step 3: Unknown initial value (PW=';
   rsDead = 'Seems you''ve done it again! Let me get a replacement! (And restart your scan!)';
-  rsTryAgain3 = 'Step 3 isn''t really that hard. Just do a new scan, unkown initial value and then decreased value till you find it. Almost everyone gets past'
+  rsTryAgain3 = 'Step 3 isn''t really that hard. Just do a new scan, unknown initial value and then decreased value till you find it. Almost everyone gets past'
     +' this one. Sure you want to quit?';
   rsLOSER = 'BOO';
 
   rsTutorialStep3=
     'Ok, seeing that you''ve figured out how to find a value using exact value let''s move on to the next step.'+#13#10+
           ''+#13#10+
-          'First things first though. Since you are doing a new scan, you have to click on New Scan first, to start a new scan. (You may think this is straighforward, but you''d be surprised how many people get stuck on that step) I won''t be explaining this step again, so keep this in mind.'+#13#10+
+          'First things first though. Since you are doing a new scan, you have to click on New Scan first, to start a new scan. (You may think this is straightforward, but you''d be surprised how many people get stuck on that step) I won''t be explaining this step again, so keep this in mind.'+#13#10+
           'Now that you''ve started a new scan, let''s continue.'+#13#10+
           ''+#13#10+
           'In the previous test we knew the initial value so we could do an exact value search, but now we have a status bar where '+
@@ -60,7 +60,7 @@ resourcestring
           ''+#13#10+
           'Again there are several different ways to find the value. (like doing a decreased value by... scan), but I''ll only '+
           'explain the easiest. "Unknown initial value", and decreased value.'+#13#10+
-          'Because you don''t know the value it is right now, exact value wont do any good, so choose as scantype '+
+          'Because you don''t know the value it is right now, exact value wont do any good, so choose as scan type '+
           '''Unknown initial value'', again, the value type is 4-bytes. (Most windows apps use 4-bytes.) '+
           'Click First scan and wait till it''s done.'+#13#10+
           ''+#13#10+

--- a/Cheat Engine/Tutorial/Unit5.pas
+++ b/Cheat Engine/Tutorial/Unit5.pas
@@ -49,7 +49,7 @@ resourcestring
   rsStep4FloatingPointsPW = 'Step 4: Floating points (PW=';
   rsOutOfAmmo = 'Out of ammo!%sPress ok to stock up on some ammo';
   rsDead = 'I think you''re dead!%sPress ok to become a brain eating zombie';
-  rsConfirmClose5 = 'Come on. This step is simple. For health do a float scan, and for ammo a double type. (don''t forget to disable fastscan for double in '
+  rsConfirmClose5 = 'Come on. This step is simple. For health do a float scan, and for ammo a double type. (don''t forget to disable fast scan for double in '
     +'this case) Just ignore the fact that it looks different because it has a "." in the value. You sure you want to quit?';
   rsLOSER = 'BOO';
 

--- a/Cheat Engine/Tutorial/Unit9.pas
+++ b/Cheat Engine/Tutorial/Unit9.pas
@@ -101,7 +101,7 @@ resourcestring
           'In step 6 you had a simple level-1 pointer, with the first address found already being the real base address.'+#13#10+
           'This step however is a level-4 pointer. It has a pointer to a pointer to a pointer to a pointer to a pointer to the health.'+#13#10+
           ''+#13#10+
-          'You basicly do the same as in step 6. Find out what accesses the value, look at the instruction and what probably is '+
+          'You basically do the same as in step 6. Find out what accesses the value, look at the instruction and what probably is '+
           'the base pointer value, and what is the offset, and already fill that in or write it down. But in this case the address '+
           'you''ll find will also be a pointer. You just have to find out the pointer to that pointer exactly the same way as you did '+
           'with the value. Find out what accesses that address you found, look at the assembler instruction, note the probable '+


### PR DESCRIPTION
Fixed typos and made some phrases more consistent between CE and the tutorial (e.g scantype -> scan type)