### PR TITLE
Function to get MonoReflectionMethod and unbox a MonoObject

### DIFF
--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
@@ -543,7 +543,7 @@ void CPipeServer::InitMono()
 
 				mono_string_new = (MONO_STRING_NEW)GetProcAddress(hMono, "il2cpp_string_new");
 				mono_string_to_utf8 = (MONO_STRING_TO_UTF8)GetProcAddress(hMono, "il2cpp_string_to_utf8");
-				mono_array_new = (MONO_ARRAY_NEW)GetProcAddress(hMono, "il2cpp_array_new");
+				il2cpp_array_new = (IL2CPP_ARRAY_NEW)GetProcAddress(hMono, "il2cpp_array_new");
 				mono_array_element_size = (MONO_ARRAY_ELEMENT_SIZE)GetProcAddress(hMono, "il2cpp_array_element_size");
 				mono_value_box = (MONO_VALUE_BOX)GetProcAddress(hMono, "il2cpp_value_box");
 				mono_object_unbox = (MONO_OBJECT_UNBOX)GetProcAddress(hMono, "il2cpp_object_unbox");
@@ -2657,6 +2657,18 @@ void CPipeServer::GetArrayElementSize()
 		WriteDword(0);
 }
 
+void CPipeServer::NewCSArray()
+{
+	void* klass = (void*)ReadQword();
+	int count = ReadDword();
+	if (il2cpp && il2cpp_array_new)
+		WriteQword((UINT64)il2cpp_array_new(klass, count));
+	else if (mono_array_new)
+		WriteQword((UINT64)mono_array_new(domain, klass, count));
+	else
+		WriteQword(0);
+}
+
 void CPipeServer::IsIL2CPP()
 {
 	WriteByte(il2cpp);
@@ -3046,6 +3058,10 @@ void CPipeServer::Start(void)
 
 				case MONOCMD_ARRAYELEMENTSIZE:
 					GetArrayElementSize();
+					break;
+
+				case MONOCMD_MONOARRAYNEW:
+					NewCSArray();
 					break;
 
 				}

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -7,7 +7,7 @@
 
 
                                 //yyyymmdd
-#define MONO_DATACOLLECTORVERSION 20230409 
+#define MONO_DATACOLLECTORVERSION 20230512 
 
 #define MONO_TYPE_NAME_FORMAT_IL  0
 #define MONO_TYPE_NAME_FORMAT_REFLECTION  1
@@ -73,7 +73,9 @@
 #define MONOCMD_GETCLASSTYPE 55
 #define MONOCMD_GETCLASSOFTYPE 56
 #define MONOCMD_GETTYPEOFMONOTYPE 57
-#define MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE 58					 
+#define MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE 58
+#define MONOCMD_GETREFLECTIONMETHODOFMONOMETHOD 59
+#define MONOCMD_MONOOBJECTUNBOX 60
 
 
 typedef struct {} MonoType;
@@ -146,6 +148,8 @@ typedef void* (__cdecl* MONO_TYPE_GET_CLASS)(void* type);
 typedef int (__cdecl *MONO_TYPE_GET_TYPE)(void *type);
 typedef void* (__cdecl *MONO_TYPE_GET_OBJECT)(void *domain, void *type);
 typedef void* (__cdecl *IL2CPP_TYPE_GET_OBJECT)(void *type);
+typedef void* (__cdecl *MONO_METHOD_GET_OBJECT)(void *domain, void *method, void* klass);
+typedef void* (__cdecl *IL2CPP_METHOD_GET_OBJECT)(void* method, void* klass);
 
 
 typedef char* (__cdecl *MONO_TYPE_GET_NAME_FULL)(void *type, int format);
@@ -321,6 +325,8 @@ private:
 	MONO_TYPE_GET_TYPE mono_type_get_type;
 	MONO_TYPE_GET_OBJECT mono_type_get_object; //return a ReflectionType* object
 	IL2CPP_TYPE_GET_OBJECT il2cpp_type_get_object;
+	MONO_METHOD_GET_OBJECT mono_method_get_object;
+	IL2CPP_METHOD_GET_OBJECT il2cpp_method_get_object;
 	MONO_TYPE_IS_STRUCT mono_type_is_struct;
 	MONO_TYPE_GET_CLASS mono_type_get_class;													  
 	MONO_TYPE_GET_NAME_FULL mono_type_get_name_full;
@@ -453,6 +459,8 @@ private:
 	void GetClassOfType();
 	void GetTypeOfMonoType();
 	void GetReflectionTypeOfClassType();
+	void GetReflectionMethodOfMethod();
+	void UnBoxMonoObject();
 	void GetVTableFromClass();
 	void GetStaticFieldAddressFromClass();
 	void GetTypeClass();

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.h
@@ -76,6 +76,7 @@
 #define MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE 58
 #define MONOCMD_GETREFLECTIONMETHODOFMONOMETHOD 59
 #define MONOCMD_MONOOBJECTUNBOX 60
+#define MONOCMD_MONOARRAYNEW 61
 
 
 typedef struct {} MonoType;
@@ -205,6 +206,7 @@ typedef void* (__cdecl *MONO_IMAGE_LOADED)(void *aname);
 typedef void* (__cdecl *MONO_STRING_NEW)(void *domain, const char *text);
 typedef char* (__cdecl *MONO_STRING_TO_UTF8)(void*);
 typedef void* (__cdecl *MONO_ARRAY_NEW)(void *domain, void *eclass, uintptr_t n);
+typedef void* (__cdecl *IL2CPP_ARRAY_NEW)(void *eclass, uintptr_t n);
 typedef int (__cdecl *MONO_ARRAY_ELEMENT_SIZE)(void * klass);
 typedef void* (__cdecl *MONO_OBJECT_TO_STRING)(void *object, void **exc);
 typedef void* (__cdecl *MONO_OBJECT_NEW)(void *domain, void *klass);
@@ -369,6 +371,7 @@ private:
 	MONO_STRING_NEW mono_string_new;
 	MONO_STRING_TO_UTF8 mono_string_to_utf8;
 	MONO_ARRAY_NEW mono_array_new;
+	IL2CPP_ARRAY_NEW il2cpp_array_new;
 	MONO_ARRAY_ELEMENT_SIZE mono_array_element_size;
 	MONO_OBJECT_TO_STRING mono_object_to_string;
 	MONO_OBJECT_NEW mono_object_new;
@@ -477,6 +480,7 @@ private:
 	void IsValueTypeClass();
 	void IsSubClassOf();
 	void GetArrayElementSize();
+	void NewCSArray();
 	void IsIL2CPP();
 	void FillOptionalFunctionList(); //mainly for unixbased systems
 	void GetStaticFieldValue();

--- a/Cheat Engine/bin/autorun/monoscript.lua
+++ b/Cheat Engine/bin/autorun/monoscript.lua
@@ -19,7 +19,7 @@ local dpiscale=getScreenDPI()/96
 
 --[[local]] monocache={}
 
-mono_timeout=0 --change to 0 to never timeout (meaning: 0 will freeze your face off if it breaks on a breakpoint, just saying ...)
+mono_timeout=3000 --change to 0 to never timeout (meaning: 0 will freeze your face off if it breaks on a breakpoint, just saying ...)
 
 MONO_DATACOLLECTORVERSION=20230512
 
@@ -87,6 +87,7 @@ MONOCMD_GETTYPEOFMONOTYPE = 57
 MONOCMD_GETREFLECTIONTYPEOFCLASSTYPE = 58
 MONOCMD_GETREFLECTIONMETHODOFMONOMETHOD = 59
 MONOCMD_MONOOBJECTUNBOX = 60
+MONOCMD_MONOARRAYNEW = 61
 
 MONO_TYPE_END        = 0x00       -- End of List
 MONO_TYPE_VOID       = 0x01
@@ -3203,6 +3204,20 @@ function mono_array_element_size(arrayKlass)
   monopipe.unlock()
   return retv
 end
+
+function mono_array_new(klass,count)
+  count = count and count or 0
+  assert(klass and klass~=0,'Error: The Element class for array must be defined')
+  monopipe.lock()
+  monopipe.writeByte(MONOCMD_MONOARRAYNEW)
+  monopipe.writeQword(klass)
+  monopipe.writeDword(count)
+  local retv = monopipe.readQword()
+  monopipe.unlock()
+  return retv
+end
+
+
 function monoform_miDissectShowStruct(s, address)
   if s then
     --show it


### PR DESCRIPTION
MonoReflectionMethod is required to invoke a generic method. Basically, it is used to construct a Generic Method which can then be invoked.