### PR TITLE
Correct NOT saving code color when it is the default: advancedoptions.color

### DIFF
--- a/Cheat Engine/OpenSave.pas
+++ b/Cheat Engine/OpenSave.pas
@@ -1245,8 +1245,7 @@ begin
     begin
       CodeRecord:=CodeRecords.AppendChild(doc.CreateElement('CodeEntry'));
 
-      if (TCodeListEntry(advancedoptions.lvCodelist.Items[i].data).color<>clWindowtext) and
-         (TCodeListEntry(advancedoptions.lvCodelist.Items[i].data).color<>graphics.clDefault)
+      if not (TCodeListEntry(advancedoptions.lvCodelist.Items[i].data).color in [clWindowtext,advancedoptions.color,graphics.clDefault])
       then //don't save the color if it's the default color
       begin
         a:=doc.CreateAttribute('Color');


### PR DESCRIPTION
When saving the code color is saved even for the default color, because it didn't check against advancedoptions.color
This change includes that in the list of excluded colors to save.