### PR TITLE
LUA: Change byteTableTo* functions to take optional start offset

### DIFF
--- a/Cheat Engine/bin/celua.txt
+++ b/Cheat Engine/bin/celua.txt
@@ -105,14 +105,16 @@ extendedToByteTable(number): {}      - Converts an extended to a bytetable
 stringToByteTable(string): {}        - Converts a string to a bytetable
 wideStringToByteTable(string): {}    - Converts a string to a widestring and converts that to a bytetable
 
-byteTableToWord(table, OPTIONAL signed:boolean): number       - Converts a bytetable to a word
-byteTableToDword(table, OPTIONAL signed:boolean): number      - Converts a bytetable to a dword
-byteTableToQword(table): number      - Converts a bytetable to a qword
-byteTableToFloat(table): number      - Converts a bytetable to a float
-byteTableToDouble(table): number     - Converts a bytetable to a double
-byteTableToExtended(table): number   - Converts a bytetable to an extended and converts that to a double
-byteTableToString(table): string     - Converts a bytetable to a string
-byteTableToWideString(table): string - Converts a bytetable to a widestring and converts that to a string
+note: tableOffset is 0 based offset to start reading the bytes from the byteTable
+
+byteTableToWord(table, OPTIONAL signed:boolean, OPTIONAL tableOffset:integer): number       - Converts a bytetable to a word
+byteTableToDword(table, OPTIONAL signed:boolean, OPTIONAL tableOffset:integer): number      - Converts a bytetable to a dword
+byteTableToQword(table, OPTIONAL tableOffset:integer): number      - Converts a bytetable to a qword
+byteTableToFloat(table, OPTIONAL tableOffset:integer): number      - Converts a bytetable to a float
+byteTableToDouble(table, OPTIONAL tableOffset:integer): number     - Converts a bytetable to a double
+byteTableToExtended(table, OPTIONAL tableOffset:integer): number   - Converts a bytetable to an extended and converts that to a double
+byteTableToString(table, OPTIONAL tableOffset:integer): string     - Converts a bytetable to a string
+byteTableToWideString(table, OPTIONAL tableOffset:integer): string - Converts a bytetable to a widestring and converts that to a string
 
 bOr(int1, int2)   : Binary Or
 bXor(int1, int2)  : Binary Xor


### PR DESCRIPTION
This is so that you can have a bigger byte table and read a value that is not from the start.
The changes to the functions are backwards compatible.

This can be done purely in Lua by creating new tables that copy bytes from the original byte table but that seems like a very cumbersome way to do it, instead changing the existing functions to take an optional 'start offset' parameter seems like a much cleaner way to do it.

I have used this for my own customised search before. Though there have been other instances where I wanted to type convert in lua where it is very convenient.

I've created the pull request in case you think others would also find these change to these functions useful.