### PR TITLE
ceserver: fix a mistake that uses RSP for x86

### DIFF
--- a/Cheat Engine/ceserver/extensionloader.c
+++ b/Cheat Engine/ceserver/extensionloader.c
@@ -771,7 +771,7 @@ int loadExtension(PProcessData p, char *path)
 
     if (p->dlopencaller)
     {
-      if (ptrace(PTRACE_POKEDATA, pid, newregs.rsp+12, p->dlopencaller)!=0)
+      if (ptrace(PTRACE_POKEDATA, pid, newregs.esp+12, p->dlopencaller)!=0)
       {
         debug_log("Fuck4\n");
         safe_ptrace(PTRACE_DETACH, pid,0,0);


### PR DESCRIPTION
It seems like the code was copy-pasted from the `#ifdef __x86_64__` block above and `rsp` wasn't changed to `esp` properly