### PR TITLE
Support MonoDataCollector with ndk-build

### DIFF
--- a/Cheat Engine/MonoDataCollector/.gitignore
+++ b/Cheat Engine/MonoDataCollector/.gitignore
@@ -3,3 +3,5 @@
 /android-arm/
 /android-x86_64/
 /android-aarch64/
+ndk-build/libs/
+ndk-build/obj/

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/PipeServer.cpp
@@ -349,7 +349,7 @@ void CPipeServer::InitMono()
 	}
 	else
 	{
-		OutputDebugString("dlerror()=%s\n", dlerror);
+		OutputDebugString("dlerror()=%p\n", dlerror);
 
 		fp = dlsym(RTLD_DEFAULT, "il2cpp_thread_attach");
 		OutputDebugStringA("dlsym(RTLD_DEFAULT, \"il2cpp_thread_attach\") returned %p\n", fp);

--- a/Cheat Engine/MonoDataCollector/MonoDataCollector/linuxport.cpp
+++ b/Cheat Engine/MonoDataCollector/MonoDataCollector/linuxport.cpp
@@ -265,7 +265,7 @@ HANDLE CreateNamedPipe(char *name) //createNamedPipe and wait
             {
                 OutputDebugString((char*)"Connection attempt\n");
                 struct sockaddr_un addr_client;
-                socklen_t clisize;
+                socklen_t clisize = sizeof(addr_client);
                 int a=-1;
 
 
@@ -283,7 +283,7 @@ HANDLE CreateNamedPipe(char *name) //createNamedPipe and wait
                   }
                   else
                   {
-                    OutputDebugString((char*)"accept returned -1  ( %s )\n",a, strerror(errno));
+                    OutputDebugString((char*)"accept returned -1  ( %s )\n", strerror(errno));
 
                   }
                 }

--- a/Cheat Engine/MonoDataCollector/ndk-build/jni/Android.mk
+++ b/Cheat Engine/MonoDataCollector/ndk-build/jni/Android.mk
@@ -1,0 +1,30 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_CPPFLAGS += -fexceptions -U_FORTIFY_SOURCE
+
+LOCAL_C_INCLUDES += -I$(LOCAL_PATH)/../../MonoDataCollector -I$(LOCAL_PATH)/../../../Common
+
+LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+    PREFIX := arm
+else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+    PREFIX := aarch64
+else ifeq ($(TARGET_ARCH_ABI),x86)
+    PREFIX := x86
+else
+    PREFIX := x86_64
+endif
+
+LOCAL_MODULE := MonoDataCollector-$(PREFIX)
+
+LOCAL_SRC_FILES :=  ../../../Common/Pipe.cpp \
+                    ../../MonoDataCollector/CMemStream.cpp \
+                    ../../MonoDataCollector/linuxport.cpp \
+                    ../../MonoDataCollector/MonoDataCollector.cpp \
+                    ../../MonoDataCollector/PipeServer.cpp
+
+LOCAL_LDLIBS := -llog -lz
+include $(BUILD_SHARED_LIBRARY)

--- a/Cheat Engine/MonoDataCollector/ndk-build/jni/Application.mk
+++ b/Cheat Engine/MonoDataCollector/ndk-build/jni/Application.mk
@@ -1,0 +1,2 @@
+APP_ABI :=  x86  x86_64 armeabi-v7a arm64-v8a
+APP_STL := c++_static


### PR DESCRIPTION
In addition, several bugs were fixed.

It seems that dlsym(RTLD_DEFAULT, "il2cpp_thread_attach") fails depending on the environment, regardless of this pull request.