### PR TITLE
Add index and raw address to patch scanner

### DIFF
--- a/Cheat Engine/bin/autorun/patchscan.lua
+++ b/Cheat Engine/bin/autorun/patchscan.lua
@@ -348,12 +348,17 @@ function startPatchScan()
       lv.RowSelect=true
       lv.HideSelection=false
       lv.Name="lvResults"     
-      local caddress=lv.Columns.add()            
+      local clistid=lv.Columns.add()
+      local rawaddress=lv.Columns.add()
+      local caddress=lv.Columns.add()
       local coriginal=lv.Columns.add()          
       local cpatched=lv.Columns.add()      
 
+      clistid.Caption=translate('Index')
+      rawaddress.Caption=translate('Address')
+      rawaddress.Width=rform.Canvas.GetTextWidth('XXXXXXXXXXXXXXXXXXXXXXXX')
       caddress.Width=rform.Canvas.GetTextWidth('XXXXXXXXXXXXXXXXXXXXXXXX')
-      caddress.Caption=translate('Address')
+      caddress.Caption=translate('Name')
       coriginal.Width=rform.Canvas.GetTextWidth('XX XX XX XX XX XX XX XX XX')
       coriginal.Caption=translate('Original')
       cpatched.Width=coriginal.Width
@@ -362,7 +367,9 @@ function startPatchScan()
       for i=1,#allpatches do
         local li=lv.Items.add()
         local s=allpatches[i]
-        li.Caption=getNameFromAddress(s.Address)
+        li.Caption=i
+        li.SubItems.Add(string.format("%.2x ", s.Address))
+        li.SubItems.Add(getNameFromAddress(s.Address))
         li.SubItems.Add(byteTableToHexString(s.OriginalBytes))
         li.SubItems.Add(byteTableToHexString(s.PatchedBytes))
 


### PR DESCRIPTION
- Adds the index and raw address to list patches plugin

![image](https://github.com/cheat-engine/cheat-engine/assets/9415675/4d8d8e76-1818-4f6e-a5f8-da694add5eac)
