### PR TITLE
Avoid CPU lockup in CPUID VMEXIT handler

### DIFF
--- a/dbvm/vmm/vmeventhandler_amd.c
+++ b/dbvm/vmm/vmeventhandler_amd.c
@@ -1359,12 +1359,15 @@ int handleVMEvent_amd(pcpuinfo currentcpuinfo, VMRegisters *vmregisters, FXSAVE6
 
     case VMEXIT_CPUID:
     {
-      nosendchar[getAPICID()]=0;
-      sendstringf("!CPUID! %6->%6\n", currentcpuinfo->vmcb->RIP, currentcpuinfo->vmcb->nRIP);
-      currentcpuinfo->vmcb->RIP=currentcpuinfo->vmcb->nRIP;
-
-      while (1);
-      return 0;
+        uint32_t apicId = getAPICID();
+    
+        nosendchar[apicId] = 0;
+    
+        sendstringf("[SVM] CPUID VMEXIT: RIP=%p -> nRIP=%p (CPU %u)\n", (void*)currentcpuinfo->vmcb->RIP, (void*)currentcpuinfo->vmcb->nRIP, apicId);
+    
+        currentcpuinfo->vmcb->RIP = currentcpuinfo->vmcb->nRIP;
+    
+        return 0;
     }
 
     case VMEXIT_VINTR:


### PR DESCRIPTION
This fixes an issue in the CPUID VMEXIT handler where an infinite loop could
lock the CPU while still running in VMEXIT context.

Since VMEXIT handlers run without preemption, that loop could freeze the
system instead of acting as a temporary debug stop. The handler now simply
logs the event, advances RIP to nRIP, and returns normally.

No behavior changes to CPUID handling itself — this just removes a risky
code path and makes the handler safer and more predictable.