### PR TITLE
fix crash enum extended dbg sym

### DIFF
--- a/Cheat Engine/memscan.pas
+++ b/Cheat Engine/memscan.pas
@@ -8899,10 +8899,13 @@ function TMemScan.DeleteFolder(dir: string) : boolean;
 var
   DirInfo: TSearchRec;
   r : Integer;
-begin
+begin     
+
+  if dir = '' then exit;
  // OutputDebugString('TMemScan.DeleteFolder('+dir+')');
   ZeroMemory(@DirInfo,sizeof(TSearchRec));
   result := true;
+
 
   while dir[length(dir)]=pathdelim do //cut of \
     dir:=copy(dir,1,length(dir)-1);

--- a/Cheat Engine/symbolhandler.pas
+++ b/Cheat Engine/symbolhandler.pas
@@ -1056,6 +1056,12 @@ begin
         x:=0;
         if SymGetTypeInfo(h, ModBase, index, TI_GET_BASETYPE, @x) then
         begin
+	  if (x < ord(low(TBasicType))) or (x > ord(high(TBasicType))) then
+	  begin
+             result:='BasicType'+inttostr(x);
+	     exit;
+	  end;
+
           case TBasicType(x) of
             btNoType: result:='NoType';
             btVoid: result:='VOID';
@@ -1067,7 +1073,8 @@ begin
             btBCD: result:='BCD';
             btBool: result:='BOOL';
             btLong: result:='LONG';
-            btULong: result:='ULONG';
+            btULong: result:='ULONG';    
+	    btInt2: Result := 'INT2';
             btCurrency: result:='CURRENCY';
             btDate: result:='DATE';
             btVariant: result:='VARIANT';


### PR DESCRIPTION
This crash is a problem that has been happening for many years, since versions 6++, several developer friends have already talked about it, this usually happened to those who are developers and used Cheat Engine to debug some process that has the pdb and in some cases it caused Cheat Engine to crash.

And this only happens in the Release compilation of CE.

In some cases of processes with pdb, there are many symbols. The Release version of Cheat Engine would loop in the GetTypeName->SymTagBaseType switch when x was 32. This corrupted the entire stack and caused an access violation, which was fatal because the try/except block couldn't handle the problem. Testing the debug-nomt version, the problem did not occur. It respected the else of the switch. The switch also lacked btInt2;

Another problem that caused an access violation was in: TMemScan.DeleteFolder the dir would be nil.