### PR TITLE
Fix memory visibility (??) on Windows 11 ARM (Parallels/VMware)

### DIFF
--- a/Cheat Engine/NewKernelHandler.pas
+++ b/Cheat Engine/NewKernelHandler.pas
@@ -2318,6 +2318,13 @@ begin
     MAXPHYADDRMASKPB:=MAXPHYADDRMASK and qword($fffffffffffff000);
 
     MAXLINEARADDR:=(cpuidr.eax shr 8) and $ff;
+	{$ifdef cpu64}
+    // Fix for Windows 11 ARM64 (Prism Emulator) incorrectly reporting CPUID capabilities.
+    // The emulator might report < 48 bits, causing CE to ignore valid high memory addresses.
+    // Standard x64 architecture supports at least 48 bits of virtual address space.
+    if MAXLINEARADDR < 48 then
+      MAXLINEARADDR := 48;
+    {$endif}
     MAXLINEARADDRMASK:=qword($ffffffffffffffff);
     MAXLINEARADDRMASK:=MAXLINEARADDRMASK shr MAXLINEARADDR;
     MAXLINEARADDRMASK:=MAXLINEARADDRMASK shl MAXLINEARADDR;
@@ -2591,3 +2598,4 @@ initialization
 finalization
 
 end.
+

--- a/Cheat Engine/NewKernelHandler.pas
+++ b/Cheat Engine/NewKernelHandler.pas
@@ -2598,4 +2598,3 @@ initialization
 finalization
 
 end.
-


### PR DESCRIPTION
I've been looking into why Cheat Engine shows ?? in the memory view and returns 0 results when running on Windows 11 ARM (MacBook M-chips via Parallels or VMware Fusion).

The issue is in initMaxPhysMask. When running under emulation, the CPUID instruction (leaf 80000008h) returns 32 for virtual address bits, which is completely wrong for x64. This makes MAXLINEARADDRMASK too small, so CE thinks any address above 4GB is invalid and hides it.

According to Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 1 (Section 3.3.7.1):

> Intel 64 architecture defines a 64-bit linear address. Implementations can support less. The first implementation of
> IA-32 processors with Intel 64 architecture supports a 48-bit linear address. This means a canonical address must
> have bits 63 through 48 set to zeros or ones (depending on whether bit 47 is a zero or one).

Basically, x64 requires at least 48 bits for canonical addresses to even work (especially for the kernel and high user-mode addresses). So if the emulator reports anything less than 48, it's a bug in the emulator.

I added a simple sanity check: if it's a 64-bit build and MAXLINEARADDR is less than 48, we just force it to 48.

Tested this on MacBook Pro M4 Pro with VMware Fusion. Memory is now visible and scanning works fine.

Should fix #2504